### PR TITLE
Use protocol-relative URL to avoid SSL warnings

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -201,7 +201,7 @@ def gravatar_url(email, size=32):
     Return the full URL for a Gravatar given an email hash.
     """
     bits = (md5(email.lower()).hexdigest(), size)
-    return "http://www.gravatar.com/avatar/%s?s=%s&d=identicon&r=PG" % bits
+    return "//www.gravatar.com/avatar/%s?s=%s&d=identicon&r=PG" % bits
 
 
 @register.to_end_tag


### PR DESCRIPTION
Using the `gravatar_url` template tag on SSL generates warnings. Using a protocol-relative URL fixes that (will grab the SSL version when the page is loaded over SSL). Gravatar's official docs say to use https://secure.gravatar.com, but https://www.gravatar.com seems to work fine.
