### PR TITLE
Make the label element optional for form fields.

### DIFF
--- a/mezzanine/core/templates/includes/form_fields.html
+++ b/mezzanine/core/templates/includes/form_fields.html
@@ -11,7 +11,7 @@
 {% else %}
 <div class="form-group input_{{ field.id_for_label }} {{ field.field.type }}
     {% if field.errors %} has-error{% endif %}">
-    <label class="control-label" for="{{ field.auto_id }}">{{ field.label }}</label>
+    {% if field.label %}<label class="control-label" for="{{ field.auto_id }}">{{ field.label }}</label>{% endif %}
     {{ field }}
     {% if field.errors %}
     <p class="help-block">


### PR DESCRIPTION
Labels for form fields can be disabled by setting them to an empty string. Previously this would produce the intended result visually, but left an empty label element in the HTML. This change causes the element to only be inserted if a label value exists.
