### PR TITLE
TWITTER_STRIP_HIGH_MULTIBYTE setting to strip Emoji

### DIFF
--- a/mezzanine/twitter/models.py
+++ b/mezzanine/twitter/models.py
@@ -8,6 +8,7 @@ from django.db import models
 from django.utils.html import urlize
 from django.utils.simplejson import loads
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
 
 from mezzanine.twitter.managers import TweetManager
 from mezzanine.utils.timezone import make_aware
@@ -85,6 +86,8 @@ class Query(models.Model):
             tweet.text = urlize(tweet_json["text"])
             tweet.text = re_usernames.sub(replace_usernames, tweet.text)
             tweet.text = re_hashtags.sub(replace_hashtags, tweet.text)
+            if getattr(settings, 'TWITTER_STRIP_HIGH_MULTIBYTE', False):
+                tweet.text = ''.join([ch for ch in tweet.text if ord(ch) < 0x800])
             d = datetime.strptime(tweet_json["created_at"], date_format)
             d -= timedelta(seconds=timezone)
             tweet.created_at = make_aware(d)


### PR DESCRIPTION
When using MySQL with default UTF-8 collation, tweets containing Emoji or other high-multibyte characters cause this kind of warning messages and corrupted text in the database:

Incorrect string value: '\xF0\x9F\x8C\x82\xF0\x9F...' for column 'text' at row 1

The problem can be solved by switching to utf8mb4, but that causes other problems with index lengths and I couldn't find a way to make Django use it only for a single model. So I added this setting to strip the characters completely when saving new tweets as a quick fix.

Of course, this is not a problem with Mezzanine itself, so I'm not sure if you want this setting. However, it's currently a problem for me as cron keeps sending me these warnings, at least until I can switch to another database.

More info on utf8mb4 here: http://mathiasbynens.be/notes/mysql-utf8mb4
