### PR TITLE
Add setting TAG_CLOUD_MAX_ITEMS to limit the number of items in tag cloud.

### DIFF
--- a/mezzanine/core/defaults.py
+++ b/mezzanine/core/defaults.py
@@ -492,6 +492,15 @@ register_setting(
 )
 
 register_setting(
+    name="TAG_CLOUD_MAX_ITEMS",
+    label=_("Maximum Items in Tag Cloud"),
+    description=_("Limit the number of items in the tag cloud.  (Most "
+      "popular, set to 0 for no limit.)"),
+    editable=True,
+    default=0,
+)
+
+register_setting(
     name="TEMPLATE_ACCESSIBLE_SETTINGS",
     description=_("Sequence of setting names available within templates."),
     editable=False,

--- a/mezzanine/generic/templatetags/keyword_tags.py
+++ b/mezzanine/generic/templatetags/keyword_tags.py
@@ -41,13 +41,17 @@ def keywords_for(*args):
     except ValueError:
         return []
 
+    settings.use_editable()
     content_type = ContentType.objects.get(app_label=app_label, model=model)
     assigned = AssignedKeyword.objects.filter(content_type=content_type)
     keywords = Keyword.objects.filter(assignments__in=assigned)
     keywords = keywords.annotate(item_count=Count("assignments"))
+    max_items = settings.TAG_CLOUD_MAX_ITEMS
+    if max_items:
+        keywords = keywords.order_by("-item_count")[:max_items]
+        keywords = sorted(keywords, key=lambda k: k.title)
     if not keywords:
         return []
-    settings.use_editable()
     counts = [keyword.item_count for keyword in keywords]
     min_count, max_count = min(counts), max(counts)
     factor = (settings.TAG_CLOUD_SIZES - 1.)


### PR DESCRIPTION
With a large number of keywords (as I have after importing from another software) the tag cloud looks rather ugly (many keywords are only used on 1 post).  This offers an option to limit the number of tags included in the tag cloud, while leaving the default behavior unchanged.
