### PR TITLE
Add check to settings.py to prevent breaking fabric scripts.

### DIFF
--- a/mezzanine/project_template/settings.py
+++ b/mezzanine/project_template/settings.py
@@ -363,5 +363,10 @@ except ImportError:
 # set_dynamic_settings() will rewrite globals based on what has been
 # defined so far, in order to provide some better defaults where
 # applicable.
-from mezzanine.utils.conf import set_dynamic_settings
-set_dynamic_settings(globals())
+
+# Since fabric scripts may import this file, and this code only works
+# if run in a Django context, check that the DJANGO_SETTINGS_MODULE
+# variable has been set by Django
+if 'DJANGO_SETTINGS_MODULE' in os.environ:
+    from mezzanine.utils.conf import set_dynamic_settings
+    set_dynamic_settings(globals())


### PR DESCRIPTION
Since fabfile.py can import settings.py, conditionally execute certain Django-related code only when DJANGO_SETTINGS_MODULE is set.

Fix for #336.
