### PR TITLE
Fix UnicodeDecodeError for python3 setup.py bdist_rpm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ try:
         author_email="stephen.mc@gmail.com",
         description="An open source content management platform built using "
                     "the Django framework.",
-        long_description=open("README.rst").read(),
+        long_description=open("README.rst", 'rb').read().decode('utf-8'),
         license="BSD",
         url="http://mezzanine.jupo.org/",
         zip_safe=False,


### PR DESCRIPTION
`python3 setup.py bdist_rpm` gave the following error:

```
Traceback (most recent call last):
  File "setup.py", line 60, in <module>
    long_description=open("README.rst").read(),
  File "/usr/lib64/python3.3/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 11646: ordinal not in range(128)
```

While Python3 is unsupported yet, why not make it easier in the future?
