### PR TITLE
Don't try to create any pages if the models it uses aren't installed

### DIFF
--- a/mezzanine/core/management/__init__.py
+++ b/mezzanine/core/management/__init__.py
@@ -30,6 +30,12 @@ def create_user(app, created_models, verbosity, interactive, **kwargs):
 
 
 def create_pages(app, created_models, verbosity, interactive, **kwargs):
+    if not all([
+        'mezzanine.forms' in settings.INSTALLED_APPS,
+        'mezzanine.galleries' in settings.INSTALLED_APPS,
+        'mezzanine.blog' in settings.INSTALLED_APPS]):
+        return
+
     from mezzanine.forms.models import Form
     from mezzanine.galleries.models import Gallery
 


### PR DESCRIPTION
I use mezzanine without the blog, form, or galleries app, and this `create_pages` throws errors if they aren't installed. This patch skips the creation of pages if those apps aren't installed.
