### PR TITLE
check if the user model is already registered

### DIFF
--- a/mezzanine/accounts/admin.py
+++ b/mezzanine/accounts/admin.py
@@ -59,5 +59,5 @@ if Profile:
 
 
 if User in admin.site._registry:
-	admin.site.unregister(User)
+    admin.site.unregister(User)
 admin.site.register(User, UserProfileAdmin)


### PR DESCRIPTION
Fix usage of overwriting the UserProfileAdmin because it will be under mezzanine.accounts in INSTALLED_APPS. In this case, django.auth will not add the User model before.
