### PR TITLE
InheritanceManager before SearchableManager

### DIFF
--- a/mezzanine/core/managers.py
+++ b/mezzanine/core/managers.py
@@ -4,6 +4,7 @@ from string import punctuation
 
 from django.db.models import Manager, Q, CharField, TextField, get_models
 from django.db.models.query import QuerySet
+from django.db.models.fields.related import OneToOneField
 from django.contrib.sites.managers import CurrentSiteManager as DjangoCSM
 
 from mezzanine.conf import settings
@@ -35,7 +36,68 @@ class PublishedManager(Manager):
         return self.get(slug=slug)
 
 
-class SearchableQuerySet(QuerySet):
+class InheritanceQuerySet(QuerySet):
+    """
+    QuerySet that supplies select_subclasses() cast filter.
+    https://bitbucket.org/carljm/django-model-utils
+    """
+    def select_subclasses(self, *subclasses):
+        if not subclasses:
+            subclasses = [rel.var_name
+                          for rel in self.model._meta.get_all_related_objects()
+                          if isinstance(rel.field, OneToOneField)
+                          and issubclass(rel.field.model, self.model)]
+        new_qs = self.select_related(*subclasses)
+        new_qs.subclasses = subclasses
+        return new_qs
+
+    def _clone(self, klass=None, setup=False, **kwargs):
+        for name in ['subclasses', '_annotated']:
+            if hasattr(self, name):
+                kwargs[name] = getattr(self, name)
+        return super(InheritanceQuerySet, self)._clone(klass, setup, **kwargs)
+
+    def annotate(self, *args, **kwargs):
+        qset = super(InheritanceQuerySet, self).annotate(*args, **kwargs)
+        qset._annotated = [a.default_alias for a in args] + kwargs.keys()
+        return qset
+
+    def iterator(self):
+        iter = super(InheritanceQuerySet, self).iterator()
+        if getattr(self, 'subclasses', False):
+            for obj in iter:
+                sub_obj = [getattr(obj, s)
+                        for s in self.subclasses if getattr(obj, s)] or [obj]
+                sub_obj = sub_obj[0]
+                if getattr(self, '_annotated', False):
+                    for k in self._annotated:
+                        setattr(sub_obj, k, getattr(obj, k))
+
+                yield sub_obj
+        else:
+            for obj in iter:
+                yield obj
+
+
+class InheritanceManager(Manager):
+    """
+    Manager that allows queries on a base model to return heterogenous
+    results of the actual proper subtypes, without any additional queries
+    https://bitbucket.org/carljm/django-model-utils
+    """
+    use_for_related_fields = True
+
+    def get_query_set(self):
+        return InheritanceQuerySet(self.model)
+
+    def select_subclasses(self, *subclasses):
+        return self.get_query_set().select_subclasses(*subclasses)
+
+    def get_subclass(self, *args, **kwargs):
+        return self.get_query_set().select_subclasses().get(*args, **kwargs)
+
+
+class SearchableQuerySet(InheritanceQuerySet):
     """
     QuerySet providing main search functionality for
     ``SearchableManager``.
@@ -181,7 +243,7 @@ class SearchableQuerySet(QuerySet):
         return results
 
 
-class SearchableManager(Manager):
+class SearchableManager(InheritanceManager):
     """
     Manager providing a chainable queryset.
     Adapted from http://www.djangosnippets.org/snippets/562/


### PR DESCRIPTION
Stephen,

This lets you add select_subclasses() to a filter() on Page or Product (anything that uses the DisplayManager) so you can automatically downcast to the appropriate subclass.  Only works with a single level of hierarchy.  I pulled the code directly from django-model-utils.  Discussion of the overhead (essentially select-related turned on) in the second link.  Requires Django 1.2+.

https://github.com/carljm/django-model-utils#inheritancemanager
http://jeffelmore.org/2010/11/11/automatic-downcasting-of-inherited-models-in-django/

```
>>> from mezzanine.pages.models import Page
>>> Page.objects.filter().select_subclasses()
[<RichTextPage: About>, <RichTextPage: About / Benefits>, <RichTextPage: About / Management>, <RichTextPage: About / Market Studies>, <RichTextPage: About / Motivation>, <RichTextPage: About / What We Do>, <RichTextPage: Account>, <RichTextPage: Account / Dashboard>, <RichTextPage: Account / Orders>, <RichTextPage: Account / Profile>, <Category: Catalog>, <Category: Catalog / Applications>, <Category: Catalog / Expertise>, <Category: Catalog / Platforms>, <Category: Catalog / Services>, <Form: Contact>, <Form: EC2 login credentials>, <RichTextPage: Help>, <RichTextPage: Help / Abaqus Remote Desktop>, <RichTextPage: Help / About the Manifold Flow Predictor>, '...(remaining elements truncated)...']
>>> Page.objects.filter()
[<Page: About>, <Page: About / Benefits>, <Page: About / Management>, <Page: About / Market Studies>, <Page: About / Motivation>, <Page: About / What We Do>, <Page: Account>, <Page: Account / Dashboard>, <Page: Account / Orders>, <Page: Account / Profile>, <Page: Catalog>, <Page: Catalog / Applications>, <Page: Catalog / Expertise>, <Page: Catalog / Platforms>, <Page: Catalog / Services>, <Page: Contact>, <Page: EC2 login credentials>, <Page: Help>, <Page: Help / Abaqus Remote Desktop>, <Page: Help / About the Manifold Flow Predictor>, '...(remaining elements truncated)...']
>>> ^D

```