### PR TITLE
Correction in approved account email

### DIFF
--- a/mezzanine/accounts/templates/email/account_approved.html
+++ b/mezzanine/accounts/templates/email/account_approved.html
@@ -2,5 +2,5 @@
 {% block main %}
 <p>{% trans "Hey there, your account has been activated." %}</p>
 <p>{% trans "Please use the link below to log in." %}</p>
-<p><a href="http://{{ request.get_host }}{% url "login" %}">http://http://{{ request.get_host }}{% url "login" %}</a></p>
+<p><a href="http://{{ request.get_host }}{% url "login" %}">http://{{ request.get_host }}{% url "login" %}</a></p>
 {% endblock %}


### PR DESCRIPTION
Was two times "http://" in the account_approved.html email templates in accounts app.
Seems like a typo, link was not working properly in the sent email.
