### PR TITLE
Fixed admin page tree on reload.

### DIFF
--- a/mezzanine/pages/static/mezzanine/js/admin/page_tree.js
+++ b/mezzanine/pages/static/mezzanine/js/admin/page_tree.js
@@ -43,8 +43,13 @@ $(function() {
 
     // Show previously opened branches.
     if (ids) {
-        $('#page-' + ids.split(',').join(', #page-')).click();
-    }
+    	$('#page-' + ids.split(',').join(', #page-')).each(function(){
+			var pageLink = $(this);
+			pageLink.parent().parent().find('ul:first').toggle();			
+			pageLink.find('.close').css('display', 'inline');
+			pageLink.find('.open').css('display', 'none');
+		});
+	}
 
     // The dropdown list for adding a new page contains URLs for each
     // model - redirect when selected.


### PR DESCRIPTION
The problem occurred when reloading a page after setting an open child branch's
parent as closed. When you reloaded a page the routine that would
reopen previously opened child branches (that are currently hidden by a parent)
was causing said child branch displaying both the show(+) and hide(-)
icons side by side which could be seen when reopening the parent.
It would also cause this said hidden, opened child branch
to no longer be registered in the opened branch cookie. So if you were to
reload the page again, this branch wouldn't be opened at all.

The solution involves simply reopening all previously opened branches on
reload without worrying about adding their ID's again to the cookie. It also
avoids using the Jquery toggle() function which seemed to be the problem
that caused both the show(+) and hide(-) buttons to appear.
