### PR TITLE
Remove inclusion of mezzanine.accounts when testing.

### DIFF
--- a/mezzanine/utils/conf.py
+++ b/mezzanine/utils/conf.py
@@ -75,9 +75,6 @@ def set_dynamic_settings(s):
     s.setdefault("MESSAGE_STORAGE", storage)
 
     if s["TESTING"]:
-        # Enable accounts when testing so the URLs exist.
-        append("INSTALLED_APPS", "mezzanine.accounts")
-
         # Following bits are work-arounds for some assumptions that
         # Django 1.5's tests make.
 


### PR DESCRIPTION
Tests are still passing without these lines.
