### PR TITLE
Correct varible name in single model search

### DIFF
--- a/mezzanine/core/templates/includes/search_form.html
+++ b/mezzanine/core/templates/includes/search_form.html
@@ -5,7 +5,7 @@
 
 {% if search_model_choices %}
     {% if search_model_choices|length == 1 %}
-    <input type="hidden" name="type" value="{{ search_models.0.1 }}">
+    <input type="hidden" name="type" value="{{ search_model_choices.0.1 }}">
     {% else %}
     <select name="type">
         <option value="">{% trans "Everything" %}</option>


### PR DESCRIPTION
Hey Steve, I believe there is a slight mistake in the variable name when performing single model searches. In my tests this fixes it.
