### PR TITLE
Allow a single BCC address in addition to list/tuple

### DIFF
--- a/mezzanine/utils/email.py
+++ b/mezzanine/utils/email.py
@@ -39,6 +39,8 @@ def send_mail_template(subject, template, addr_from, addr_to, context=None,
     # Allow for a single address to be passed in.
     if not hasattr(addr_to, "__iter__"):
         addr_to = [addr_to]
+    if addr_bcc is not None and not hasattr(addr_bcc, "__iter__"):
+        addr_bcc = [addr_bcc]
     # Loads a template passing in vars as context.
     render = lambda type: loader.get_template("%s.%s" %
                           (template, type)).render(Context(context))


### PR DESCRIPTION
BCC fails if the addr_bcc argument is a single address rather than a list/tuple. This commit wraps a single address in a list to fix this problem.
