### PR TITLE
Use Page URLs without trailing slash when APPEND_SLASH is False

### DIFF
--- a/mezzanine/pages/urls.py
+++ b/mezzanine/pages/urls.py
@@ -1,10 +1,11 @@
 
 from django.conf.urls.defaults import patterns, url
+from django.conf import settings
 
 
 # Page patterns.
 urlpatterns = patterns("mezzanine.pages.views",
     url("^admin_page_ordering/$", "admin_page_ordering",
         name="admin_page_ordering"),
-    url("^(?P<slug>.*)/$", "page", name="page"),
+    url("^(?P<slug>.*)" + ("/" if settings.APPEND_SLASH else "") + "$", "page", name="page"),
 )


### PR DESCRIPTION
Very simple fix to remove the trailing slash from pages/urls.py if APPEND_SLASH is False in the Django settings.
