### PR TITLE
Fix age display: use a blocktrans instead of {% trans 'ago' %}

### DIFF
--- a/mezzanine/generic/templates/admin/includes/recent_comments.html
+++ b/mezzanine/generic/templates/admin/includes/recent_comments.html
@@ -19,7 +19,7 @@
                 </a>
                 &middot;
                 <a href="{{ comment.get_absolute_url }}">
-                    {{ comment.submit_date|timesince }} {% trans "ago" %}
+                    {% blocktrans with sometime=comment.submit_date|timesince %}{{ sometime }} ago{% endblocktrans %}
                 </a>
             </p>
         </li>

--- a/mezzanine/generic/templates/generic/includes/comment.html
+++ b/mezzanine/generic/templates/generic/includes/comment.html
@@ -19,7 +19,7 @@
             {{ comment.user_name }}
             {% endif %}
         </strong>
-        <span class="timespan">{{ comment.submit_date|timesince }} {% trans "ago" %}</span>
+        <span class="timespan">{% blocktrans with sometime=comment.submit_date|timesince %}{{ sometime }} ago{% endblocktrans %}</span>
         <p>{{ comment.comment|comment_filter }}</p>
 
         <a href="{{ request.path }}#comment-{{ comment.id }}">{% trans "Link" %}</a> /
@@ -50,7 +50,7 @@
             {{ comment.user_name }}
             {% endif %}
         </strong>
-        <span class="timespan">{{ comment.submit_date|timesince }} {% trans "ago" %}</span>
+        <span class="timespan">{% blocktrans with sometime=comment.submit_date|timesince %}{{ sometime }} ago{% endblocktrans %}</span>
         <p>{{ comment.comment|comment_filter }}</p>
         {% endif %}
 
@@ -60,7 +60,7 @@
             {% else %}
             {% trans "Comment awaiting approval" %}
             {% endif %}
-            <span class="timespan">{{ comment.submit_date|timesince }} {% trans "ago" %}</span>
+            <span class="timespan">{% blocktrans with sometime=comment.submit_date|timesince %}{{ sometime }} ago{% endblocktrans %}</span>
         </p>
 
         {% endif %}

--- a/mezzanine/mobile/templates/mobile/blog/blog_post_detail.html
+++ b/mezzanine/mobile/templates/mobile/blog/blog_post_detail.html
@@ -27,7 +27,7 @@
                 >{{ author.get_full_name|default:author.username }}</a>
             {% endwith %}
         </strong>
-        {{ blog_post.publish_date|timesince }} {% trans "ago" %}
+        {% blocktrans with sometime=blog_post.publish_date|timesince %}{{ sometime }} ago{% endblocktrans %}
     </em>
 </p>
 

--- a/mezzanine/mobile/templates/mobile/blog/blog_post_list.html
+++ b/mezzanine/mobile/templates/mobile/blog/blog_post_list.html
@@ -25,7 +25,7 @@
 		<li>
         {% editable blog_post.title blog_post.publish_date %}
         <h2 class="blog-post-title"><a href="{% url "blog_post_detail" blog_post.slug %}">{{ blog_post.title }}</a></h2>
-        <em class="since">{{ blog_post.publish_date|timesince }} {% trans "ago" %}</em>
+        <em class="since">{% blocktrans with sometime=blog_post.publish_date|timesince %}{{ sometime }} ago{% endblocktrans %}</em>
         {% endeditable %}
         </li>
     {% endfor %}

--- a/mezzanine/twitter/templates/twitter/tweets.html
+++ b/mezzanine/twitter/templates/twitter/tweets.html
@@ -17,7 +17,7 @@
         <a href="http://twitter.com/{{ tweet.retweeter_user_name }}">@{{ tweet.retweeter_full_name }}</a></p>
         {% endif %}
         <div>{{ tweet.text|safe }}</div>
-        <span class="timespan">{{ tweet.created_at|timesince }} {% trans "ago" %}</span>
+        <span class="timespan">{% blocktrans with sometime=tweet.created_at|timesince %}{{ sometime }} ago{% endblocktrans %}</span>
     </li>
     {% endfor %}
 </ul>


### PR DESCRIPTION
In some languages, like french "ago" is a preposition, so doing
something like "{{ value }} {% trans 'ago' %}" will not work, we have to
use a blocktrans.
