### PR TITLE
Docstring typo in Displayable's save method

### DIFF
--- a/mezzanine/core/models.py
+++ b/mezzanine/core/models.py
@@ -118,7 +118,7 @@ class Displayable(Slugged, MetaData):
 
     def save(self, *args, **kwargs):
         """
-        Set default for ``publsh_date`` and ``description`` if none
+        Set default for ``publish_date`` and ``description`` if none
         given.
         """
         if self.publish_date is None:


### PR DESCRIPTION
Just messing inside Mezzanine for translation app and found another small typo.
