### PR TITLE
Page's slug may not content slashes (except for home page)

### DIFF
--- a/mezzanine/pages/views.py
+++ b/mezzanine/pages/views.py
@@ -69,6 +69,10 @@ def page(request, slug, template=u"pages/page.html", extra_context=None):
         page = extra_context["page"]
     except KeyError:
         raise Http404
+    
+    # '/' is not allowed in slug except for home page
+    if slug != home_slug() and '/' in slug:
+        raise Http404
 
     # Check for a template name matching the page's slug. If the homepage
     # is configured as a page instance, the template "pages/index.html" is


### PR DESCRIPTION
Page's slug may not content slashes (except for home page). If the slug contains a slash Http404 is raised.
