### PR TITLE
Make mezzanine.generic optional

### DIFF
--- a/mezzanine/core/templates/admin/base_site.html
+++ b/mezzanine/core/templates/admin/base_site.html
@@ -34,7 +34,9 @@ and mezzanine.core.admin.SingletonAdmin
 {% get_current_language as LANGUAGE_CODE %}
 window.__home_link = '<a href="{% url "home" %}">{% trans "View site" %}</a>';
 window.__csrf_token = '{{ csrf_token }}';
+{% ifinstalled mezzanine.generic %}
 window.__admin_keywords_submit_url = '{% url "admin_keywords_submit" %}';
+{% endifinstalled %}
 window.__filebrowser_url = '{{ fb_browse_url }}';
 window.__admin_url = '{{ admin_index_url }}';
 window.__static_proxy = '{{ static_proxy_url }}';

--- a/mezzanine/urls.py
+++ b/mezzanine/urls.py
@@ -63,8 +63,12 @@ if getattr(settings, "PACKAGE_NAME_FILEBROWSER") in settings.INSTALLED_APPS:
 # Miscellanous Mezzanine patterns.
 urlpatterns += patterns("",
     ("^", include("mezzanine.core.urls")),
-    ("^", include("mezzanine.generic.urls")),
 )
+
+if "mezzanine.generic" in settings.INSTALLED_APPS:
+    urlpatterns += patterns("",
+        ("^", include("mezzanine.generic.urls")),
+    )
 
 # Mezzanine's Accounts app
 _old_accounts_enabled = getattr(settings, "ACCOUNTS_ENABLED", False)


### PR DESCRIPTION
Enables `mezzanine.generic` to be removed from INSTALLED_APPS.

I fully admit to not understanding what I was doing and simply bashing on things until it worked. :-)
