### PR TITLE
Fix login/logout redirects for sites with a URL prefix.

### DIFF
--- a/mezzanine/accounts/views.py
+++ b/mezzanine/accounts/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth import (authenticate, login as auth_login,
                                                logout as auth_logout)
 from django.contrib.auth.decorators import login_required
 from django.contrib.messages import info, error
-from django.core.urlresolvers import NoReverseMatch
+from django.core.urlresolvers import NoReverseMatch, get_script_prefix
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.translation import ugettext_lazy as _
 
@@ -40,7 +40,7 @@ def logout(request):
     """
     auth_logout(request)
     info(request, _("Successfully logged out"))
-    return redirect(next_url(request) or "/")
+    return redirect(next_url(request) or get_script_prefix())
 
 
 def signup(request, template="accounts/account_signup.html"):

--- a/mezzanine/utils/urls.py
+++ b/mezzanine/utils/urls.py
@@ -116,7 +116,7 @@ def login_redirect(request):
         try:
             next = reverse(settings.LOGIN_REDIRECT_URL)
         except NoReverseMatch:
-            next = "/"
+            next = get_script_prefix()
     return redirect(next)
 
 


### PR DESCRIPTION
Out of the box, Mezzanine will redirect login/logouts to "/", which doesn't work great for sites with a prefix, such as www.foo.com/bar/. The rest of Mezzanine works fine in this setup, but upon login or logout, a redirect to www.foo.com occurs.

Change uses get_script_prefix() instead of "/" in order to play better with prefixes.
