### PR TITLE
Use urljoin in Page.get_absolute_url for link pages

### DIFF
--- a/mezzanine/pages/models.py
+++ b/mezzanine/pages/models.py
@@ -1,3 +1,8 @@
+try:
+    from urllib.parse import urljoin
+except ImportError:     # Python 2
+    from urlparse import urljoin
+
 from django.core.urlresolvers import resolve, reverse
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -54,8 +59,7 @@ class Page(BasePage):
         slug = self.slug
         if self.content_model == "link":
             # Ensure the URL is absolute.
-            if not slug.lower().startswith("http"):
-                slug = "/" + self.slug.lstrip("/")
+            slug = urljoin('/', slug)
             return slug
         if slug == "/":
             return reverse("home")


### PR DESCRIPTION
I came upon this when I wanted to add a `mailto:` url as a link. `urljoin` from Python's standard library handles more schemes and edge cases. Another way to add a few schemes could be:

```
url_schemes = ('http:', 'https:', 'mailto:', 'ftp:')
if not slug.lower().startswith(url_schemes):
    slug = "/" + self.slug.lstrip("/")
```

If you don't like `urljoin`, I can send a pull request with this fix.
