### PR TITLE
Use CSS instead of JavaScript for the admin app dropdowns

### DIFF
--- a/mezzanine/core/static/mezzanine/css/admin/global.css
+++ b/mezzanine/core/static/mezzanine/css/admin/global.css
@@ -15,23 +15,41 @@ label.interface {display:inline !important; float:none !important;
     width:100%;
 }
 .dropdown-menu {left:0; padding:0; display:block;}
-.dropdown-menu ul {display:inline; padding:0; margin:0;}
+.dropdown-menu ul {display:inline-block; padding:0; margin:0;}
 .dropdown-menu li {
-    float:left; width:auto; padding:7px 23px 7px 0; cursor:pointer;
+    float:left; width:auto; padding:7px 23px 2px 0; cursor:pointer;
     font-size:15px; font-weight:bold; list-style-type:none;
 }
-.cloned {margin:5px 0 0 -20px;}
-.cloned li {display:block; font-size:13px; font-weight:normal;
-            padding:15px 25px 15px 20px !important;
-            border-top:1px solid #eee;}
-.cloned .first {border-top:0px !important;}
-.dropdown-menu li ul {display:none; float:left;}
-.cloned {
-    background:#e6e6e6; border-radius:0 0 5px 5px; padding:0;
-    border-bottom:1px solid #ccc;
+.dropdown-menu li ul {
+    background: #e6e6e6;
+    border-bottom: 1px solid #ccc;
+    border-radius: 0 0 5px 5px;
+    display: none;
+    margin: 0 0 0 -20px;
+    padding: 0;
 }
-.dropdown-menu-hover {cursor:pointer;}
-.dropdown-menu-hover a {color:#444;}
+.dropdown-menu li ul li {
+    border-top: 1px solid #eee;
+    display: block;
+    float: none;
+    font-size: 13px;
+    font-weight: normal;
+    padding: 0;
+}
+.dropdown-menu li ul li a {
+    display: block;
+    padding: 15px 25px 15px 20px;
+}
+.dropdown-menu li ul li.first {
+    border-top: 0px;
+}
+.dropdown-menu li ul li.first a {
+    padding-top: 20px;
+}
+.dropdown-menu li:hover ul {
+    display: block;
+    position: absolute;
+}
 
 .dropdown-menu form {float:right; margin:3px 22px 0 0;}
 #djDebugToolbarHandle {margin-top:50px !important;}

--- a/mezzanine/core/static/mezzanine/js/admin/navigation.js
+++ b/mezzanine/core/static/mezzanine/js/admin/navigation.js
@@ -1,103 +1,19 @@
-
-// Global flag used for checking whether to hide the visible menu
-// after a small timeout has passed when mousing out from a menu.
-var onMenu;
-
 $(function() {
-
     // Empty out the breadcrumbs div and add the menu into it.
     $('.breadcrumbs').html('')
                      .append($('.dropdown-menu').show())
                      .css({display: 'inline-block'});
 
-    var primaryMenuItems = $('.dropdown-menu a');
-
-    primaryMenuItems.mouseover(function() {
-        var menu = $(this).parent().find('.dropdown-menu-menu').clone();
-        // If we're over a primary menu link, clone the child menu and
-        // show it.
-        if (menu.length == 1) {
-            onMenu = true;
-            $('.cloned').remove();
-            $('body').append(menu);
-            // Position the child menu under its parent.
-            var pos = {
-                top: $(this).offset().top + $(this).height(),
-                left: $(this).offset().left,
-                position: 'absolute'
-            }
-            menu.css(pos).addClass('cloned').show();
-            // Ensure the menu stays visible when we mouse onto
-            // another item in it.
-            menu.mouseover(function() {
-                onMenu = true;
-            });
-            // Trigger the parent mouseout if we mouseout of the menu.
-            menu.mouseout(function() {
-                $('.dropdown-menu a').mouseout();
-            });
-        }
-    });
-
-    // Set a timeout to hide visible menus on mouseout of primary
-    // menu item.
-    primaryMenuItems.mouseout(function() {
-        if ($(this).parent().find('.dropdown-menu-menu').length == 1) {
-            onMenu = false;
-            window.setTimeout(function() {
-                if (!onMenu) {
-                    $('.cloned').remove();
-                }
-            }, 1000);
-        }
-    });
-
-     // If the primary menu item is clicked, go to the URL for
-     // its first child.
-     primaryMenuItems.click(function(e) {
-        if (e.isDefaultPrevented() || e.metaKey || e.ctrlKey) {
-            // Don't open the clicked link when Cmd+Click is used on OS X
-            // Regular LMB click pass-through works as intended
-            // #TODO: test on other platforms and browsers
-            return;
-        }
-
-        var thisHref = $(this).attr('href');
-        if (thisHref && thisHref != '#') {
-            return true;
-        }
-        var first = $(this).parent().find('.dropdown-menu-menu a:first');
-        var firstHref = first.attr('href');
-        if (firstHref) {
-            location = firstHref;
-        }
-        return false;
-    });
-
-    // Give the drop-down menu items elements the same hover
-    // state and click event as their anchors.
-    var subMenuItems = $('.dropdown-menu-menu li');
-
-    subMenuItems.live('mouseover', function() {
-        $(this).addClass('dropdown-menu-hover');
-    });
-
-    subMenuItems.live('mouseout', function() {
-        $(this).removeClass('dropdown-menu-hover');
-    });
-
-    subMenuItems.live('click', function(e) {
-        if (e.isDefaultPrevented() || e.metaKey || e.ctrlKey) {
-            // Don't open the clicked link when Cmd+Click is used on OS X
-            return;
-        }
-
-        location = $(this).find('a').attr('href');
+    // Set the hrefs for the primary menu items to the href of their first
+    // child (unless the primary menu item already has an href).
+    $('.dropdown-menu a').each(function() {
+       if ( $(this).attr('href') == '#' ) {
+         $(this).attr('href', $(this).parent().find('.dropdown-menu-menu a:first').attr('href'));
+       }
     });
 
     // Provides link to site.
     $('#user-tools li:last').before('<li>' + window.__home_link + '</li>');
-
 });
 
 // Remove extraneous ``template`` forms from inline formsets since


### PR DESCRIPTION
There were some bugs with the dropdowns when they were in JavaScript:
1.  When you open a dropdown and then scroll, the dropdown would stay put, instead of following the scroll.
2.  The JavaScript used `.live('mouseover')` which binds to body and wastes memory because it's fired for mouseover on every single DOM element.
3.  Occasionally, the dropdowns never disappeared even after mouseout.

This commit fixes those bugs by using CSS and `:hover` instead of JavaScript.  Additionally, it simplifies the JavaScript related to setting the href of the primary menu item links to their first child.

It is a pixel for pixel match of the previous functionality and appearance. Some of the CSS could be removed if the design doesn't need to exactly match the old version.

I tested in Chrome and Firefox. I didn't test IE, but [IE >= 7 supports `:hover`](http://quirksmode.org/css/selectors/#t41) so I don't anticipate any problems.
