### PR TITLE
Issue loading correct slug when using cms page as homepage.  ( updated middleware )

### DIFF
--- a/mezzanine/pages/middleware.py
+++ b/mezzanine/pages/middleware.py
@@ -35,6 +35,8 @@ class PageMiddleware(object):
 
         slug = path_to_slug(request.path_info)
         if slug == "/":
+            if resolve('/').kwargs.has_key('slug'):
+                slug = resolve('/').kwargs['slug']
             slugs = [slug]
         else:
             # Create a list containing this slug, plus each of the


### PR DESCRIPTION
...the page tree

Old code did not detect the slug appropriatley forcing you to make the slug / in the admin area.

Let me know if I am way off base here.
