### PR TITLE
add a block left_panel in base.html

### DIFF
--- a/mezzanine/core/templates/base.html
+++ b/mezzanine/core/templates/base.html
@@ -90,7 +90,9 @@ $(function() {
 <div class="row">
 
 <div class="span2 left">
+    {% block left_panel %}
     <div class="panel tree">{% page_menu "pages/menus/tree.html" %}</div>
+    {% endblock %}
 </div>
 
 <div class="span7 middle">


### PR DESCRIPTION
makes it easier to over-ride the left panel content without copying all of base.html
