### PR TITLE
Adding Bootstrap .control-label

### DIFF
--- a/mezzanine/core/templates/includes/form_fields.html
+++ b/mezzanine/core/templates/includes/form_fields.html
@@ -19,7 +19,9 @@
 {% else %}
 <div class="control-group input_{{ field.id_for_label }} {{ field.field.type }}
     {% if field.errors %} error{% endif %}">
-    <label class="control-label" for="{{ field.auto_id }}">{{ field.label }}</label>
+    <label class="control-label" for="{{ field.auto_id }}">
+        {{ field.label }}
+    </label>
     <div class="controls">
         {{ field }}
         {% if field.errors %}


### PR DESCRIPTION
So forms look like this:
![image](https://f.cloud.github.com/assets/530530/949998/dd573580-0387-11e3-8d1a-fb0375a61884.png)

not this:
![image](https://f.cloud.github.com/assets/530530/950011/14f71bc2-0388-11e3-828d-f3312944a446.png)
