### PR TITLE
Inline (front-end) editing: fix edit links that are children of absolutely positioned elements

### DIFF
--- a/mezzanine/core/static/mezzanine/css/editable.css
+++ b/mezzanine/core/static/mezzanine/css/editable.css
@@ -10,11 +10,12 @@ right ahead and fix it.
 /* TOOLBAR */
 
 #editable-toolbar, .editable-highlight, .editable-link {top:0; left:0;
-    z-index:300; display:none; position:absolute;}
-#editable-toolbar {z-index:700;}
+    z-index:300; position:absolute;}
+#editable-toolbar {z-index:700; display:none;}
 #editable-loading {z-index:10000; display:none; position:absolute;}
 #editable-toolbar {position:fixed;}
 .editable-highlight {border:1px solid #ccc;}
+.editable-link {display: block;}
 
 #editable-toolbar, .editable-link {
     background:#fffcc3; float:left; cursor:pointer; padding:4px;

--- a/mezzanine/core/static/mezzanine/js/editable.js
+++ b/mezzanine/core/static/mezzanine/js/editable.js
@@ -41,32 +41,34 @@ jQuery(function($) {
             editable = $(editable);
             // Position the editable area's edit link.
             var link = editable.next('.editable-link');
-            link.css({top: editable.offset().top,
-                left: editable.offset().left - link.width() - 12});
+            link.offset({top: editable.offset().top,
+                left: editable.offset().left - link.outerWidth() - 1});
             // Apply the editable area's overlay handler.
             var expose = {color: '#333', loadSpeed: 200, opacity: 0.9};
-            var overlay = {expose: expose, closeOnClick: true, close: ':button'};
+            var overlay = {expose: expose, closeOnClick: true, close: ':button', left: 'center', top: 'center'};
             link.overlay(overlay);
             // Position the editable area's highlight.
-            link.next('.editable-highlight').css({
-                width: editable.width(), height: editable.height(),
-                top: editable.offset().top, left: editable.offset().left
+            var highlight = link.next('.editable-highlight')
+            highlight.css({
+                width: editable.width(),
+                height: editable.height()
             });
+            highlight.offset({top: editable.offset().top, left: editable.offset().left});
         });
     };
 
-	realign();
+    realign();
 
     // Show/hide the editable area's highlight when mousing over/out the of
     // the edit link.
     $('.editable-link').hover(function(e) {
-    	$(this).next('.editable-highlight').show();
+        $(this).next('.editable-highlight').css('visibility', 'visible');
     }, function(e) {
-    	$(this).next('.editable-highlight').hide();
+        $(this).next('.editable-highlight').css('visibility', 'hidden');
     });
 
     $('body, .editable-original').on('resize', function(e) {
-    	realign();
+        realign();
     });
 
     // Add the toolbar HTML and handlers.
@@ -80,15 +82,17 @@ jQuery(function($) {
     $(window.__toolbar_html).appendTo('body');
     $('#editable-toolbar-toggle').click(function() {
         var toggle = $(this);
-        var controls = $('.editable-link, ' +
-            '#editable-toolbar *[id!=editable-toolbar-toggle]');
+        var links = $('.editable-link');
+        var toolbar = $('#editable-toolbar *[id!=editable-toolbar-toggle]');
         if (toggle.text() == '<<') {
             toggle.text('>>');
-            controls.hide();
+            toolbar.hide();
+            links.css('visibility', 'hidden');
             document.cookie = cookie + '=1; path=/';
         } else {
             toggle.text('<<');
-            controls.show();
+            toolbar.show();
+            links.css('visibility', 'visible');
             document.cookie = cookie + '=; path=/';
         }
         return false;

--- a/mezzanine/core/templates/includes/editable_form.html
+++ b/mezzanine/core/templates/includes/editable_form.html
@@ -21,9 +21,9 @@
 <div class="editable-original">{{ original }}</div>
 
 {# Edit link #}
-<a style="display:none;" class="editable-link" href="#"
+<a style="visibility:hidden;" class="editable-link" href="#"
     rel="#{{ form.uuid }}">{% trans "Edit" %}</a>
 
 {# Edit highlight #}
-<div style="display:none;" class="editable-highlight"></div>
+<div style="visibility:hidden;" class="editable-highlight"></div>
 


### PR DESCRIPTION
The problem is best demonstrated by an example:

``` html
<div>
    <span></span>
</div>
```

``` css
div {
    position: absolute;
    top: 50px;
    left: 50px;
}
span {
    position: absolute;
    top: 100px;
    left: 100px;
}
```

In this case the span will be placed on the page 150px from the top and the left because absolutely positioned elements are positioned relative to their nearest positioned ancestor. However the current code for positioning the "Edit" links (and highlights) gets the original element's offset (position relative to the document) and then sets the edit link's top and left style based on the offset. This works fine unless the original element has a positioned ancestor (quite common actually) in which case it will be wrong.

The fix for this is to set the "Edit" link's offset instead of top/left so that jquery automatically does all the calculations to position it relative to the document.

The one caveat is that jQuery's offset function doesn't work while elements are set to display:none, which is currently what the "Edit" link and highlight are using. To fix this we switch to using visibility:hidden instead, which does work.

Let me know if you have any questions/concerns. I've tested this is Webkit, Firefox, and IE7+. Hope this is useful!
