### PR TITLE
Fix page browsing in multilingual setups

### DIFF
--- a/mezzanine/utils/urls.py
+++ b/mezzanine/utils/urls.py
@@ -6,6 +6,7 @@ from django.core.urlresolvers import resolve, reverse, NoReverseMatch, \
     get_script_prefix
 from django.shortcuts import redirect
 from django.utils.encoding import smart_unicode
+from django.utils import translation
 
 from mezzanine.conf import settings
 from mezzanine.utils.importing import import_dotted_path
@@ -86,10 +87,17 @@ def login_redirect(request):
 def path_to_slug(path):
     """
     Removes everything from the given URL path, including
-    ``PAGES_SLUG`` if it is set, returning a slug that would match a
-    ``Page`` instance's slug.
+    language code and ``PAGES_SLUG`` if any is set, returning
+    a slug that would match a ``Page`` instance's slug.
     """
     from mezzanine.urls import PAGES_SLUG
-    for prefix in (settings.SITE_PREFIX, PAGES_SLUG):
-        path = path.strip("/").replace(prefix, "", 1)
-    return path or "/"
+
+    # If i18n is disabled Django uses a fake translation object,
+    # returning None for every path.
+    lang_code = translation.get_language_from_path(path)
+
+    for prefix in (lang_code, settings.SITE_PREFIX, PAGES_SLUG):
+        if prefix:
+            path = path.replace(prefix, "", 1)
+
+    return path.strip("/") or "/"


### PR DESCRIPTION
Pages are not found when using `i18n_patterns`.  Reproducing requires setting up a multilingual project:
-- create a new Mezzanine project, run `createdb`;
-- add some `LANGUAGES` and toggle `USE_I18N` in settings;
-- add `LocaleMiddleware` where it should be;
-- replace `patterns` with `i18n_patterns` in url configuration.
(Documentation: [languages and middleware](https://docs.djangoproject.com/en/dev/topics/i18n/translation/#how-django-discovers-language-preference) and [i18n_patterns](https://docs.djangoproject.com/en/dev/topics/i18n/translation/#internationalization-in-url-patterns), and here's a [diff with all the needed changes](https://gist.github.com/4701985)).

Then run the server and click on say the about page link (`en/about`) or just run core tests. Pages are not found, because the middleware tries to lookup slugs without stripping the language prefix from the path first.
