### PR TITLE
The db_type field must take a second 'connection' argument, even though ...

### DIFF
--- a/mezzanine/generic/fields.py
+++ b/mezzanine/generic/fields.py
@@ -39,7 +39,7 @@ class BaseGenericRelation(GenericRelation):
             kwargs.setdefault("to", to)
         super(BaseGenericRelation, self).__init__(*args, **kwargs)
 
-    def db_type(self):
+    def db_type(self, connection):
         """
         South expects this to return a string for initial migrations
         against MySQL, to check for text or geometery columns. These


### PR DESCRIPTION
...unused, otherwise one gets an 'unexpected keyword argument connection' TypeError
