### PR TITLE
Cache Strategy documentation tweaks

### DIFF
--- a/docs/caching-strategy.rst
+++ b/docs/caching-strategy.rst
@@ -62,7 +62,7 @@ object, including session-specific data.
 
 Accordingly, Mezzanine provides the start and end template tags
 ``nevercache`` and ``endnevercache``. Content wrapped in these tags
-will ensure that the enclosed content is not cached. With two-phased
+will not be cached. With two-phased
 rendering, the page is cached without any of the template code
 inside ``nevercache`` and ``endnevercache`` executed for the first
 phase. The second phase then occurs after the page is retrieved from


### PR DESCRIPTION
Just cleaned up the text a bit -- though I wasn't sure about this one sentence:

```
This approach ensures that cache misses never actually occur and that (almost) only one
client will ever perform regeneration of a cache entry.
```

Perhaps just check to see if I've captured the meaning here.
