### PR TITLE
Render admin "add" link if no change permission

### DIFF
--- a/mezzanine/core/templates/admin/includes/app_list.html
+++ b/mezzanine/core/templates/admin/includes/app_list.html
@@ -9,21 +9,21 @@
            {% for model in app.models %}
            <tr>
            {% if model.perms.change or model.perms.custom %}
-               <th scope="row" width="100%"><a 
+               <th scope="row" width="100%"><a
                     href="{{ model.admin_url }}">{{ model.name }}</a></th>
            {% else %}
                <th scope="row" width="100%">{{ model.name }}</th>
            {% endif %}
-           
+
            {% if model.perms.add %}
-               <td><a href="{{ model.admin_url }}add/" 
+               <td><a href="{{ model.add_url }}"
                     class="addlink">{% trans 'Add' %}</a></td>
            {% else %}
                <td>&nbsp;</td>
            {% endif %}
-           
+
            {% if model.perms.change %}
-               <td><a href="{{ model.admin_url }}" 
+               <td><a href="{{ model.admin_url }}"
                     class="changelink">{% trans 'Change' %}</a></td>
            {% else %}
                <td>&nbsp;</td>

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -381,8 +381,14 @@ def admin_app_list(request):
             admin_url_name = ""
             if perms["change"]:
                 admin_url_name = "changelist"
-            elif perms["add"]:
+                change_url = admin_url(model, admin_url_name)
+            else:
+                change_url = None
+            if perms["add"]:
                 admin_url_name = "add"
+                add_url = admin_url(model, admin_url_name)
+            else:
+                add_url = None
             if admin_url_name:
                 model_label = "%s.%s" % (opts.app_label, opts.object_name)
                 for (name, items) in menu_order:
@@ -397,12 +403,15 @@ def admin_app_list(request):
                 else:
                     index = None
                     app_title = opts.app_label
+
                 model_dict = {
                     "index": index,
                     "perms": model_admin.get_model_perms(request),
                     "name": capfirst(model._meta.verbose_name_plural),
-                    "admin_url": admin_url(model, admin_url_name),
+                    "admin_url": change_url,
+                    "add_url": add_url
                 }
+
                 app_title = app_title.title()
                 if app_title in app_dict:
                     app_dict[app_title]["models"].append(model_dict)


### PR DESCRIPTION
Handle the case where a non-superuser staff member has "add" permission but not "change" permission.

Fix for #399.
