### PR TITLE
Uninstalling the twitter will currently cause a template exception with default templates

### DIFF
--- a/mezzanine/core/templates/base.html
+++ b/mezzanine/core/templates/base.html
@@ -91,9 +91,7 @@ $(function() {
     {% include "includes/user_panel.html" %}
     <div class="panel">
     {% block right_panel %}
-    {% if "mezzanine.twitter"|is_installed %}
-    {% include "twitter/tweets.html" %}
-    {% endif %}
+    {% include_if_installed mezzanine.twitter twitter/tweets.html %}
     {% endblock %}
     </div>
 </div>

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -348,3 +348,29 @@ def dashboard_column(context, token):
         t = Template("{%% load %s %%}{%% %s %%}" % tuple(tag.split(".")))
         output.append(t.render(Context(context)))
     return "".join(output)
+
+
+@register.render_tag
+def include_if_installed(context, token):
+    """
+    Loads a template and renders it with the current context if a specified app
+    is installed. Otherwise, doesn't check for the existance of the template.
+    """
+    bits = token.split_contents()
+    if len(bits) < 3:
+        raise TemplateSyntaxError("%r tag takes at least two argument: the "
+        "name of the app that to check for installation and the template to be"
+        "included." % bits[0])
+    app = bits[1]
+    if app in settings.INSTALLED_APPS:
+        path = bits[2]
+        try:
+            template = get_template(path)
+            output = template.render(context)
+            return output
+        except:
+            if settings.TEMPLATE_DEBUG:
+                raise
+            return ''
+    else:
+        return ''


### PR DESCRIPTION
Fixed template error with default templates when twitter app isn't installed by writing custom template tag to include lazily rather than complaining the template doesn't exist even when it isn't required which Django's ConstantIncludeNode will.
