### PR TITLE
Precedence of conflicting page processor context

### DIFF
--- a/mezzanine/pages/middleware.py
+++ b/mezzanine/pages/middleware.py
@@ -86,7 +86,9 @@ class PageMiddleware(object):
                 return processor_response
             elif processor_response:
                 try:
-                    response.context_data.update(processor_response)
+                    new_items = {k: v for k, v in processor_response.items()
+                                 if k not in response.context_data}
+                    response.context_data.update(new_items)
                 except (TypeError, ValueError):
                     name = "%s.%s" % (processor.__module__, processor.__name__)
                     error = ("The page processor %s returned %s but must "


### PR DESCRIPTION
The order of execution of page processors was reversed in #315 so that custom page processors returning an HttpResponse would bypass the default processors.

That had the side-effect of making context variables in default processors overwrite those in custom processors, which isn't very intuitive. This change restores the original behaviour of context variables, while retaining the reversed execution order.
