### PR TITLE
Remove Nimbis Services link for now

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -297,7 +297,6 @@ Sites Using Mezzanine
   * `Enrico Tröger <http://www.uvena.de>`_
   * `Matthe Wahn <http://www.matthewahn.com>`_
   * `Bit of Pixels <http://bitofpixels.com>`_
-  * `Nimbis Services <http://schott.nimbis.net>`_
   * `European Crystallographic Meeting <http://ecm29.ecanews.org>`_
   * `Dreamperium <http://dreamperium.com>`_
   * `UT Dallas <http://utdallasiia.com>`_


### PR DESCRIPTION
We haven't deployed our Mezzanine-based Nimbis Services site into production yet (the old link was to a testing site that is only used internally).

We'll add this back in once we go live with our Mezzanine site.
