### PR TITLE
Encode comment text to UTF-8 before sending to Akismet

### DIFF
--- a/mezzanine/utils/views.py
+++ b/mezzanine/utils/views.py
@@ -79,7 +79,11 @@ def is_spam_akismet(request, form, url):
         elif isinstance(field.widget, Textarea):
             data_field = "comment"
         if data_field and not data.get(data_field):
-            data[data_field] = form.cleaned_data.get(name)
+            cleaned_data = form.cleaned_data.get(name)
+            try:
+                data[data_field] = cleaned_data.encode('utf-8')
+            except UnicodeEncodeError:
+                data[data_field] = cleaned_data
     if not data.get("comment"):
         return False
     api_url = ("http://%s.rest.akismet.com/1.1/comment-check" %


### PR DESCRIPTION
If any non-ASCII text is submitted in the form, urlencode() would encode the string implicitly to ASCII
which fails if there are non-ASCII characters in the string. And since just "Exception" is caught and
ignored silently, those submits would never passed to Akismet and so not detected as spam.
If the encoding to UTF-8 fails, we still try to pass it as is to Akismet, like before.
