### PR TITLE
Fix for non-ssl browsing in nginx.

### DIFF
--- a/mezzanine/project_template/deploy/nginx.conf
+++ b/mezzanine/project_template/deploy/nginx.conf
@@ -4,14 +4,12 @@ upstream %(proj_name)s {
 }
 
 server {
-
     listen 80;
-    listen 443;
+    listen 443 default ssl;
     server_name %(live_host)s;
     client_max_body_size 10M;
     keepalive_timeout    15;
 
-    ssl                  on;
     ssl_certificate      conf/%(proj_name)s.crt;
     ssl_certificate_key  conf/%(proj_name)s.key;
     ssl_session_cache    shared:SSL:10m;


### PR DESCRIPTION
Not sure how backwards compatible this is.
Please see: http://stackoverflow.com/questions/8768946/dealing-with-nginx-400-the-plain-http-request-was-sent-to-https-port-error
