### PR TITLE
Escape percents

### DIFF
--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -1,5 +1,6 @@
 
 import os
+import re
 import sys
 from functools import wraps
 from getpass import getpass, getuser


### PR DESCRIPTION
I think this should solve issue #494, although I did also consider that it might be better to just add a couple of lines of documentation at the top of each template file (explaining that any '%' symbols will need to be escaped with '%%').

Not sure what the general consensus is around comments & style, please feel free to make any changes as required.

Also, sorry about the rather messy commit history.
