### PR TITLE
Add noindex tag to search results

### DIFF
--- a/mezzanine/core/templates/search_results.html
+++ b/mezzanine/core/templates/search_results.html
@@ -4,6 +4,9 @@
 
 {% block meta_title %}{% trans "Search Results" %}{% endblock %}
 {% block title %}{% trans "Search Results" %}{% endblock %}
+{% block extra_head %}
+<meta name="robots" content="noindex">
+{% endblock %}
 
 {% block breadcrumb_menu %}
 <li>


### PR DESCRIPTION
Search results shouldn't normally be indexed, given that they can be generated for arbitrary queries, and link to already-indexed content. This patch adds a noindex tag to the head.
