### PR TITLE
Add support for settings.RICHTEXT_FILTERS

### DIFF
--- a/mezzanine/core/defaults.py
+++ b/mezzanine/core/defaults.py
@@ -282,6 +282,13 @@ register_setting(
     editable=False,
     default=None,
 )
+register_setting(
+    name="RICHTEXT_FILTERS",
+    description=_("List of dotted paths to functions, called in order, on a "
+        "``RichTextField`` value before it is rendered to the template."),
+    editable=False,
+    default=(),
+)
 
 RICHTEXT_FILTER_LEVEL_HIGH = 1
 RICHTEXT_FILTER_LEVEL_LOW = 2


### PR DESCRIPTION
I inquired about the possibility of this change [on the news group](https://groups.google.com/forum/#!topic/mezzanine-users/JksrFFGnfxQ), but found only crickets.  So here's a pull request instead.

`RICHTEXT_FILTER` is convenient, but not flexible for multiple reusable apps to leverage.  While it's simple to write my own filter to rule them all, and import/execute my third-party filters, I believe this is more Django-like, the way middleware and context processors work.

This update adds support for a plural list-based `RICH_TEXT_FILTERS`, whose purpose is to provide an ordered sequence of filters:

``` python
RICHTEXT_FILTERS = (
    'mdown.filters.codehilite',
    'gist_embed.filters.gist_embed',
)
```

Underneath, `RICH_TEXT_FILTER` is a fallback if the plural version is empty, so everything works as it did before.

For consistency, an alias for the `richtext_filter` template filter has been added to match the plural nature of the new setting: `richtext_filters` simply calls on `richtext_filter` for its output.  Not sure how you would prefer to handle that, but maintaining backwards compatibility with existing use of `richtext_filter` seems the best idea, I'm sure you agree.
