### PR TITLE
Remove call to authenticate in ProfileForm.save()?

### DIFF
--- a/mezzanine/accounts/forms.py
+++ b/mezzanine/accounts/forms.py
@@ -1,3 +1,4 @@
+
 from django.contrib.auth import authenticate
 from django.db.models import Q
 from django import forms
@@ -179,7 +180,7 @@ class ProfileForm(Html5Mixin, forms.ModelForm):
         password = self.cleaned_data.get("password1")
         if password:
             user.set_password(password)
-        else if self._signup:
+        elif self._signup:
             user.set_unusable_password()
         user.save()
 


### PR DESCRIPTION
I suspect the call to authenticate that I've taken out is be unnecessary - it's only called if it's a new signup, in which case `password` is non-blank and has just been passed to `set_password`. This should always succeed and has no side-effects AFAICT - is there any need for it to be there?

I bring this up because I'm allowing password-less logons (i.e. via email only) by making a password optional at signup. Since the password isn't set, `authenticate()` returns None and the signup view breaks.

To make this case a bit more robust I've added a call to set_unusable_password() if the password is blank and it's a signup. This will only happen if the developer has modified the form to allow blank passwords in the first place.
