### PR TITLE
Some support for password-less configurations

### DIFF
--- a/mezzanine/accounts/forms.py
+++ b/mezzanine/accounts/forms.py
@@ -208,8 +208,9 @@ class ProfileForm(Html5Mixin, forms.ModelForm):
                 user.is_active = False
                 user.save()
             else:
+                token = default_token_generator.make_token(user)
                 user = authenticate(uidb36=int_to_base36(user.id),
-                                    token=default_token_generator.make_token(user),
+                                    token=token,
                                     is_active=True)
         return user
 


### PR DESCRIPTION
When a new user is created, perform the initial authentication using a token instead of a password - this way a user can be created without a password without having to subclass Mezzanine's ProfileForm.

Also explicitly indicate that a user has no password by calling `user.set_unusable_password()` if the password is blank.

Based on discussion in #809.
