### PR TITLE
Fix importing Pages in a middleware

### DIFF
--- a/mezzanine/generic/fields.py
+++ b/mezzanine/generic/fields.py
@@ -72,6 +72,14 @@ class BaseGenericRelation(GenericRelation):
             for (name_string, field) in self.fields.items():
                 if "%s" in name_string:
                     name_string = name_string % name
+                # We don't call get_all_field_names() which fill the app cache
+                # get_fields_with_model() is safe
+                field_names = [i.name for i, _ in cls._meta.get_fields_with_model()]
+                # In Django 1.6, add_to_class will be called on a parent
+                # model's field more than once, so contribute_to_class needs to
+                # be idempotent.
+                if name_string in field_names:
+                    continue
                 if not field.verbose_name:
                     field.verbose_name = self.verbose_name
                 cls.add_to_class(name_string, copy(field))


### PR DESCRIPTION
Hi,

We have a [middleware that falls back on certain template when there are no Django url](//github.com/fusionbox/django-fusionbox/blob/master/fusionbox/middleware.py#L50). We [wrote one that work with Mezzanine](//github.com/fusionbox/django-fusionbox/blob/master/fusionbox/mezzanine/middleware.py#L14).

I was using Mezzanine on one of my projects. And I had a bug when deploying with uwsgi and gunicorn, but I couldn't reproduce this bug locally. This is why I couldn't write test for this bug.

This is the error message:

```
Traceback (most recent call last):
  File "lib/python2.7/site-packages/gunicorn/workers/sync.py", line 131, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 236, in __call__
    self.load_middleware()
  File "lib/python2.7/site-packages/django/core/handlers/base.py", line 53, in load_middleware
    raise exceptions.ImproperlyConfigured('Error importing middleware %s: "%s"' % (mw_module, e))
ImproperlyConfigured: Error importing middleware fusionbox.mezzanine.middleware: "cannot import name Link"
```

Anyway, after a `git bisect` I found the [guilty commit](https://github.com/fusionbox/mezzanine/commit/19288b896a5ccb146ae8fe8e25cde5a768079c0d). We encountered a similar problem on [widgy](//github.com/fusionbox/django-widgy) and @gavinwahl [fixed it](//github.com/fusionbox/django-widgy/commit/4964243f7a3a03c4eb43453c1ed0371fc61c3e81). I applied the same fix to mezzanine.

Could you please review my change, and let me know if there is any problem.

Thanks!
