### PR TITLE
"Go" string context

### DIFF
--- a/mezzanine/core/templates/includes/search_form.html
+++ b/mezzanine/core/templates/includes/search_form.html
@@ -15,7 +15,7 @@
             {{ verbose_name }}
         </option>
         {% endfor %}
-        <input type="submit" class="btn" value="{% trans "Go" %}">
+        <input type="submit" class="btn" value="{% trans "Go" context "Search" %}">
     </select>
     {% endif %}
 {% endif %}


### PR DESCRIPTION
There are two "Go" strings marked for translation used with different meanings. One is displayed on the action button over change lists in admin, so it stands for "Execute the action", while the other is a label for the search form button meaning "Search and display results". In English you may use one word for both, but not in some other languages.

Note: template contexts were introduced in Django 1.4.
