### PR TITLE
Namespace jQuery in the admin pages to prevent conflicts

### DIFF
--- a/mezzanine/core/static/mezzanine/js/admin/ajax_csrf.js
+++ b/mezzanine/core/static/mezzanine/js/admin/ajax_csrf.js
@@ -1,5 +1,7 @@
-$.ajaxSetup({
-    beforeSend: function(xhr, settings) {
-        xhr.setRequestHeader('X-CSRFToken', window.__csrf_token);
-    }
+jQuery(function($) {
+    $.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+            xhr.setRequestHeader('X-CSRFToken', window.__csrf_token);
+        }
+    });
 });

--- a/mezzanine/core/static/mezzanine/js/admin/collapse_backport.js
+++ b/mezzanine/core/static/mezzanine/js/admin/collapse_backport.js
@@ -1,5 +1,5 @@
-$(document).ready(function(){
-    
+jQuery(document).ready(function($){
+     
     /// FIELDSETS
     $('fieldset[class*="collapse-closed"]').each(function() {
         $(this).addClass("collapsed");
@@ -13,12 +13,12 @@ $(document).ready(function(){
         $(this).parent().toggleClass('collapse-closed');
         $(this).parent().toggleClass('collapse-open');
     });
-    
+
     /// OPEN FIELDSETS WITH ERRORS
     $('fieldset[class*="collapse-closed"]').children('div[class*="errors"]').each(function(i) {
         $(this).parent().toggleClass("collapsed");
         $(this).parent().toggleClass('collapse-closed');
         $(this).parent().toggleClass('collapse-open');
     });
-    
+
 });

--- a/mezzanine/core/static/mezzanine/js/admin/dynamic_inline.js
+++ b/mezzanine/core/static/mezzanine/js/admin/dynamic_inline.js
@@ -30,7 +30,7 @@ var anyFieldsDirty = function(fields) {
     }).length > 0;
 };
 
-$(function() {
+jQuery(function($) {
 
     var itemSelector = window.__grappelli_installed ? '.items' : 'tbody';
     var parentSelector = '.dynamic-inline ' + itemSelector;

--- a/mezzanine/core/static/mezzanine/js/admin/keywords_field.js
+++ b/mezzanine/core/static/mezzanine/js/admin/keywords_field.js
@@ -1,5 +1,4 @@
-
-$(function() {
+jQuery(function($) {
 
     $('.keywords-field').css(window.__grappelli_installed ?
                             {margin: '5px 0 0 130px', width: '700px'} :

--- a/mezzanine/core/static/mezzanine/js/admin/login.js
+++ b/mezzanine/core/static/mezzanine/js/admin/login.js
@@ -1,4 +1,4 @@
-$(function() {
+jQuery(function($) {
     // Fix the ``Home`` breadcrumb link non logged-in views.
     var home = $('.breadcrumbs a:first');
     if (home.length == 1) {

--- a/mezzanine/core/static/mezzanine/js/admin/navigation.js
+++ b/mezzanine/core/static/mezzanine/js/admin/navigation.js
@@ -1,4 +1,4 @@
-$(function() {
+jQuery(function($) {
     // Empty out the breadcrumbs div and add the menu into it.
     $('.breadcrumbs').html('')
                      .append($('.dropdown-menu').show())
@@ -35,7 +35,7 @@ $(function() {
 
 // Remove extraneous ``template`` forms from inline formsets since
 // Mezzanine has its own method of dynamic inlines.
-$(function() {
+jQuery(function($) {
     var removeRows = {};
     $.each($('*[name*=__prefix__]'), function(i, e) {
         var row = $(e).parent();


### PR DESCRIPTION
Stephen,

I have been working with FusionBox on django-widgy, and they found that the jQuery in the admin pages is global. I am proposing this change along with a change in grappelli_safe to take it out of the global namespace.

Please advise any changes or if you do not want this in your projects.

Thank you,

Zach
