### PR TITLE
Fixed view and JS to be compatible with jQuery 1.8

### DIFF
--- a/mezzanine/pages/static/mezzanine/js/admin/page_tree.js
+++ b/mezzanine/pages/static/mezzanine/js/admin/page_tree.js
@@ -83,7 +83,7 @@ $(function() {
 
         var args = {
             id: ui.item[0].id,
-            parent_id: parent.length ? parent[0].id : null,
+            parent_id: parent.length ? parent[0].id : "null",
             siblings: ui.item.parent().children().map(function(index, elem) {
                 return elem.id;
             }).get()

--- a/mezzanine/pages/views.py
+++ b/mezzanine/pages/views.py
@@ -18,7 +18,7 @@ def admin_page_ordering(request):
 
     def get_id(s):
         s = s.split("_")[-1]
-        return s if s != "null" else None
+        return s if (s != "null" and s !="") else None
     page = get_object_or_404(Page, id=get_id(request.POST['id']))
     old_parent_id = page.parent_id
     new_parent_id = get_id(request.POST['parent_id'])


### PR DESCRIPTION
Related to https://github.com/stephenmcd/mezzanine/issues/735.

In jQuery versions before 1.8, if the value of a POST variable was null, jQuery posted 'null' to the server.

In jQuery 1.8 and higher, jQuery posts an empty string for a null value. (See jquery/jquery#714)

Changed js to put null in quotes and changed views to accept an empty string as well as a null.
