### PR TITLE
Use content_model not the base Page in PageAdmin

### DIFF
--- a/mezzanine/pages/admin.py
+++ b/mezzanine/pages/admin.py
@@ -112,8 +112,8 @@ class PageAdmin(DisplayableAdmin):
                                        content_model.id)
                 return HttpResponseRedirect(change_url)
         extra_context = extra_context or {}
-        extra_context["hide_delete_link"] = not page.can_delete(request)
-        extra_context["hide_slug_field"] = page.overridden()
+        extra_context["hide_delete_link"] = not content_model.can_delete(request)
+        extra_context["hide_slug_field"] = content_model.overridden()
         return super(PageAdmin, self).change_view(request, object_id,
                                                   extra_context=extra_context)
 


### PR DESCRIPTION
When calling methods on a page, they should be called on the subclass,
not the base Page. This allows page types to override them.
