### PR TITLE
Remove use of ``from future import standard_library`` for now (issue #826)

### DIFF
--- a/mezzanine/blog/management/commands/import_rss.py
+++ b/mezzanine/blog/management/commands/import_rss.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from future import standard_library
 
 from datetime import timedelta
 from optparse import make_option

--- a/mezzanine/blog/tests.py
+++ b/mezzanine/blog/tests.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from future import standard_library
 
 try:
     from urllib.parse import urlparse

--- a/mezzanine/core/views.py
+++ b/mezzanine/core/views.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, unicode_literals
-from future import standard_library
 from future.builtins import int, open, str
 
 import os

--- a/mezzanine/forms/admin.py
+++ b/mezzanine/forms/admin.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from future import standard_library
 from future.builtins import open
 
 from copy import deepcopy

--- a/mezzanine/galleries/models.py
+++ b/mezzanine/galleries/models.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from future import standard_library
 from future.builtins import str
 from future.utils import native, PY2
 

--- a/mezzanine/pages/models.py
+++ b/mezzanine/pages/models.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from future import standard_library
 from future.builtins import filter, str
 try:
     from urllib.parse import urljoin

--- a/mezzanine/utils/docs.py
+++ b/mezzanine/utils/docs.py
@@ -3,7 +3,6 @@ Utils called from project_root/docs/conf.py when Sphinx
 documentation is generated.
 """
 from __future__ import division, print_function, unicode_literals
-from future import standard_library
 from future.builtins import map, open, str
 
 from datetime import datetime

--- a/mezzanine/utils/html.py
+++ b/mezzanine/utils/html.py
@@ -1,11 +1,15 @@
 from __future__ import absolute_import, unicode_literals
-from future import standard_library
-from future.builtins import chr
-from future.builtins import int
+from future.builtins import chr, int
 
-from html.parser import HTMLParser, HTMLParseError
-from html.entities import name2codepoint
+try:
+    from html.parser import HTMLParser, HTMLParseError
+    from html.entities import name2codepoint
+except ImportError:         # Python 2
+    from HTMLParser import HTMLParser, HTMLParseError
+    from htmlentitydefs import name2codepoint
+
 import re
+
 
 SELF_CLOSING_TAGS = ['br', 'img']
 

--- a/mezzanine/utils/tests.py
+++ b/mezzanine/utils/tests.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from future import standard_library
 from future.builtins import open, range, str
 from future.utils import native_str
 
@@ -49,9 +48,6 @@ IGNORE_ERRORS = (
 
     # Deprecated compat timezones for Django 1.3
     "mezzanine/utils/timezone",
-
-    # 'from future import standard_library' installs PEP 302 import hooks
-    "'standard_library' imported but unused",
 )
 
 
@@ -160,12 +156,7 @@ def run_pyflakes_for_package(package_name, extra_ignore=None):
     If pyflakes is installed, run it across the given package name
     returning any warnings found.
     """
-    # Pyflakes v0.6.1 incorrectly assumes we're running under Python 3
-    # if "import builtins" succeeds, which it does with "from future
-    # import standard_library" in effect.
-    standard_library.disable_hooks()
     from pyflakes.checker import Checker
-    standard_library.enable_hooks()
 
     def pyflakes_checker(path):
         with open(path, "U") as source_file:


### PR DESCRIPTION
This patch removes the use of the `from future import standard_library` feature. This line was actually redundant in most of the modules using it anyway, particularly because the feature doesn't yet support remapping of `urllib`, so these cases were handled manually using `try` / `except` anyway.

I have posted to python-list about a safer mechanism for import hooks for the `standard_library` feature in `future`, and I'll cross-post it to the Import-SIG list.

Thanks, @AlexHill, for the heads-up!
