### PR TITLE
Removed redundant jQuery media from KeywordsWidget

### DIFF
--- a/mezzanine/generic/forms.py
+++ b/mezzanine/generic/forms.py
@@ -31,8 +31,7 @@ class KeywordsWidget(forms.MultiWidget):
     """
 
     class Media:
-        js = ("mezzanine/js/%s" % settings.JQUERY_FILENAME,
-              "mezzanine/js/admin/keywords_field.js",)
+        js = ("mezzanine/js/admin/keywords_field.js",)
 
     def __init__(self, attrs=None):
         """


### PR DESCRIPTION
This jQuery inclusion is redundant as it's already included in base admin template (in grappelli-safe at least). Such duplication is actually harmful not only due to download size considerations but also being included twice, second instance resets all jQuery plugins loaded before it (since "jQuery" namespace is being overwritten).

So if any jQ plugins are loaded between the jQ inclusions they will stop working after the second one.
