### PR TITLE
Added INLINE_EDITING_ENABLED setting

### DIFF
--- a/docs/inline-editing.rst
+++ b/docs/inline-editing.rst
@@ -11,6 +11,9 @@ found next to each piece of editable content, such as a page's title or a
 blog post's body. Clicking on the Edit icon will allow the author to update
 the individual piece of content without leaving the page.
 
+In-line editing can be disabled by setting ``INLINE_EDITING_ENABLED`` to
+``False``.
+
 Template Configuration
 ======================
 

--- a/mezzanine/core/defaults.py
+++ b/mezzanine/core/defaults.py
@@ -157,6 +157,13 @@ register_setting(
 )
 
 register_setting(
+    name="INLINE_EDITING_ENABLED",
+    editable=True,
+    description=_("If ``True``, frontend inline editing will be enabled."),
+    default=True,
+)
+
+register_setting(
     name="HOST_THEMES",
     description=_("A sequence mapping host names to themes, allowing "
                   "different templates to be served per HTTP hosts "

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -349,7 +349,7 @@ def editable_loader(context):
     """
     user = context["request"].user
     context["has_site_permission"] = has_site_permission(user)
-    if context["has_site_permission"]:
+    if settings.INLINE_EDITING_ENABLED and context["has_site_permission"]:
         t = get_template("includes/editable_toolbar.html")
         context["REDIRECT_FIELD_NAME"] = REDIRECT_FIELD_NAME
         context["toolbar"] = t.render(Context(context))
@@ -394,7 +394,8 @@ def editable(parsed, context, token):
             parsed = "".join([unicode(getattr(*field)) for field in fields])
         except AttributeError:
             pass
-    if fields and "request" in context:
+
+    if settings.INLINE_EDITING_ENABLED and fields and "request" in context:
         obj = fields[0][0]
         if isinstance(obj, Model) and is_editable(obj, context["request"]):
             field_names = ",".join([f[1] for f in fields])


### PR DESCRIPTION
Hi Stephen. The frontend editor is great, but sometimes gets in the way of specific/odd JS or CSS or can be confusing for some users. I saw there was some interest in being able to disable it easily, so I wrote up this patch. I think I covered everything, except for generating the new settings docs as I'm not sure about your process for that. Let me know if there's anything else it needs.

Thanks,
Jeff
