### PR TITLE
Add topic infrastructure to twitter feeds.

### DIFF
--- a/mezzanine/twitter/admin.py
+++ b/mezzanine/twitter/admin.py
@@ -1,0 +1,23 @@
+# admin interface for mezzanine twitter app including topics
+
+from django.contrib import admin
+
+from mezzanine.twitter.models import Query, Tweet, Topic
+
+
+class QueryAdmin(admin.ModelAdmin):
+    """
+    Admin class for twitter queries.
+    """
+    pass
+
+
+class TopicAdmin(admin.ModelAdmin):
+    """
+    Admin class for twitter topics.
+    """
+    pass
+
+
+admin.site.register(Query, QueryAdmin)
+admin.site.register(Topic, TopicAdmin)

--- a/mezzanine/twitter/management/commands/poll_topics.py
+++ b/mezzanine/twitter/management/commands/poll_topics.py
@@ -1,0 +1,19 @@
+
+from django.core.management.base import NoArgsCommand
+from django.db import models
+from mezzanine.twitter.models import Query, Topic
+
+
+class Command(NoArgsCommand):
+    """
+    Polls the Twitter API for tweets associated to the queries in templates.
+    Temporarily mark each query item as "interested" since this is required
+    to get query.run() to actually pick up the tweets.
+    """
+    def handle_noargs(self, **options):
+        for query in Query.objects.annotate(n=models.Count('topic')).filter(n__gt=0):
+            query.interested = True
+            query.run()
+            pass
+        return
+    pass

--- a/mezzanine/twitter/management/commands/poll_twitter.py
+++ b/mezzanine/twitter/management/commands/poll_twitter.py
@@ -7,6 +7,10 @@ from mezzanine.twitter.models import Query
 class Command(NoArgsCommand):
     """
     Polls the Twitter API for tweets associated to the queries in templates.
+    Note that query.run() expects to have query.interested set to True
+    which is a side-effect of having a page accessed by a client.
+    If it has not been accessed since the last poll then the tweets
+    will not be updated.
     """
     def handle_noargs(self, **options):
         for query in Query.objects.filter(interested=True):

--- a/mezzanine/twitter/models.py
+++ b/mezzanine/twitter/models.py
@@ -121,3 +121,27 @@ class Tweet(models.Model):
 
     def is_retweet(self):
         return self.retweeter_user_name is not None
+
+
+class Topic(models.Model):
+    """
+    Organizes twitter feeds by topic.
+    Define each feed using the Query model
+    then define a category or topic here.
+    Use the tweets_on template tag to access
+    the most recent content and use::
+
+       manage.py poll_topics
+
+    to pull the content into the database.
+    """
+    name = models.CharField(_("Name"), max_length=20)
+    query = models.ManyToManyField(Query)
+
+    class Meta:
+        verbose_name = _("topic")
+        verbose_name_plural = _("topics")
+        # ordering = ("-query",)
+
+    def __unicode__(self):
+        return "%s" % (self.name,)


### PR DESCRIPTION
Hi Stephen. I've merged in the "topic" feature for twitter feeds. As we've discussed
earlier, it may be helpful (it is to me) to take the actual feed configuration out
of templates and make them configurable. And to be able to aggregate multiple feeds
into a "topic" to get some more variety into the content. If this is a possibility for you
it would be great to see it in the base repo; let me know if you need any changes
to make that a possibility for you.

Here is the commit comment:

Previously all twitter feeds were defined in-place by use of tags in templates.
A new tag, tweets_on, takes a string "topic" rather than an explicit feed name
as do the existing tags tweets_for_user etc.
Provide an admin interface to define topics as well as queries, which
previously were defined only by their first usage in a template.
Use the command "poll_topics" to get content from twitter.com in the
same way as poll_twitter does, with the only difference being that
poll_topics will refresh every defined topic and feed even if the
"is_interested" flag has not been previously set by a page access.
