### PR TITLE
If the static url starts with /static/ then, the prefix /static/ is not ...

### DIFF
--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -220,3 +220,18 @@ class CoreTests(TestCase):
 
         site1.delete()
         site2.delete()
+
+    def test_static_proxy(self):
+        from filebrowser_safe import settings
+        from urllib import urlencode
+
+        self.client.login(username=self._username, password=self._password)
+        url = "%s%s/%s" % (settings.URL_FILEBROWSER_MEDIA,
+                           'uploadify',
+                           'uploadify.swf')
+
+        assert url.startswith("/static/")
+
+        response = self.client.get(
+            '%s?u=%s' % (reverse('static_proxy'), urlencode([('u', url)])))
+        self.assertEqual(response.status_code, 200)

--- a/mezzanine/core/views.py
+++ b/mezzanine/core/views.py
@@ -135,16 +135,18 @@ def static_proxy(request):
     SWF, as these are normally static files, and will break with
     cross-domain JavaScript errors if ``STATIC_URL`` is an external
     host. URL for the file is passed in via querystring in the inline
-    popup plugin template, and we then attempt to pull out the relative
-    path to the file, so that we can serve it locally via Django.
+    popup plugin template.
     """
-    normalize = lambda u: "//" + u.split("://")[-1]
-    url = normalize(request.GET["u"])
-    host = normalize(request.get_host())
-    static_url = settings.STATIC_URL
-    if "://" in static_url:
-        static_url = normalize(static_url)
-    for prefix in (host, static_url, "/"):
+    # Get the relative URL after STATIC_URL.
+    url = request.GET["u"]
+    protocol = "http" if not request.is_secure() else "https"
+    host = protocol + "://" + request.get_host()
+    generic_host = "//" + request.get_host()
+    # STATIC_URL often contains host or generic_host, so remove it
+    # first otherwise the replacement loop below won't work.
+    static_url = settings.STATIC_URL.replace(host, "", 1)
+    static_url = static_url.replace(generic_host, "", 1)
+    for prefix in (host, generic_host, static_url, "/"):
         if url.startswith(prefix):
             url = url.replace(prefix, "", 1)
     response = ""


### PR DESCRIPTION
...removed because two // where added

I was having problems with the url http://localhost:8000/asset_proxy/?u=/static/filebrowser/uploadify/uploadify.swf which kept responding with 400. 

I checked out the `static_proxy` view was launching and exception at `path = finders.find(url)` in particular:

```
SuspiciousFileOperation: Attempted access to '//static/filebrowser/uploadify/uploadify.swf ' denied.
```

When I checked the view, it seems that if the url starts with /static/ then, it's not removed from the prefix, because after normalization it adds //, so you get ///static/.

Going back to what was before fixes the problem.
