### PR TITLE
Update page_processory.py (check slug basestring)

### DIFF
--- a/mezzanine/pages/page_processors.py
+++ b/mezzanine/pages/page_processors.py
@@ -28,7 +28,7 @@ def processor_for(content_model_or_slug, exact_page=False):
     """
     content_model = None
     slug = ""
-    if isinstance(content_model_or_slug, (str, _str)):
+    if isinstance(content_model_or_slug, basestring):
         try:
             content_model = get_model(*content_model_or_slug.split(".", 1))
         except TypeError:


### PR DESCRIPTION
The processor_for decorator wasn't allowing me to pass in page slugs.  I updated the isistance to check for basestring instead of string.

http://docs.python.org/2/library/functions.html#basestring
