### PR TITLE
Google Analytics script update

### DIFF
--- a/mezzanine/core/templates/base.html
+++ b/mezzanine/core/templates/base.html
@@ -42,6 +42,8 @@ $(function() {
 
 {% block extra_head %}{% endblock %}
 
+{% google_analytics %}
+
 </head>
 <body id="{% block body_id %}body{% endblock %}">
 

--- a/mezzanine/core/templates/includes/footer_scripts.html
+++ b/mezzanine/core/templates/includes/footer_scripts.html
@@ -2,16 +2,4 @@
 
 {% editable_loader %}
 
-<script>
-{% if settings.GOOGLE_ANALYTICS_ID and not request.user.is_staff %}
-var _gaq = _gaq || [['_trackPageview']];
-_gaq.unshift(['_setAccount', '{{ settings.GOOGLE_ANALYTICS_ID }}']);
-(function(d, t) {
-    var g = d.createElement(t),
-        s = d.getElementsByTagName(t)[0];
-    g.async = true;
-    g.src = '//www.google-analytics.com/ga.js';
-    s.parentNode.insertBefore(g, s);
-})(document, 'script');
-{% endif %}
-</script>
+{# Add your footer scripts here #}

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -211,6 +211,25 @@ def pagination_for(context, current_page):
     return {"current_page": current_page, "querystring": querystring}
 
 
+@register.simple_tag(takes_context=True)
+def google_analytics(context):
+    request = context["request"]
+    script = """<script type='text/javascript'>
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', '%s'
+    _gaq.push(['_trackPageview']);
+    (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
+    </script>"""
+    if not settings.DEBUG and settings.GOOGLE_ANALYTICS_ID and not request.user.is_staff:
+        return script % settings.GOOGLE_ANALYTICS_ID
+    else:
+        return ""
+
+
 @register.simple_tag
 def thumbnail(image_url, width, height, quality=95):
     """


### PR DESCRIPTION
The Google Analytics script has changed. If you use the old one, Google will not be able to identify the site as "yours". Existing sites that used the obsolete script seem to continue working, but new sites won't.

Also, I've moved the Google Analytics script outside footer_scripts.html and into its own template tag. This is because Google Webmaster Tools requires the script to be in the <head>. With the template tag the developer can put it wherever he wants.

Lastly, the script won't be included if DEBUG = True. This is just a safe in case you have defined the Analytics ID in production and copied the DB to development (it happens).
