### PR TITLE
Fixed the auto-escaping of label_tag using mark_safe

### DIFF
--- a/mezzanine/accounts/forms.py
+++ b/mezzanine/accounts/forms.py
@@ -3,6 +3,7 @@ from django.contrib.auth import authenticate
 from django.db.models import Q
 from django import forms
 from django.utils.translation import ugettext_lazy as _
+from django.utils.safestring import mark_safe
 
 from mezzanine.accounts import get_profile_model, get_profile_user_fieldname
 from mezzanine.conf import settings
@@ -26,9 +27,9 @@ if Profile is not None:
 
 if settings.ACCOUNTS_NO_USERNAME:
     _exclude_fields += ("username",)
-    username_label = _("Email address")
+    username_label = mark_safe(_("Email address"))
 else:
-    username_label = _("Username or email address")
+    username_label = mark_safe(_("Username or email address"))
 
 
 class LoginForm(Html5Mixin, forms.Form):
@@ -36,7 +37,7 @@ class LoginForm(Html5Mixin, forms.Form):
     Fields for login.
     """
     username = forms.CharField(label=username_label)
-    password = forms.CharField(label=_("Password"),
+    password = forms.CharField(label=mark_safe(_("Password")),
                                widget=forms.PasswordInput(render_value=False))
 
     def clean(self):
@@ -68,9 +69,9 @@ class ProfileForm(Html5Mixin, forms.ModelForm):
     fields are injected into the form.
     """
 
-    password1 = forms.CharField(label=_("Password"),
+    password1 = forms.CharField(label=mark_safe(_("Password")),
                                 widget=forms.PasswordInput(render_value=False))
-    password2 = forms.CharField(label=_("Password (again)"),
+    password2 = forms.CharField(label=mark_safe(_("Password (again)")),
                                 widget=forms.PasswordInput(render_value=False))
 
     class Meta:

--- a/mezzanine/core/forms.py
+++ b/mezzanine/core/forms.py
@@ -81,7 +81,8 @@ class DynamicInlineAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(DynamicInlineAdminForm, self).__init__(*args, **kwargs)
         if issubclass(self._meta.model, Orderable):
-            self.fields["_order"] = forms.CharField(label=_("Order"),
+            self.fields["_order"] = forms.CharField(
+                label=mark_safe(_("Order")),
                 widget=OrderWidget, required=False)
 
 

--- a/mezzanine/forms/forms.py
+++ b/mezzanine/forms/forms.py
@@ -287,7 +287,8 @@ class EntriesForm(forms.Form):
                 self.fields["%s_from" % field_key] = forms.DateField(
                     label=" ", widget=SelectDateWidget(), required=False)
                 self.fields["%s_to" % field_key] = forms.DateField(
-                    label=_("and"), widget=SelectDateWidget(), required=False)
+                    label=mark_safe(_("and")), widget=SelectDateWidget(),
+                    required=False)
             else:
                 # Text box for search term to filter by.
                 contains_field = forms.CharField(label=" ", required=False)
@@ -302,7 +303,8 @@ class EntriesForm(forms.Form):
         self.fields["%s_from" % field_key] = forms.DateField(
             label=" ", widget=SelectDateWidget(), required=False)
         self.fields["%s_to" % field_key] = forms.DateField(
-            label=_("and"), widget=SelectDateWidget(), required=False)
+            label=mark_safe(_("and")), widget=SelectDateWidget(),
+            required=False)
 
     def __iter__(self):
         """

--- a/mezzanine/generic/forms.py
+++ b/mezzanine/generic/forms.py
@@ -80,12 +80,12 @@ class KeywordsWidget(forms.MultiWidget):
 
 class ThreadedCommentForm(CommentForm, Html5Mixin):
 
-    name = forms.CharField(label=_("Name"), help_text=_("required"),
+    name = forms.CharField(label=mark_safe(_("Name")), help_text=_("required"),
                            max_length=50)
-    email = forms.EmailField(label=_("Email"),
+    email = forms.EmailField(label=mark_safe(_("Email")),
                              help_text=_("required (not published)"))
-    url = forms.URLField(label=_("Website"), help_text=_("optional"),
-                         required=False)
+    url = forms.URLField(label=mark_safe(_("Website")),
+                         help_text=_("optional"), required=False)
 
     # These are used to get/set prepopulated fields via cookies.
     cookie_fields = ("name", "email", "url")


### PR DESCRIPTION
All label fields are now marked safe using django.utils.safestring.mark_safe in forms.
Necessary since django 1.5, see:
https://docs.djangoproject.com/en/dev/releases/1.5/#miscellaneous
