### PR TITLE
Fixing 'get_absolute_url' for the BlogCategory Model

### DIFF
--- a/mezzanine/blog/models.py
+++ b/mezzanine/blog/models.py
@@ -1,4 +1,3 @@
-
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
@@ -82,4 +81,4 @@ class BlogCategory(Slugged):
 
     @models.permalink
     def get_absolute_url(self):
-        return ("blog_post_list_category", (), {"slug": self.slug})
+        return ("blog_post_list_category", (), {"category": self.slug})


### PR DESCRIPTION
Wrong keyword argument passed to <code>blog_post_list_category</code> in <code>get_absolute_url </code>for the <code>BlogCategory</code> model. This results in an empty url when using 

``` html
<a href="{{ category.get_absolute_url }}">Link to my Category</a>
```

The problem was that the <code>blog/urls.py</code> uses <code>'category'</code> as the keyword and the <code>get_absolute_url</code> used <code>'slug'</code> as the keyword. I changed it within <code>get_absolute_url</code> because changing it within <code>blog/urls.py</code> might break backwards compatibility.
