### PR TITLE
Check has_home to avoid duplicates.

### DIFF
--- a/mezzanine/pages/templates/pages/menus/footer_tree.html
+++ b/mezzanine/pages/templates/pages/menus/footer_tree.html
@@ -5,7 +5,7 @@
 <ul class="footer-tree-menu-level-{{ branch_level }}">
 	{% for page in page_branch %}
 
-    {% if page.is_primary and forloop.first %}
+    {% if not has_home and page.is_primary and forloop.first %}
 	<li class="first{% if on_home %} active{% endif %}"
         id="footer-tree-menu-home">
 	    <a href="{% url "home" %}">{% trans "Home" %}</a>


### PR DESCRIPTION
Updated footer_tree.html to behave the same as the other menu templates, checking has_home so that a page that is also the home doesn't end up in the menus twice.
