### PR TITLE
Allows regular link Cmd+Click behaviour on OS X

### DIFF
--- a/mezzanine/core/static/mezzanine/js/admin/navigation.js
+++ b/mezzanine/core/static/mezzanine/js/admin/navigation.js
@@ -54,7 +54,14 @@ $(function() {
 
      // If the primary menu item is clicked, go to the URL for
      // its first child.
-     primaryMenuItems.click(function() {
+     primaryMenuItems.click(function(e) {
+        if (e.isDefaultPrevented() || e.metaKey || e.ctrlKey) {
+            // Don't open the clicked link when Cmd+Click is used on OS X
+            // Regular LMB click pass-through works as intended
+            // #TODO: test on other platforms and browsers
+            return;
+        }
+
         var thisHref = $(this).attr('href');
         if (thisHref && thisHref != '#') {
             return true;
@@ -79,7 +86,12 @@ $(function() {
         $(this).removeClass('dropdown-menu-hover');
     });
 
-    subMenuItems.live('click', function() {
+    subMenuItems.live('click', function(e) {
+        if (e.isDefaultPrevented() || e.metaKey || e.ctrlKey) {
+            // Don't open the clicked link when Cmd+Click is used on OS X
+            return;
+        }
+
         location = $(this).find('a').attr('href');
     });
 


### PR DESCRIPTION
Bug: Admin navigation menu links; minor annoyance.

_Expected behaviour_:
When emulating a middle-click on OS X with Cmd+LMB Click a new tab or window opens in the browser directed to the link's `href`. Current window stays as-is.

_Actual behaviour_:
Current `window.location` is also set to the same destination as the new tab/window.

Notes:
- Regular click behaviour still applies
- Tested to work in OS X Chrome 24 beta and Firefox 16 beta
- Tested to work on Win7 Chrome, Firefox, Opera and IE9

With credit and thanks to "o.v." from StackOverflow; http://stackoverflow.com/a/10808972/
