### PR TITLE
set mimetype to empty string in case path is not found

### DIFF
--- a/mezzanine/core/views.py
+++ b/mezzanine/core/views.py
@@ -116,6 +116,7 @@ def static_proxy(request):
         if url.startswith(prefix):
             url = url.replace(prefix, "", 1)
     response = ""
+    mimetype = ""
     path = finders.find(url)
     if path:
         if isinstance(path, (list, tuple)):


### PR DESCRIPTION
This should turn a more sensible exception in a rare error condition.  See issue #269.
