### PR TITLE
Login redirect setting bugfix

### DIFF
--- a/mezzanine/project_template/settings.py
+++ b/mezzanine/project_template/settings.py
@@ -141,6 +141,7 @@ ROOT_URLCONF = "%s.urls" % PROJECT_DIRNAME
 TEMPLATE_DIRS = (os.path.join(PROJECT_ROOT, "templates"),)
 
 LOGIN_URL = "/admin/"
+LOGIN_REDIRECT_URL = "/admin/"
 
 
 ################


### PR DESCRIPTION
Upon login to the admin interface, the user was being redirected to /accounts/profile/ by default (non-existent page).  I added the LOGIN_REDIRECT_URL="/admin/" setting to the project template to fix this.

Audrey
