### PR TITLE
Bugfix: static_proxy view doesn't work with generic-protocol hostnames for STATIC_URL

### DIFF
--- a/mezzanine/core/views.py
+++ b/mezzanine/core/views.py
@@ -1,4 +1,3 @@
-
 import os
 from urlparse import urljoin, urlparse
 
@@ -135,7 +134,8 @@ def static_proxy(request):
     url = request.GET["u"]
     protocol = "http" if not request.is_secure() else "https"
     host = protocol + "://" + request.get_host()
-    for prefix in (host, settings.STATIC_URL):
+    generic_host = "//" + request.get_host()
+    for prefix in (host, generic_host, settings.STATIC_URL):
         if url.startswith(prefix):
             url = url.replace(prefix, "", 1)
     response = ""


### PR DESCRIPTION
STATIC_URL = '//mybucket.s3.amazonaws.com' (which lets static URLs work on HTTP and HTTPS) would break the static_proxy prefix stripper, and therefore break tinyMCE plugins. This fix adds proper handling of generic-protocol hostnames to the static_proxy view.
