### PR TITLE
added in-navigation test to level 1

### DIFF
--- a/mezzanine/pages/templates/pages/menus/dropdown.html
+++ b/mezzanine/pages/templates/pages/menus/dropdown.html
@@ -29,10 +29,12 @@
 {% if branch_level == 1 %}
 <ul class="dropdown-menu">
     {% for page in page_branch %}
+    {% if page.in_navigation %}
     <li{% if page.is_current_or_ascendant %} class="active"{% endif %}
         id="dropdown-menu-{{ page.html_id }}">
         <a href="{{ page.get_absolute_url }}">{{ page.title }}</a>
     </li>
+    {% endif %}
     {% endfor %}
 </ul>
 {% endif %}


### PR DESCRIPTION
While internally testing our site, we realized that the drop down menu was showing second-level pages regardless of their in-navigation flag state.  This seems to fix it.
