### PR TITLE
Strip query parameters from url in thumbnail tag

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -276,6 +276,9 @@ def thumbnail(image_url, width, height, quality=95):
         return ""
 
     image_url = unquote(unicode(image_url))
+    # Strip query parameters from url, if any
+    if '?' in image_url:
+        image_url = image_url[:image_url.find('?')]
     if image_url.startswith(settings.MEDIA_URL):
         image_url = image_url.replace(settings.MEDIA_URL, "", 1)
     image_dir, image_name = os.path.split(image_url)


### PR DESCRIPTION
In the thumbnail mezzanine template tag, check if there are query parameters in the image url and strip them.

Fixes #794
