### PR TITLE
Fix edge case in url templatetag causing ViewDoesNotExist error. 

### DIFF
--- a/mezzanine/accounts/templates/accounts/includes/user_panel.html
+++ b/mezzanine/accounts/templates/accounts/includes/user_panel.html
@@ -2,7 +2,9 @@
 
 {% if request.user.is_authenticated %}
     {% trans "Logged in as: " %}
-    {% url profile request.user.username as profile_url %}
+    {% if settings.ACCOUNTS_PROFILE_VIEWS_ENABLED %}
+        {% url profile request.user.username as profile_url %}
+    {% endif %}
     {% if profile_url %}
         <a href="{{ profile_url }}">{{ request.user.username }}</a><br>
         <a href="{% url profile_update %}"

--- a/mezzanine/core/defaults.py
+++ b/mezzanine/core/defaults.py
@@ -437,6 +437,7 @@ register_setting(
     description=_("Sequence of setting names available within templates."),
     editable=False,
     default=(
+        "ACCOUNTS_PROFILE_VIEWS_ENABLED",
         "ACCOUNTS_VERIFICATION_REQUIRED", "ADMIN_MEDIA_PREFIX",
         "BLOG_BITLY_USER", "BLOG_BITLY_KEY",
         "COMMENTS_DISQUS_SHORTNAME", "COMMENTS_NUM_LATEST",


### PR DESCRIPTION
It happened when ACCOUNTS_PROFILE_VIEWS_ENABLED was set to False
and profile app called `profile` (same as url name) was added
to INSTALLED_APPS.
