### PR TITLE
fix migration without blog app

### DIFF
--- a/mezzanine/core/migrations/0002_auto__del_keyword.py
+++ b/mezzanine/core/migrations/0002_auto__del_keyword.py
@@ -3,13 +3,19 @@ import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
+from django.conf import settings
 
 class Migration(SchemaMigration):
 
-    depends_on = [
-        ('blog', '0006_auto__del_field_blogpost__keywords__add_field_blogpost_keywords_string'),
-        ('pages', '0002_auto__del_field_page__keywords__add_field_page_keywords_string__chg_fi'),
-        ]
+    if 'mezzanine.blog' in settings.INSTALLED_APPS:
+        depends_on = [
+            ('blog', '0006_auto__del_field_blogpost__keywords__add_field_blogpost_keywords_string'),
+            ('pages', '0002_auto__del_field_page__keywords__add_field_page_keywords_string__chg_fi'),
+            ]
+    else:
+        depends_on = [
+            ('pages', '0002_auto__del_field_page__keywords__add_field_page_keywords_string__chg_fi'),
+            ]
 
     def forwards(self, orm):
         


### PR DESCRIPTION
if mezzanine.blog was not installed in INSTALLED_APPS south migration throws exception:

south.exceptions.DependsOnUnmigratedApplication: Migration 'core:0002_auto__del_keyword' depends on unmigrated application 'blog'.

So I've added simple check.
