### PR TITLE
make js code specific to dynamic inlines only applied to dynamic inlines

### DIFF
--- a/mezzanine/core/static/mezzanine/js/admin/navigation.js
+++ b/mezzanine/core/static/mezzanine/js/admin/navigation.js
@@ -36,7 +36,7 @@ jQuery(function($) {
     // Remove extraneous ``template`` forms from inline formsets since
     // Mezzanine has its own method of dynamic inlines.
     var removeRows = {};
-    $.each($('*[name*=__prefix__]'), function(i, e) {
+    $.each($('.dynamic-inline *[name*=__prefix__]'), function(i, e) {
         var row = $(e).parent();
         if (!row.attr('id')) {
             row.attr('id', 'remove__prefix__' + i);


### PR DESCRIPTION
I'm not even sure why this code is in `core/static/mezzanine/js/admin/navigation.js`? Shouldn't it be in `core/static/mezzanine/js/admin/dynamic_inline.js`?
