### PR TITLE
Use publish_date for BlogPosts in /sitemap.xml

### DIFF
--- a/mezzanine/core/sitemaps.py
+++ b/mezzanine/core/sitemaps.py
@@ -2,7 +2,12 @@
 from django.contrib.sitemaps import Sitemap
 from django.db.models import get_models
 
+from mezzanine.conf import settings
 from mezzanine.core.models import Displayable
+
+blog_installed = "mezzanine.blog" in settings.INSTALLED_APPS
+if blog_installed:
+    from mezzanine.blog.models import BlogPost
 
 
 class DisplayableSitemap(Sitemap):
@@ -22,3 +27,7 @@ class DisplayableSitemap(Sitemap):
                 for item in model.objects.published():
                     items[item.get_absolute_url()] = item
         return items.values()
+
+    def lastmod(self, obj):
+        if blog_installed and isinstance(obj, BlogPost):
+            return obj.publish_date


### PR DESCRIPTION
Since BlogPosts most probably won't change much after they have been created, we could use the publish_date attribute as the Last Change date for the generated sitemap.

It would be cool to have this also for Pages but I'm not sure publish_date makes sense on pages since it might be not unusual that pages are updated after their publish_date.
An additional update_date attribute would be cool which could be updated automatically on each save() or so. But this is quite a heavy change just to have a date in the generated sitemap, so I don't propose that unless there might be other valid uses.
