### PR TITLE
Add some HTML5 tags to RICHTEXT_ALLOWED_TAGS

### DIFF
--- a/mezzanine/core/defaults.py
+++ b/mezzanine/core/defaults.py
@@ -247,15 +247,16 @@ register_setting(
     description=_("List of HTML tags that won't be stripped from "
         "``RichTextField`` instances."),
     editable=False,
-    default=("a", "abbr", "acronym", "address", "area", "article", "aside", 
+    default=("a", "abbr", "acronym", "address", "area", "article", "aside",
         "b", "bdo", "big", "blockquote", "br", "button", "caption", "center",
         "cite", "code", "col", "colgroup", "dd", "del", "dfn", "dir", "div",
-        "dl", "dt", "em", "fieldset", "figure", "font", "footer", "form", "h1",
-        "h2", "h3", "h4", "h5", "h6", "header", "hr", "i", "img", "input", "ins",
-        "kbd", "label", "legend", "li", "map", "menu", "nav", "ol", "optgroup",
-        "option", "p", "pre", "q", "s", "samp", "section", "select", "small", 
-        "span", "strike", "strong", "sub", "sup", "table", "tbody", "td", "textarea",
-        "tfoot", "th", "thead", "tr", "tt", "u", "ul", "var", "wbr"),
+        "dl", "dt", "em", "fieldset", "figure", "font", "footer", "form",
+        "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr", "i", "img",
+        "input", "ins", "kbd", "label", "legend", "li", "map", "menu", "nav",
+        "ol", "optgroup", "option", "p", "pre", "q", "s", "samp", "section",
+        "select", "small", "span", "strike", "strong", "sub", "sup", "table",
+        "tbody", "td", "textarea", "tfoot", "th", "thead", "tr", "tt", "u",
+        "ul", "var", "wbr"),
 )
 
 register_setting(


### PR DESCRIPTION
Hi,

This patch adds the following tags to RICHTEXT_ALLOWED_TAGS:
- article
- aside
- figure
- caption
- header
- footer
- nav
- section

... all of which are becoming increasingly common, and should all be safe to allow.

Thanks!
