### PR TITLE
Caution. Dragons may lie ahead.

### DIFF
--- a/mezzanine/blog/templates/blog/blog_post_list.html
+++ b/mezzanine/blog/templates/blog/blog_post_list.html
@@ -19,23 +19,27 @@
 {% endblock %}
 
 {% block main %}
-<p id="description">
-{% if tag %}
-    {% trans "Viewing posts tagged" %} {{ tag }}
-{% else %}{% if category %}
-    {% trans "Viewing posts for the category" %} {{ category }}
-{% else %}{% if year or month %}
-    {% trans "Viewing posts from" %} {% if month %}{{ month }}, {% endif %}
+
+{% if tag or category or year or month or user %}
+    <p id="description">
+    {% if tag %}
+        {% trans "Viewing posts tagged" %} {{ tag }}
+    {% else %}{% if category %}
+        {% trans "Viewing posts for the category" %} {{ category }}
+    {% else %}{% if year or month %}
+        {% trans "Viewing posts from" %} {% if month %}{{ month }}, {% endif %}
     {{ year }}
-{% else %}{% if user %}
-    {% trans "Viewing posts by" %} 
-    {{ user.get_full_name|default:user.username }}
-{% else %}
-    {% editable blog_page.content %}
-    {{ blog_page.content|safe }}
-    {% endeditable %}
+    {% else %}{% if user %}
+        {% trans "Viewing posts by" %} 
+        {{ user.get_full_name|default:user.username }}
 {% endif %}{% endif %}{% endif %}{% endif %}
 </p>
+{% else %}
+    {% editable blog_page.content %}
+        {{ blog_page.content|safe }}
+        {% endeditable %}
+{% endif %}
+
 
 {% for blog_post in blog_posts.object_list %}
 {% editable blog_post.title blog_post.publish_date %}


### PR DESCRIPTION
Another simple styling/semantic hook for the blog title. The second feels hackish to me, but maybe you can figure out a way to make it more elegant and/or resolve the initial issue. I was having the issue that <p id="description"></p> was showing up on my blog lists page and was adding some extra spacing that I didn't realize because it was empty. I believe the intended behavior was for the description field entered via the admin panel to be displayed inside of this tag but it is being displayed as a separate p tag element below this empty p tag. I hope that I am making sense. If you need any clarification, please feel free to reach out!

Lee
