### PR TITLE
Exclude tracking code if user is part of the staff team

### DIFF
--- a/mezzanine/core/templates/includes/footer_scripts.html
+++ b/mezzanine/core/templates/includes/footer_scripts.html
@@ -3,7 +3,7 @@
 {% editable_loader %}
 
 <script>
-{% if settings.GOOGLE_ANALYTICS_ID %}
+{% if settings.GOOGLE_ANALYTICS_ID and not request.user.is_staff %}
 var _gaq = _gaq || [['_trackPageview']];
 _gaq.unshift(['_setAccount', '{{ settings.GOOGLE_ANALYTICS_ID }}']);
 (function(d, t) {


### PR DESCRIPTION
Added a check in footer_scripts to only include the analytics tracking code if user is not part of the staff team
