### PR TITLE
page middleware: use request.path_info

### DIFF
--- a/mezzanine/pages/middleware.py
+++ b/mezzanine/pages/middleware.py
@@ -35,7 +35,7 @@ class PageMiddleware(object):
         # Remove the page slug which is set when the blog is at
         # the root of the site (BLOG_SLUG is empty).
 
-        slug = request.path
+        slug = request.path_info
         if slug != "/":
             from mezzanine.urls import PAGES_SLUG
             slug = slug.strip("/").replace(PAGES_SLUG, "", 1)


### PR DESCRIPTION
Use request.path_info instead of request.path:

https://docs.djangoproject.com/en/dev/ref/request-response/#django.http.HttpRequest.path_info

With this patch mezzanine will be compatible with django-localeurl.
And multilingual testing will be continued.
