### PR TITLE
Minor fix for SSL in disqus comments template

### DIFF
--- a/mezzanine/generic/templates/generic/includes/disqus_comments.html
+++ b/mezzanine/generic/templates/generic/includes/disqus_comments.html
@@ -9,7 +9,7 @@
     var disqus_identifier = '{% disqus_id_for object_for_comments %}';
   (function() {
    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-   dsq.src = 'http://{{ settings.COMMENTS_DISQUS_SHORTNAME }}.disqus.com/embed.js';
+   dsq.src = 'http{% if request.is_secure %}s{% endif %}://{{ settings.COMMENTS_DISQUS_SHORTNAME }}.disqus.com/embed.js';
    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
   })();
 </script>


### PR DESCRIPTION
...SSL. Comments do not appear if the site is running on SSL and js link is http.
