### PR TITLE
Use current_page instead of request for is_current

### DIFF
--- a/mezzanine/pages/models.py
+++ b/mezzanine/pages/models.py
@@ -6,7 +6,7 @@ from mezzanine.conf import settings
 from mezzanine.core.models import Displayable, Orderable, RichText
 from mezzanine.pages.fields import MenusField
 from mezzanine.pages.managers import PageManager
-from mezzanine.utils.urls import path_to_slug, slugify
+from mezzanine.utils.urls import slugify
 
 
 class BasePage(Orderable, Displayable):


### PR DESCRIPTION
Since we already have the 'current page' object, we can compare it
against ourself to find if we are current.

This means that `set_helpers` is independent of a request, so it can be used to render navigation for a page on a different URL.
