### PR TITLE
Sitemap: Ensure urls are only added once to the list of items

### DIFF
--- a/mezzanine/core/sitemaps.py
+++ b/mezzanine/core/sitemaps.py
@@ -17,7 +17,14 @@ class DisplayableSitemap(Sitemap):
         ``Displayable``.
         """
         items = []
+        item_urls = set()
         for model in get_models():
             if issubclass(model, Displayable):
-                items.extend(model.objects.published())
+                for item in model.objects.published():
+                    url = item.get_absolute_url()
+                    # check if the url of that item was already seen
+                    # (this might happen for Page items and subclasses of Page like RichTextPage)
+                    if not url in item_urls:
+                        items.append(item)
+                        item_urls.add(url)
         return items


### PR DESCRIPTION
I noticed it might happen that pages are listed multiple times in /sitemap.xml since for instance a RichTextPage is also a Page and both are subclasses of Displayable.

This solution is probably somewhat slower than the previous easy listing as it needs to iterate over each single item and then retrieve each item's get_absolute_url(). However, I didn't find an easier way of distinguishing unique pages (the slug attribute would be nice but it doesn't contain the PAGES/BLOG slug and so it is not unique across a site).
