### PR TITLE
fixed mezzanine/core/templatetags/mezzanine_tags.py docstring errors

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,12 +1,5 @@
 .. THIS DOCUMENT IS AUTO GENERATED VIA conf.py
 
-``ACCOUNTS_ENABLED``
---------------------
-
-If ``True``, users can create an account.
-
-Default: ``False``
-
 ``ACCOUNTS_VERIFICATION_REQUIRED``
 ----------------------------------
 
@@ -252,6 +245,20 @@ Min value for a rating.
 
 Default: ``1``
 
+``RICHTEXT_ALLOWED_ATTRIBUTES``
+-------------------------------
+
+List of HTML attributes that won't be stripped from ``RichTextField`` instances.
+
+Default: ``('abbr', 'accept', 'accept-charset', 'accesskey', 'action', 'align', 'alt', 'axis', 'border', 'cellpadding', 'cellspacing', 'char', 'charoff', 'charset', 'checked', 'cite', 'class', 'clear', 'cols', 'colspan', 'color', 'compact', 'coords', 'datetime', 'dir', 'disabled', 'enctype', 'for', 'frame', 'headers', 'height', 'href', 'hreflang', 'hspace', 'id', 'ismap', 'label', 'lang', 'longdesc', 'maxlength', 'media', 'method', 'multiple', 'name', 'nohref', 'noshade', 'nowrap', 'prompt', 'readonly', 'rel', 'rev', 'rows', 'rowspan', 'rules', 'scope', 'selected', 'shape', 'size', 'span', 'src', 'start', 'style', 'summary', 'tabindex', 'target', 'title', 'type', 'usemap', 'valign', 'value', 'vspace', 'width', 'xml:lang')``
+
+``RICHTEXT_ALLOWED_TAGS``
+-------------------------
+
+List of HTML tags that won't be stripped from ``RichTextField`` instances.
+
+Default: ``('a', 'abbr', 'acronym', 'address', 'area', 'b', 'bdo', 'big', 'blockquote', 'br', 'button', 'caption', 'center', 'cite', 'code', 'col', 'colgroup', 'dd', 'del', 'dfn', 'dir', 'div', 'dl', 'dt', 'em', 'fieldset', 'font', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'input', 'ins', 'kbd', 'label', 'legend', 'li', 'map', 'menu', 'ol', 'optgroup', 'option', 'p', 'pre', 'q', 's', 'samp', 'select', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'tr', 'tt', 'u', 'ul', 'var', 'wbr')``
+
 ``RICHTEXT_FILTER``
 -------------------
 
@@ -334,7 +341,7 @@ Default: ``4``
 
 Sequence of setting names available within templates.
 
-Default: ``('ACCOUNTS_ENABLED', 'ADMIN_MEDIA_PREFIX', 'BLOG_BITLY_USER', 'BLOG_BITLY_KEY', 'COMMENTS_DISQUS_SHORTNAME', 'COMMENTS_NUM_LATEST', 'COMMENTS_DISQUS_API_PUBLIC_KEY', 'COMMENTS_DISQUS_API_SECRET_KEY', 'DEV_SERVER', 'FORMS_USE_HTML5', 'GRAPPELLI_INSTALLED', 'GOOGLE_ANALYTICS_ID', 'JQUERY_FILENAME', 'LOGIN_URL', 'LOGOUT_URL', 'PAGES_MENU_SHOW_ALL', 'SITE_TITLE', 'SITE_TAGLINE', 'RATINGS_MAX')``
+Default: ``('ACCOUNTS_VERIFICATION_REQUIRED', 'ADMIN_MEDIA_PREFIX', 'BLOG_BITLY_USER', 'BLOG_BITLY_KEY', 'COMMENTS_DISQUS_SHORTNAME', 'COMMENTS_NUM_LATEST', 'COMMENTS_DISQUS_API_PUBLIC_KEY', 'COMMENTS_DISQUS_API_SECRET_KEY', 'DEV_SERVER', 'FORMS_USE_HTML5', 'GRAPPELLI_INSTALLED', 'GOOGLE_ANALYTICS_ID', 'JQUERY_FILENAME', 'LOGIN_URL', 'LOGOUT_URL', 'PAGES_MENU_SHOW_ALL', 'SITE_TITLE', 'SITE_TAGLINE', 'RATINGS_MAX')``
 
 ``THUMBNAILS_DIR_NAME``
 -----------------------

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -59,10 +59,10 @@ def ifinstalled(parser, token):
     Old-style ``if`` tag that renders contents if the given app is
     installed. The main use case is:
     {% ifinstalled app_name %}
-        {% include "app_name/template.html" %}
+    {% include "app_name/template.html" %}
     {% endifinstalled %}
     so we need to manually pull out all tokens if the app isn't
-    installed, since if we used a normal ``if``tag with a False arg,
+    installed, since if we used a normal ``if`` tag with a False arg,
     the include tag will still try and find the template to include.
     """
     try:


### PR DESCRIPTION
(mezz)bschott@ironman:mezzanine$ !sph
sphinx-build docs html
Making output directory...
Running Sphinx v1.1.3
/Users/bschott/Source/mezzanine/docs/../mezzanine/utils/docs.py:157: UserWarning: Couldn't build model_graph, graph_models failed on: 'default'
  warn("Couldn't build model_graph, graph_models failed on: %s" % e)
loading pickled environment... not yet created
No builder selected, using default: html
building [html]: targets for 16 source files that are out of date
updating environment: 16 added, 0 changed, 0 removed
reading sources... [100%] settings  
CHANGELOG:1245: WARNING: Inline emphasis start-string without end-string.
CHANGELOG:1369: ERROR: Unknown target name: "mezzanine".
None:None: WARNING: nonlocal image URI found: https://secure.travis-ci.org/stephenmcd/mezzanine.png?branch=master
README.rst:62: WARNING: nonlocal image URI found: http://github.com/stephenmcd/mezzanine/raw/master/docs/img/dashboard.png
/Users/bschott/Source/mezzanine/mezzanine/core/templatetags/mezzanine_tags.py:docstring of mezzanine.core.templatetags.mezzanine_tags.ifinstalled:4: ERROR: Unexpected indentation.
/Users/bschott/Source/mezzanine/mezzanine/core/templatetags/mezzanine_tags.py:docstring of mezzanine.core.templatetags.mezzanine_tags.ifinstalled:5: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/bschott/Source/mezzanine/mezzanine/core/templatetags/mezzanine_tags.py:docstring of mezzanine.core.templatetags.mezzanine_tags.ifinstalled:5: WARNING: Inline literal start-string without end-string.
looking for now-outdated files... none found
pickling environment... done
checking consistency... /Users/bschott/Source/mezzanine/docs/settings.rst:: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] settings  
writing additional files... genindex py-modindex search
copying images... [100%] img/graph-small.png  
copying static files... done
dumping search index... done
dumping object inventory... done
build succeeded, 8 warnings.
(mezz)bschott@ironman:mezzanine$ emacs mezzanine/core/templatetags/mezzanine_tags.py          
