### PR TITLE
Add _order to Page's META ordering

### DIFF
--- a/mezzanine/pages/models.py
+++ b/mezzanine/pages/models.py
@@ -38,7 +38,7 @@ class Page(BasePage):
     class Meta:
         verbose_name = _("Page")
         verbose_name_plural = _("Pages")
-        ordering = ("titles",)
+        ordering = ("_order", "titles",)
         order_with_respect_to = "parent"
 
     def __unicode__(self):


### PR DESCRIPTION
I bubble content up from child pages into the parent, but I don't want them sorted by title but by the order in which they appear in the Pages admin.
