### PR TITLE
Device detection uses lowercase strings

### DIFF
--- a/mezzanine/utils/device.py
+++ b/mezzanine/utils/device.py
@@ -11,7 +11,7 @@ def device_from_request(request):
     try:
         # If a device was set via cookie, match available devices.
         for (device, _) in settings.DEVICE_USER_AGENTS:
-            if device == request.COOKIES["mezzanine-device"].lower():
+            if device == request.COOKIES["mezzanine-device"]
                 return device
     except KeyError:
         # If a device wasn't set via cookie, match user agent.


### PR DESCRIPTION
Changed utils.device.device_from_request to use all lower case strings for matching.
