### PR TITLE
Fix parent of Team and History pages in fixtures

### DIFF
--- a/mezzanine/pages/fixtures/mezzanine_optional.json
+++ b/mezzanine/pages/fixtures/mezzanine_optional.json
@@ -38,7 +38,7 @@
         "fields": {
             "status": 2,
             "_order": 0,
-            "parent": 1,
+            "parent": 2,
             "description": "Team",
             "title": "Team",
             "titles": "About / Team",
@@ -54,7 +54,7 @@
         "fields": {
             "status": 2,
             "_order": 1,
-            "parent": 1,
+            "parent": 2,
             "description": "History",
             "title": "History",
             "titles": "About / History",


### PR DESCRIPTION
Assign the Team and History pages to the About page (id 2) instead of the Blog page (id 1) in Page fixtures.
