### PR TITLE
Generate better meta descriptions from markdown content.

### DIFF
--- a/mezzanine/core/models.py
+++ b/mezzanine/core/models.py
@@ -10,7 +10,6 @@ from django.utils.html import strip_tags
 from django.utils.timesince import timesince
 from django.utils.translation import ugettext, ugettext_lazy as _
 
-from mezzanine.core.templatetags.mezzanine_tags import richtext_filter
 from mezzanine.core.fields import RichTextField
 from mezzanine.core.managers import DisplayableManager, CurrentSiteManager
 from mezzanine.generic.fields import KeywordsField
@@ -151,6 +150,8 @@ class MetaData(models.Model):
                         field.name != "description":
                         description = getattr(self, field.name)
                         if description:
+                            from mezzanine.core.templatetags.mezzanine_tags \
+                            import richtext_filter
                             description = richtext_filter(description)
                             break
         # Fall back to the title if description couldn't be determined.


### PR DESCRIPTION
By using the newline character as the first pattern in the generation of the meta description, markdown content (which normally lacks closing `</p>` tags) is processed correctly.

I propose this change because with the previous ordering of patterns, meta descriptions from markdown content end up being the whole content itself.
