### PR TITLE
Redirects "/users/" and "/account/" to "/users/logged_in_username/"

### DIFF
--- a/mezzanine/accounts/urls.py
+++ b/mezzanine/accounts/urls.py
@@ -34,6 +34,8 @@ urlpatterns = patterns("mezzanine.accounts.views",
 
 if settings.ACCOUNTS_PROFILE_VIEWS_ENABLED:
     urlpatterns += patterns("mezzanine.accounts.views",
+        url("^account/$", "profile"),
+        url("^%s/$" % PROFILE_URL.strip("/"), "profile"),
         url("^%s/(?P<username>.*)/$" % PROFILE_URL.strip("/"), "profile",
             name="profile"),
     )

--- a/mezzanine/accounts/views.py
+++ b/mezzanine/accounts/views.py
@@ -79,11 +79,11 @@ def signup_verify(request, uidb36=None, token=None):
         return redirect("/")
 
 
-def profile(request, username, template="accounts/account_profile.html"):
+def profile(request, username=None, template="accounts/account_profile.html"):
     """
     Display a profile.
     """
-    profile_user = get_object_or_404(User, username=username, is_active=True)
+    profile_user = get_object_or_404(User, username=username or request.user.username, is_active=True)
     profile_fields = SortedDict()
     Profile = get_profile_model()
     if Profile is not None:


### PR DESCRIPTION
"/users/" and "/account/" now points to no where. This patch points it to the logged in user's profile. 

This way, we can set LOGIN_REDIRECT_URL="/users/".

Should we also redirect "/accounts/profile/" to the user's profile (Django's default url for profile, which is different from Mezzanine) ? 
