### PR TITLE
Don't show site selection form when there's only one site

### DIFF
--- a/mezzanine/core/templates/admin/includes/dropdown_menu.html
+++ b/mezzanine/core/templates/admin/includes/dropdown_menu.html
@@ -16,7 +16,7 @@
     </li>
     {% endfor %}
 </ul>
-{% if dropdown_menu_sites %}
+{% if dropdown_menu_sites and dropdown_menu_sites|length > 1 %}
 <form action="{% url "set_site" %}">
 <input type="hidden" name="next" value="{{ request.path }}">
 <select name="site_id" onchange="this.form.submit();">


### PR DESCRIPTION
If there's only a single site, there's no need to show this form, because it can't do anything.
