### PR TITLE
Added ALLOWED_HOSTS configuration for Django

### DIFF
--- a/mezzanine/project_template/settings.py
+++ b/mezzanine/project_template/settings.py
@@ -92,6 +92,10 @@ ADMINS = (
 )
 MANAGERS = ADMINS
 
+# Hosts/domain names that are valid for this site; required if DEBUG is False
+# See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = []
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.


### PR DESCRIPTION
As it's part of the default django settings, we also need this in mezzanine

we should add this to cartridge too and upgrade the local_settings.py template as in mezzanine
