### PR TITLE
verbose_names should be capitalized when output

### DIFF
--- a/mezzanine/pages/templates/admin/pages/page/change_list.html
+++ b/mezzanine/pages/templates/admin/pages/page/change_list.html
@@ -25,7 +25,7 @@
             {% for model in page_models %}
 			    {% set_model_permissions model %}
 			    {% if model.perms.add %}
-                <option value="{{ model.add_url }}">{{ model.meta_verbose_name }}</option>
+                <option value="{{ model.add_url }}">{{ model.meta_verbose_name|capfirst }}</option>
                 {% endif %}
             {% endfor %}
         </select>

--- a/mezzanine/pages/templates/pages/menus/admin.html
+++ b/mezzanine/pages/templates/pages/menus/admin.html
@@ -33,7 +33,7 @@
                     {% set_model_permissions model %}
                     {% if model.perms.add %}
                     <option value="{{ model.add_url }}?parent={{ page.id }}"
-                        >{{ model.meta_verbose_name }}</option>
+                        >{{ model.meta_verbose_name|capfirst }}</option>
                     {% endif %}
                 {% endfor %}
             </select>


### PR DESCRIPTION
The convention is to always use lowercase verbose_names and capitalize in the template where necessary.

https://docs.djangoproject.com/en/1.0/topics/db/models/#verbose-field-names

> The convention is not to capitalize the first letter of the verbose_name. Django will automatically capitalize the first letter where it needs to.
