### PR TITLE
Added database engine prefixes for settings.py and local_settings.py templates

### DIFF
--- a/mezzanine/project_template/local_settings.py.template
+++ b/mezzanine/project_template/local_settings.py.template
@@ -3,17 +3,12 @@ DEBUG = True
 
 DATABASES = {
     "default": {
-        # "postgresql_psycopg2", "postgresql", "mysql", "sqlite3" or "oracle".
-        "ENGINE": "sqlite3",
-        # DB name or path to database file if using sqlite3.
-        "NAME": "dev.db",
-        # Not used with sqlite3.
-        "USER": "",
-        # Not used with sqlite3.
-        "PASSWORD": "",
-        # Set to empty string for localhost. Not used with sqlite3.
-        "HOST": "",
-        # Set to empty string for default. Not used with sqlite3.
-        "PORT": "",
+        "ENGINE": "django.db.backends.sqlite", # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+        'NAME': 'devdb', # DB name or path to database file if using sqlite3.
+        'USER': '', # Not used with sqlite3.
+        'PASSWORD': '', # Not used with sqlite3.
+        'HOST': '', # Set to empty string for localhost. Not used with sqlite3.
+        'PORT': '', # Set to empty string for default. Not used with sqlite3.
+        
     }
 }

--- a/mezzanine/project_template/settings.py
+++ b/mezzanine/project_template/settings.py
@@ -153,8 +153,7 @@ LOGOUT_URL = "/account/logout/"
 
 DATABASES = {
     "default": {
-        # "postgresql_psycopg2", "postgresql", "mysql", "sqlite3" or "oracle".
-        "ENGINE": "",
+        "ENGINE": "'django.db.backends.",
         # DB name or path to database file if using sqlite3.
         "NAME": "",
         # Not used with sqlite3.


### PR DESCRIPTION
Unprefixed format for database engines was removed from django 1.4. Added django.db.backends. to settings.py and local_settings.py templates. Compatible down to Django 1.2
