### PR TITLE
Fix: Middleware and custom Page models

### DIFF
--- a/mezzanine/pages/middleware.py
+++ b/mezzanine/pages/middleware.py
@@ -37,7 +37,7 @@ class PageMiddleware(object):
         pages = Page.objects.with_ascendants_for_slug(slug,
                         for_user=request.user, include_login_required=True)
         if pages:
-            page = pages[0]
+            page = pages[0].get_content_model()
         else:
             # If we can't find a page matching this slug or any
             # of its sub-slugs, skip all further processing.


### PR DESCRIPTION
Mezzanine middleware for the Page model inserts the page into the template context.  However, custom content model types that inherit from the Page model are not accessible as only the parent model is passed.

This change explicitly passes the Page subclass into context so any custom properties / fields of that content type is accessible in the template.
