### PR TITLE
Fix for broken Posterous import

### DIFF
--- a/mezzanine/blog/management/commands/import_posterous.py
+++ b/mezzanine/blog/management/commands/import_posterous.py
@@ -70,10 +70,10 @@ class Command(BaseImporterCommand):
                     "Please pass your blog hostname if you have more than"
                     " one blog on your posterous account."
                 )
-
-        path = 'sites/%s/posts' % site['id']
         page = 1
         while True:
+            path = 'sites/%s/posts' % site['id']
+            time.sleep(2)
             posts = self.request(path, data={'page': page})
             print len(posts)
             if not posts:
@@ -123,4 +123,4 @@ class Command(BaseImporterCommand):
                         body=body
                     )
             page += 1
-            time.sleep(2)
+            


### PR DESCRIPTION
Importing a posterous with comments was broken, the request url path wasn't reset after grabbing a page of comments and so the next trip through the loop would break with a non helpful error message. Also moved sleep to the top of the loop to guarantee it's called before a request as I was running into api limit errors. 
