### PR TITLE
Allow translators to rephrase the 'timesince' string in the blog

### DIFF
--- a/mezzanine/blog/templates/blog/blog_post_detail.html
+++ b/mezzanine/blog/templates/blog/blog_post_detail.html
@@ -30,7 +30,7 @@
     {% with blog_post.user as author %}
     <a href="{% url "blog_post_list_author" author %}">{{ author.get_full_name|default:author.username }}</a>
     {% endwith %}
-    {{ blog_post.publish_date|timesince }} {% trans "ago" %}
+    {% blocktrans with sometime=blog_post.publish_date|timesince %}{{sometime}} ago{% endblocktrans %}
 </h6>
 {% endeditable %}
 {% endblock %}

--- a/mezzanine/blog/templates/blog/blog_post_list.html
+++ b/mezzanine/blog/templates/blog/blog_post_list.html
@@ -90,7 +90,7 @@
     <a href="{% url "blog_post_list_category" category.slug %}">{{ category }}</a>
     {% endfor %}
     {% endif %}
-    {{ blog_post.publish_date|timesince }} {% trans "ago" %}
+    {% blocktrans with sometime=blog_post.publish_date|timesince %}{{sometime}} ago{% endblocktrans %}
 </h6>
 {% endeditable %}
 {% endblock %}


### PR DESCRIPTION
In some languages, the construction of 'timesince' messages varies from English. For example, '10 minutes ago' is 'Hace 10 minutos' in Spanish. Notice how the time part changed positions. I'm updating the templates to use blocktrans which allows translators to rephrase the message as they see fit.
