### PR TITLE
A Template-object can't be used in a list with template names.

### DIFF
--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -91,8 +91,10 @@ class TemplateForDeviceMiddleware(object):
     """
     def process_template_response(self, request, response):
         if hasattr(response, "template_name"):
-            templates = templates_for_device(request, response.template_name)
-            response.template_name = templates
+            if not isinstance(response.template_name, Template):
+                templates = templates_for_device(request, 
+                    response.template_name)
+                response.template_name = templates
         return response
 
 
@@ -102,8 +104,10 @@ class TemplateForHostMiddleware(object):
     """
     def process_template_response(self, request, response):
         if hasattr(response, "template_name"):
-            templates = templates_for_host(request, response.template_name)
-            response.template_name = templates
+            if not isinstance(response.template_name, Template):
+                templates = templates_for_host(request, 
+                    response.template_name)
+                response.template_name = templates
         return response
 
 


### PR DESCRIPTION
The error occurred with a django.template.response.SimpleTemplateResponse instance. This class can be instantiated with a Template object and this is saved into the variable template_name.

Later, during the rendering process, the function resolve_template gets called to determine the Template for the rendering. For a list or tuple the function loader.select_template is called and this function only works with list elements of the type six.string_types.
