### PR TITLE
Fixed blog post categories list in blog_post_list.html template

### DIFF
--- a/mezzanine/blog/templates/blog/blog_post_list.html
+++ b/mezzanine/blog/templates/blog/blog_post_list.html
@@ -84,7 +84,7 @@
     {% with blog_post.user as author %}
     <a href="{% url "blog_post_list_author" author %}">{{ author.get_full_name|default:author.username }}</a>
     {% endwith %}
-    {% with blog_post.category.all as categories %}
+    {% with blog_post.categories.all as categories %}
     {% if categories %}
     {% trans "in" %}
     {% for category in categories %}


### PR DESCRIPTION
Blog post list template contained invalid relation name for individual post's categories m2m which prevented categories from being rendered. Grepped through all the codebase to check if there are more like this - found none.
