### PR TITLE
use ugettext_lazy strings for settings form

### DIFF
--- a/mezzanine/accounts/defaults.py
+++ b/mezzanine/accounts/defaults.py
@@ -10,7 +10,7 @@ that are only read during startup shouldn't be editable, since changing
 them would require an application reload.
 """
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from mezzanine.conf import register_setting
 

--- a/mezzanine/blog/defaults.py
+++ b/mezzanine/blog/defaults.py
@@ -10,7 +10,7 @@ that are only read during startup shouldn't be editable, since changing
 them would require an application reload.
 """
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from mezzanine.conf import register_setting
 

--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -5,7 +5,8 @@ or Django itself. Settings can also be made editable via the admin.
 """
 
 from django.conf import settings as django_settings
-from django.template.defaultfilters import urlize
+from django.utils.encoding import force_unicode
+from django.utils.functional import Promise
 
 from mezzanine import __version__
 
@@ -23,13 +24,15 @@ def register_setting(name="", label="", editable=False, description="",
         registry[name]["default"] += default
     else:
         default = getattr(django_settings, name, default)
+        if isinstance(default, Promise):
+            default = force_unicode(default)
         setting_type = type(default)
         if not label:
             label = name.replace("_", " ").title()
         if setting_type is str:
             setting_type = unicode
         registry[name] = {"name": name, "label": label,
-                          "description": urlize(description),
+                          "description": description,
                           "editable": editable, "default": default,
                           "choices": choices, "type": setting_type}
 

--- a/mezzanine/conf/forms.py
+++ b/mezzanine/conf/forms.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from django import forms
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
+from django.template.defaultfilters import urlize
 
 from mezzanine.conf import settings, registry
 from mezzanine.conf.models import Setting
@@ -33,7 +34,8 @@ class SettingsForm(forms.Form):
                     "label": setting["label"] + ":",
                     "required": setting["type"] == int,
                     "initial": getattr(settings, name),
-                    "help_text": self.format_help(setting["description"]),
+                    "help_text": self.format_help(
+                                               urlize(setting["description"])),
                 }
                 if setting["choices"]:
                     field_class = forms.ChoiceField

--- a/mezzanine/core/defaults.py
+++ b/mezzanine/core/defaults.py
@@ -11,7 +11,7 @@ them would require an application reload.
 """
 
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from mezzanine.conf import register_setting
 

--- a/mezzanine/forms/defaults.py
+++ b/mezzanine/forms/defaults.py
@@ -10,7 +10,7 @@ that are only read during startup shouldn't be editable, since changing
 them would require an application reload.
 """
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from mezzanine.conf import register_setting
 

--- a/mezzanine/generic/defaults.py
+++ b/mezzanine/generic/defaults.py
@@ -11,7 +11,7 @@ them would require an application reload.
 """
 
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from mezzanine.conf import register_setting
 

--- a/mezzanine/pages/defaults.py
+++ b/mezzanine/pages/defaults.py
@@ -10,7 +10,7 @@ that are only read during startup shouldn't be editable, since changing
 them would require an application reload.
 """
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from mezzanine.conf import register_setting
 

--- a/mezzanine/twitter/defaults.py
+++ b/mezzanine/twitter/defaults.py
@@ -10,7 +10,7 @@ that are only read during startup shouldn't be editable, since changing
 them would require an application reload.
 """
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from mezzanine.conf import register_setting
 from mezzanine.twitter import QUERY_TYPE_CHOICES, QUERY_TYPE_SEARCH


### PR DESCRIPTION
So this form is displaying correctly in the case of dynamic language middleware (via subdomain or other).
I hope this code will help a bit to do mezzanine internationalization feature :)
