### PR TITLE
Set the default FileField format to Image so filebrowser can allow for f...

### DIFF
--- a/mezzanine/core/fields.py
+++ b/mezzanine/core/fields.py
@@ -70,7 +70,7 @@ else:
         def __init__(self, *args, **kwargs):
             kwargs.setdefault("directory", kwargs.pop("upload_to", None))
             super(FileField, self).__init__(*args, **kwargs)
-            self.format = self.format or 'Image'
+            self.format = self.format or "file"
 
 
 HtmlField = RichTextField  # For backward compatibility in south migrations.


### PR DESCRIPTION
...older selection.

This will need an associated filebrowser-safe change to allow for selectability of folders.
https://github.com/stephenmcd/filebrowser-safe/blob/master/filebrowser_safe/templatetags/fb_tags.py#L126

Long story short, after these changes any FileField will allow the user to select a folder, but by default will fail on save because the folder extension `''` is not allowed.
https://groups.google.com/forum/?fromgroups#!topic/mezzanine-users/cAX58wm4gGg
