### PR TITLE
Add ALLOWED_HOSTS to local_settings.py

### DIFF
--- a/mezzanine/project_template/local_settings.py.template
+++ b/mezzanine/project_template/local_settings.py.template
@@ -19,3 +19,7 @@ DATABASES = {
         "PORT": "",
     }
 }
+
+ALLOWED_HOSTS = (
+    "127.0.0.1",
+)


### PR DESCRIPTION
Otherwise it splits out warning:

`UserWarning: You haven't defined the ALLOWED_HOSTS settings, which Django 1.5 requires. Will fall back to the domains configured as sites.`
