### PR TITLE
Put block tags into all blog templates so they can be overridden.  Closes #443

### DIFF
--- a/mezzanine/blog/templates/blog/blog_post_detail.html
+++ b/mezzanine/blog/templates/blog/blog_post_detail.html
@@ -23,6 +23,7 @@
 
 {% block main %}
 
+{% block blog_post_detail_postedby %}
 <h6>
     {% trans "Posted by" %}:
     {% with blog_post.user as author %}
@@ -30,20 +31,28 @@
     {% endwith %}
     {{ blog_post.publish_date|timesince }} {% trans "ago" %}
 </h6>
+{% endblock %}
+{% block blog_post_detail_commentlink %}
 <p>
     {% if blog_post.allow_comments %}(<a href="#comments">{% spaceless %}
         {% blocktrans count blog_post.comments_count as comments_count %}1 comment{% plural %}{{ comments_count }} comments{% endblocktrans %}
     {% endspaceless %}</a>){% endif %}
 </p>
+{% endblock %}
 
+{% block blog_post_detail_featured_image %}
 {% if blog_post.featured_image %}
 <p><img src="{{ MEDIA_URL }}{% thumbnail blog_post.featured_image 600 0 %}"></p>
 {% endif %}
+{% endblock %}
 
+{% block blog_post_detail_content %}
 {% editable blog_post.content %}
 {{ blog_post.content|richtext_filter|safe }}
 {% endeditable %}
+{% endblock %}
 
+{% block blog_post_detail_keywords %}
 {% keywords_for blog_post as tags %}
 {% if tags %}
 {% spaceless %}
@@ -55,13 +64,17 @@
 </ul>
 {% endspaceless %}
 {% endif %}
+{% endblock %}
 
 {% rating_for blog_post %}
 
+{% block blog_post_detail_sharebuttons %}
 {% set_short_url_for blog_post %}
 <a class="btn small primary share-twitter" target="_blank" href="http://twitter.com/home?status={{ blog_post.short_url|urlencode }}%20{{ blog_post.title|urlencode }}">{% trans "Share on Twitter" %}</a>
 <a class="btn small primary share-facebook" target="_blank" href="http://facebook.com/sharer.php?u={{ request.build_absolute_uri }}&amp;t={{ blog_post.title|urlencode }}">{% trans "Share on Facebook" %}</a>
+{% endblock %}
 
+{% block blog_post_detail_related_posts %}
 {% if blog_post.related_posts.all %}
 <div id="related-posts">
 <h3>{% trans 'Related posts' %}</h3>
@@ -72,7 +85,10 @@
 </ul>
 </div>
 {% endif %}
+{% endblock %}
 
+{% block blog_post_detail_comments %}
 {% if blog_post.allow_comments %}{% comments_for blog_post %}{% endif %}
+{% endblock %}
 
 {% endblock %}

--- a/mezzanine/blog/templates/blog/blog_post_list.html
+++ b/mezzanine/blog/templates/blog/blog_post_list.html
@@ -44,6 +44,7 @@
 {% block main %}
 
 {% if tag or category or year or month or author %}
+    {% block blog_post_list_filterinfo %}
     <p>
     {% if tag %}
         {% trans "Viewing posts tagged" %} {{ tag }}
@@ -56,20 +57,28 @@
         {% trans "Viewing posts by" %}
         {{ author.get_full_name|default:author.username }}
     {% endif %}{% endif %}{% endif %}{% endif %}
+    {% endblock %}
     </p>
 {% else %}
     {% if page %}
+    {% block blog_post_list_pagecontent %}
     {% editable page.richtextpage.content %}
     {{ page.richtextpage.content|safe }}
     {% endeditable %}
+    {% endblock %}
     {% endif %}
 {% endif %}
 
 {% for blog_post in blog_posts.object_list %}
-{% editable blog_post.title blog_post.publish_date %}
+{% block blog_post_list_post_title %}
+{% editable blog_post.title %}
 <h2>
     <a href="{{ blog_post.get_absolute_url }}">{{ blog_post.title }}</a>
 </h2>
+{% endeditable %}
+{% endblock %}
+{% block blog_post_list_post_metainfo %}
+{% editable blog_post.publish_date %}
 <h6>
     {% trans "Posted by" %}:
     {% with blog_post.user as author %}
@@ -84,15 +93,21 @@
     {{ blog_post.publish_date|timesince }} {% trans "ago" %}
 </h6>
 {% endeditable %}
+{% endblock %}
 
 {% if blog_post.featured_image %}
+{% block blog_post_list_post_featured_image %}
 <img class="featured-thumb" src="{{ MEDIA_URL }}{% thumbnail blog_post.featured_image 90 90 %}">
+{% endblock %}
 {% endif %}
 
+{% block blog_post_list_post_content %}
 {% editable blog_post.content %}
 {{ blog_post.description_from_content|safe }}
 {% endeditable %}
+{% endblock %}
 
+{% block blog_post_list_post_links %}
 <p class="blog-list-detail">
     {% if blog_post.keyword_list %}
     {% trans "Tags" %}:
@@ -116,6 +131,7 @@
     </a>
     {% endif %}
 </p>
+{% endblock %}
 {% endfor %}
 
 {% pagination_for blog_posts %}

--- a/mezzanine/blog/templates/blog/includes/filter_panel.html
+++ b/mezzanine/blog/templates/blog/includes/filter_panel.html
@@ -1,5 +1,6 @@
 {% load blog_tags keyword_tags i18n future %}
 
+{% block blog_recent_posts %}
 {% blog_recent_posts 5 as recent_posts %}
 {% if recent_posts %}
 <h3>{% trans "Recent Posts" %}</h3>
@@ -10,7 +11,9 @@
 {% endfor %}
 </ul>
 {% endif %}
+{% endblock %}
 
+{% block blog_months %}
 {% blog_months as months %}
 {% if months %}
 <h3>{% trans "Archive" %}</h3>
@@ -24,7 +27,9 @@
 {% endfor %}
 </ul>
 {% endif %}
+{% endblock %}
 
+{% block blog_categories %}
 {% blog_categories as categories %}
 {% if categories %}
 <h3>{% trans "Categories" %}</h3>
@@ -35,7 +40,9 @@
 {% endfor %}
 </ul>
 {% endif %}
+{% endblock %}
 
+{% block blog_keywords %}
 {% keywords_for blog.blogpost as tags %}
 {% if tags %}
 <h3>{% trans "Tags" %}</h3>
@@ -49,7 +56,9 @@
 {% endfor %}
 </ul>
 {% endif %}
+{% endblock %}
 
+{% block blog_authors %}
 {% blog_authors as authors %}
 {% if authors %}
 <h3>{% trans "Authors" %}</h3>
@@ -61,7 +70,9 @@
 {% endfor %}
 </ul>
 {% endif %}
+{% endblock %}
 
+{% block blog_feeds %}
 <h3>{% trans "Feeds" %}</h3>
 {% if tag %}
     <a href="{% url "blog_post_feed_tag" tag.slug "rss" %}">{% trans "RSS" %}</a> /
@@ -79,3 +90,4 @@
     <a href="{% url "blog_post_feed" "rss" %}">{% trans "RSS" %}</a> /
     <a href="{% url "blog_post_feed" "atom" %}">{% trans "Atom" %}</a>
 {% endif %}
+{% endblock %}


### PR DESCRIPTION
This resulted in the splitting of the editable field for the title and
publication date in the list page into two editable fields, so they
could be two separate blocks.  I notice that the blog detail page
doesn't have an editable field for the publish date at all, which I
shall address separately.

block tags are namespaced by blog_post_detail_ and blog_post_list_
respectively, and inside the list page, the blocks related to an
individual post are namespaced with blog_post_list_post_.
