### PR TITLE
Alter fabfile.py to allow git repo_url to point to a ssh hosted git repository

### DIFF
--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -363,7 +363,7 @@ def create():
                 return False
             remove()
         run("virtualenv %s --distribute" % env.proj_name)
-	git = env.repo_url.startswith("git") or env.repo_url.endswith(".git")
+        git = env.repo_url.startswith("git") or env.repo_url.endswith(".git")
         vcs = "git" if git else "hg"
         run("%s clone %s %s" % (vcs, env.repo_url, env.proj_path))
 
@@ -503,7 +503,8 @@ def rollback():
     """
     with project():
         with update_changed_requirements():
-            git = env.repo_url.startswith("git") or env.repo_url.endswith(".git")
+            git = (env.repo_url.startswith("git") or
+                env.repo_url.endswith(".git"))
             update = "git checkout" if git else "hg up -C"
             run("%s `cat last.commit`" % update)
         with cd(os.path.join(static(), "..")):


### PR DESCRIPTION
I made a small change to the repo_url checks in the fabfile.py file regarding git. I am not running the git daemon on my production server but I can access my repository via ssh. By default, the fabfile checks if the repo_url starts with git in order to verify that the url points to a git repository. That check would work for people running the git daemon on their server or for people who host their repository on github. However, access a git repository hosted via ssh will not work using the default check.

I made a small change to also check if the repo_url ends with .git. This change has allowed me to access a private repository that is accessible via ssh
