### PR TITLE
EXTRA_MODEL_FIELDS definition typo fix.

### DIFF
--- a/docs/model-customization.rst
+++ b/docs/model-customization.rst
@@ -59,7 +59,7 @@ from the previous example, suppose you wanted to add a regular Django
             "mezzanine.blog.models.BlogPost.image",
             "somelib.fields.ImageField",
             (_("Image"),),
-            {"blank": True, "upload_to: "blog"},
+            {"blank": True, "upload_to": "blog"},
         ),
         # Example of adding a field to *all* of Mezzanine's content types:
         (

--- a/mezzanine/project_template/settings.py
+++ b/mezzanine/project_template/settings.py
@@ -45,7 +45,7 @@
 #         # Positional args for field class.
 #         (_("Image"),),
 #         # Keyword args for field class.
-#         {"blank": True, "upload_to: "blog"},
+#         {"blank": True, "upload_to": "blog"},
 #     ),
 #     # Example of adding a field to *all* of Mezzanine's content types:
 #     (


### PR DESCRIPTION
Typo fix for EXTRA_MODEL_FIELDS definitions in docs and settings.py.
