### PR TITLE
Fix for Issue #316: Authentication fails on registration

### DIFF
--- a/mezzanine/accounts/forms.py
+++ b/mezzanine/accounts/forms.py
@@ -165,8 +165,9 @@ class ProfileForm(Html5Mixin, forms.ModelForm):
                 user.is_active = False
                 user.save()
             else:
-                user = authenticate(username=user.username,
-                                    password=password, is_active=True)
+                user.is_active = True
+                user.save()
+                user = authenticate(username=user.username, password=password)
         return user
 
 


### PR DESCRIPTION
Set user 'is_active' before calling authenticate().
