### PR TITLE
Fix for ignoring search_fields when they are set on the ModelAdmin

### DIFF
--- a/mezzanine/core/admin.py
+++ b/mezzanine/core/admin.py
@@ -59,9 +59,11 @@ class DisplayableAdmin(admin.ModelAdmin):
     def __init__(self, *args, **kwargs):
         super(DisplayableAdmin, self).__init__(*args, **kwargs)
         # TODO: check if the list() call is necessary below on Python 3:
+        if not hasattr(self, 'search_fields'):
+            self.search_fields = []
         try:
-            self.search_fields = list(
-                               self.model.objects.get_search_fields().keys())
+            self.search_fields = list(set(list(self.search_fields) + list(
+                               self.model.objects.get_search_fields().keys())))
         except AttributeError:
             pass
 


### PR DESCRIPTION
As per [Cartridge issue 170](https://github.com/stephenmcd/cartridge/issues/170).
