### PR TITLE
This fixes the issue when deploying for the first time using the fabfile.py provided in the template

### DIFF
--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -479,7 +479,9 @@ def deploy():
         upload_template_and_reload(name)
     with project():
         backup("last.db")
-        run("tar -cf last.tar %s" % static())
+        static_dir = static()
+        if exists(static_dir):
+            run("tar -cf last.tar %s" % static_dir)
         git = env.git
         last_commit = "git rev-parse HEAD" if git else "hg id -i"
         run("%s > last.commit" % last_commit)


### PR DESCRIPTION
Instead of trying to tar the static directory (which
fails when the dir does not exist), we create it when
is missing.
