### PR TITLE
Added window.__language_code variable to admin and inline loader

### DIFF
--- a/mezzanine/core/templates/admin/base_site.html
+++ b/mezzanine/core/templates/admin/base_site.html
@@ -31,6 +31,7 @@ and mezzanine.core.admin.SingletonAdmin
 {% url "static_proxy" as static_proxy_url %}
 {% url "fb_browse" as fb_browse_url %}
 {% url "admin:index" as admin_index_url %}
+{% get_current_language as LANGUAGE_CODE %}
 window.__home_link = '<a href="{% url "home" %}">{% trans "View site" %}</a>';
 window.__csrf_token = '{{ csrf_token }}';
 window.__admin_keywords_submit_url = '{% url "admin_keywords_submit" %}';
@@ -39,6 +40,7 @@ window.__admin_url = '{{ admin_index_url }}';
 window.__static_proxy = '{{ static_proxy_url }}';
 window.__admin_media_prefix__ = '{% static "admin/" %}';
 window.__grappelli_installed = {{ settings.GRAPPELLI_INSTALLED|lower }};
+window.__language_code = '{{ LANGUAGE_CODE }}';
 </script>
 {% if not settings.GRAPPELLI_INSTALLED %}
 <script src="{% static "mezzanine/js/"|add:settings.JQUERY_FILENAME %}"></script>

--- a/mezzanine/core/templates/includes/editable_loader.html
+++ b/mezzanine/core/templates/includes/editable_loader.html
@@ -6,9 +6,11 @@
 <script>
 {% url "fb_browse" as fb_browse_url %}
 {% url "static_proxy" as static_proxy_url %}
+{% get_current_language as LANGUAGE_CODE %}
 window.__filebrowser_url = '{{ fb_browse_url }}';
 window.__toolbar_html = '{{ toolbar|escapejs }}';
 window.__static_proxy = '{{ static_proxy_url }}';
+window.__language_code = '{{ LANGUAGE_CODE }}';
 </script>
 <script src="{% static "mezzanine/js/jquery.tools.toolbox.expose.js" %}"></script>
 <script src="{% static "mezzanine/js/jquery.tools.overlay.js" %}"></script>


### PR DESCRIPTION
This is useful for widgets that implement their own i18n (like text editors).
