### PR TITLE
Fix TinyMCE asset_proxy by stripping STATIC_URL, leading / from proxied URLs

### DIFF
--- a/mezzanine/core/views.py
+++ b/mezzanine/core/views.py
@@ -135,7 +135,7 @@ def static_proxy(request):
     protocol = "http" if not request.is_secure() else "https"
     host = protocol + "://" + request.get_host()
     generic_host = "//" + request.get_host()
-    for prefix in (host, generic_host, settings.STATIC_URL):
+    for prefix in (settings.STATIC_URL, host, generic_host, '/'):
         if url.startswith(prefix):
             url = url.replace(prefix, "", 1)
     response = ""


### PR DESCRIPTION
`STATIC_URL` often contains `host` or `generic_host` (esp. if `STATIC_URL` is a path on the same domain), so it needs to be removed first to ensure it is removed completely.

Also removed leading `/` from URL, since it appears staticfiles doesn't like absolute paths, and I suspect that's what was causing the `SuspiciousOperation`.

This fixes #779 for me.
