### PR TITLE
verbose_name & verbose_name_plural inconsistencies

### DIFF
--- a/mezzanine/blog/models.py
+++ b/mezzanine/blog/models.py
@@ -17,7 +17,7 @@ class BlogPost(Displayable, Ownable, RichText, AdminThumbMixin):
     categories = models.ManyToManyField("BlogCategory",
                                         verbose_name=_("Categories"),
                                         blank=True, related_name="blogposts")
-    allow_comments = models.BooleanField(verbose_name=_("Allow comments"),
+    allow_comments = models.BooleanField(verbose_name=_("Allow Comments"),
                                          default=True)
     comments = CommentsField(verbose_name=_("Comments"))
     rating = RatingField(verbose_name=_("Rating"))
@@ -25,13 +25,13 @@ class BlogPost(Displayable, Ownable, RichText, AdminThumbMixin):
                                upload_to="blog", format="Image",
                                max_length=255, null=True, blank=True)
     related_posts = models.ManyToManyField("self",
-                                 verbose_name=_("Related posts"), blank=True)
+                                 verbose_name=_("Related Posts"), blank=True)
 
     admin_thumb_field = "featured_image"
 
     class Meta:
-        verbose_name = _("Blog post")
-        verbose_name_plural = _("Blog posts")
+        verbose_name = _("Blog Post")
+        verbose_name_plural = _("Blog Posts")
         ordering = ("-publish_date",)
 
     @models.permalink

--- a/mezzanine/pages/models.py
+++ b/mezzanine/pages/models.py
@@ -2,7 +2,6 @@ from django.core.urlresolvers import resolve, reverse
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from mezzanine.conf import settings
 from mezzanine.core.models import Displayable, Orderable, RichText
 from mezzanine.pages.fields import MenusField
 from mezzanine.pages.managers import PageManager
@@ -207,13 +206,6 @@ class Page(BasePage):
         # Default branch level - gets assigned in the page_menu tag.
         self.branch_level = 0
 
-    def in_menu_template(self, template_name):
-        if self.in_menus is not None:
-            for i, l, t in settings.PAGE_MENU_TEMPLATES:
-                if not unicode(i) in self.in_menus and t == template_name:
-                    return False
-        return True
-
 
 class RichTextPage(Page, RichText):
     """
@@ -222,8 +214,8 @@ class RichTextPage(Page, RichText):
     """
 
     class Meta:
-        verbose_name = _("Rich text page")
-        verbose_name_plural = _("Rich text pages")
+        verbose_name = _("Rich Text Page")
+        verbose_name_plural = _("Rich Text Pages")
 
 
 class Link(Page):


### PR DESCRIPTION
Trivial change for aesthetic reasons-
There's some visual inconsistencies amongst some of the bundled apps. I made these changes to clean that up a touch and hopefully standardize. All models within the admin interface should now show each descriptive word capitalized. 

It's a petpeeve of mine.
