### PR TITLE
allow <a> tags inside <button> in TinyMCE

### DIFF
--- a/mezzanine/core/static/mezzanine/js/tinymce_setup.js
+++ b/mezzanine/core/static/mezzanine/js/tinymce_setup.js
@@ -75,7 +75,8 @@ if (typeof tinyMCE != 'undefined') {
         paste_strip_class_attributes: true,
 
         // don't strip anything since this is handled by bleach
-        valid_elements : "*[*]"
+        valid_elements: "+*[*]",
+        valid_children: "+button[a]"
 
 	});
 


### PR DESCRIPTION
This adds the ability to add <a> tags inside of <button> tags using TinyMCE. I also added a + to the valid elements entry to make sure blank tags, which are used sometimes in Bootstrap, such as <span class="caret"></span> are not removed.
