### PR TITLE
Pin Django docs version for 1.4-style user profiles

### DIFF
--- a/docs/user-accounts.rst
+++ b/docs/user-accounts.rst
@@ -53,7 +53,7 @@ update profile forms, as well as in the user's public profile page.
     model is configured.
 
 For more information consult the `Django docs for profiles
-<https://docs.djangoproject.com/en/dev/topics/auth/#storing-additional-information-about-users>`_.
+<https://docs.djangoproject.com/en/1.4/topics/auth/#storing-additional-information-about-users>`_.
 
 Restricting Account Fields
 ==========================


### PR DESCRIPTION
Given that we're using 1.4's user profile rather than 1.5's custom User model we'll want the correct docs referenced.

As an alternative we could direct users to the updated docs (indicating deprecation of the `AUTH_PROFILE_MODULE`: https://docs.djangoproject.com/en/dev/topics/auth/customizing/#extending-the-existing-user-model
