### PR TITLE
Make auto-generated slugs propagate. Fixes #831.

### DIFF
--- a/mezzanine/core/models.py
+++ b/mezzanine/core/models.py
@@ -71,16 +71,22 @@ class Slugged(SiteRelated):
 
     def save(self, *args, **kwargs):
         """
-        Create a unique slug by appending an index.
+        If no slug is provided, generates one before saving.
         """
         if not self.slug:
-            self.slug = self.get_slug()
+            self.slug = self.generate_unique_slug()
+        super(Slugged, self).save(*args, **kwargs)
+
+    def generate_unique_slug(self):
+        """
+        Create a unique slug by passing the result of get_slug() to
+        utils.urls.unique_slug, which appends an index if necessary.
+        """
         # For custom content types, use the ``Page`` instance for
         # slug lookup.
         concrete_model = base_concrete_model(Slugged, self)
         slug_qs = concrete_model.objects.exclude(id=self.id)
-        self.slug = unique_slug(slug_qs, "slug", self.slug)
-        super(Slugged, self).save(*args, **kwargs)
+        return unique_slug(slug_qs, "slug", self.get_slug())
 
     def get_slug(self):
         """

--- a/mezzanine/pages/admin.py
+++ b/mezzanine/pages/admin.py
@@ -22,12 +22,10 @@ class PageAdminForm(DisplayableAdminForm):
 
     def clean_slug(self):
         """
-        If the slug has been changed, save the old one. We will use it later
-        in PageAdmin.model_save() to make the slug change propagate down the
-        page tree.
+        Save the old slug to be used later in PageAdmin.model_save()
+        to make the slug change propagate down the page tree.
         """
-        if self.instance.slug != self.cleaned_data['slug']:
-            self.instance._old_slug = self.instance.slug
+        self.instance._old_slug = self.instance.slug
         return self.cleaned_data['slug']
 
 
@@ -140,12 +138,12 @@ class PageAdmin(DisplayableAdmin):
 
     def save_model(self, request, obj, form, change):
         """
-        Set the ID of the parent page if passed in via querystring, and make
-        sure the new slug propagates to all descendant pages.
+        Set the ID of the parent page if passed in via querystring, and
+        make sure the new slug propagates to all descendant pages.
         """
-        if change and hasattr(obj, "_old_slug"):
+        if change and obj._old_slug != obj.slug:
             # _old_slug was set in PageAdminForm.clean_slug().
-            new_slug = obj.slug
+            new_slug = obj.slug or obj.generate_unique_slug()
             obj.slug = obj._old_slug
             obj.set_slug(new_slug)
 


### PR DESCRIPTION
This change factors out `Slugged`'s unique slug generation from `save()` into its own new method, `generate_unique_slug()`, so that it can be called separately. This method is then called in `PageAdmin.save_model()` before `Page.set_slug()`, so that the automatically-generated slug propagates down the page tree.

Ideally I would like the new slug to be generated in `PageAdminForm.clean_slug()` - seems like the better logical place to put it - that's tricky, because we only have access to the existing instance with its old field values, but all the slug-handling methods operate on fields on `self` rather than method arguments.
