### PR TITLE
Use FieldFile.url to get full image-url in gallery

### DIFF
--- a/mezzanine/galleries/templates/pages/gallery.html
+++ b/mezzanine/galleries/templates/pages/gallery.html
@@ -33,7 +33,7 @@ $(document).ready(function() {
 {% with page.gallery.images.all as images %}
 {% for image in images %}
 <div class="col-xs-4 col-sm-3">
-    <a class="thumbnail" rel="#image-{{ image.id }}" title="{{ image.description }}" href="{{ MEDIA_URL }}{{ image.file }}">
+    <a class="thumbnail" rel="#image-{{ image.id }}" title="{{ image.description }}" href="{{ image.file.url }}">
         <img class="img-responsive" src="{{ MEDIA_URL }}{% thumbnail image.file 131 75 %}">
     </a>
 </div>


### PR DESCRIPTION
Simple way to fix #877 

But I don't like that `MEDIA_URL` is still often used in the templates. Better way would be to have `thumbnail` return the full url or the thumbnail file-object (to stay backwards compatible, perhaps with a new template-tag?). 
