### PR TITLE
import_posterous raising error when valid host set

### DIFF
--- a/mezzanine/blog/management/commands/import_posterous.py
+++ b/mezzanine/blog/management/commands/import_posterous.py
@@ -61,6 +61,7 @@ class Command(BaseImporterCommand):
         site = None
         for s in sites:
             if s['full_hostname'] == hostname:
+                site = s
                 time.sleep(2)
                 break
         if not hostname and not site:


### PR DESCRIPTION
NoneType not subscriptable error raised when the --posterous-host option is set. It looks like it was only an issue when you assign a hostname, which you have to do when you have multiple blogs on your posterous account (it fails with an appropriate error message if you don't set a --posterous-host when multiple blogs are on the account).

From looking at code, I see site was never assigned when a hostname was set. Added assignment and I have now successfully imported my posterous blog.

I don't have any context for the time.sleep(2), I assume it's just to make sure request to posterous API don't hit a rate limit but I don't think it's really necessary at that early stage (immediately after new line). Left it in until I have more context.
