### PR TITLE
Fixed typo in accounts template

### DIFF
--- a/mezzanine/accounts/templates/accounts/account_login.html
+++ b/mezzanine/accounts/templates/accounts/account_login.html
@@ -8,7 +8,7 @@
 {% else %}
     {{ block.super }}
     {% url "signup" as signup_url %}
-    <p>{% blocktrans with request.GET.next as next %}If you don't have an acount you can <a href="{{ signup_url }}?next={{ next }}">sign up</a> for one now.{% endblocktrans %}</p>
+    <p>{% blocktrans with request.GET.next as next %}If you don't have an account you can <a href="{{ signup_url }}?next={{ next }}">sign up</a> for one now.{% endblocktrans %}</p>
     {% url "mezzanine_password_reset" as password_reset_url %}
     {% url "profile_update" as profile_update_url %}
     {% blocktrans %}<p>You can also <a href="{{ password_reset_url }}?next={{ profile_update_url }}">reset your password</a> if you've forgotten it.</p>{% endblocktrans %}</p>


### PR DESCRIPTION
Fixed the smallest typo possible....

"account" was mispelled as "acount"
