### PR TITLE
Use of staticfiles to get url to tinymce

### DIFF
--- a/mezzanine/core/forms.py
+++ b/mezzanine/core/forms.py
@@ -5,6 +5,7 @@ from django import forms
 from django.forms.extras.widgets import SelectDateWidget
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
+from django.contrib.staticfiles.storage import staticfiles_storage
 
 from mezzanine.conf import settings
 from mezzanine.core.models import Orderable
@@ -36,8 +37,8 @@ class Html5Mixin(object):
 
 _tinymce_js = ()
 if settings.GRAPPELLI_INSTALLED:
-    _tinymce_js = (settings.STATIC_URL +
-                   "grappelli/tinymce/jscripts/tiny_mce/tiny_mce.js",
+    _tinymce_js = (staticfiles_storage.url(\
+                   "grappelli/tinymce/jscripts/tiny_mce/tiny_mce.js"),
                    settings.TINYMCE_SETUP_JS,)
 
 


### PR DESCRIPTION
This pull request with this one from grappelli https://github.com/stephenmcd/grappelli-safe/pull/25 makes load the tiny_mce in admin and inline editor.

Both are related to #569

I have found other occurrences of STATIC_URL that may break other css and js loading, but did not get to them yet to correct them.I'll make new pull requests when I get to those.
