### PR TITLE
Another fix for Windows

### DIFF
--- a/mezzanine/core/management/commands/collecttemplates.py
+++ b/mezzanine/core/management/commands/collecttemplates.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
                         # specified.
                         if single_template and name != single_template:
                             continue
-                        if not admin and name.startswith("admin/"):
+                        if not admin and name.startswith("admin" + os.sep):
                             continue
                         templates.append((name, path))
 


### PR DESCRIPTION
Without this, the new collecttemplates management command copies the admin templates all the time.
