### PR TITLE
Changed page_menu template tag to obtain the deepest page for the current URL

### DIFF
--- a/mezzanine/pages/templatetags/pages_tags.py
+++ b/mezzanine/pages/templatetags/pages_tags.py
@@ -55,7 +55,7 @@ def page_menu(context, token):
         # Store the current page being viewed in the context. Used
         # for comparisons in page.set_menu_helpers.
         if "page" not in context:
-           context["_current_page"] = None
+            context["_current_page"] = None
 
             # Obtain page with the deepest URL that matches within the
             # current URL. Used when page is not placed in current


### PR DESCRIPTION
While working on integrating DjangoBB into Mezzanine, I found that Mezzanine was not able to place a page that was associated with the forums main URL into the response's context. djangobb_forum.views.index and other djangobb views return a HttpResponse from the render shortcut function. Since views in DjangoBB do not return a TemplateResponse, the PageMiddleware will not find a context_data attribute in the response and return.

```
# If we can't add context to the response we just return it.
# (redirects, etc)
if getattr(response, "context_data", None) is None:
    return response
```

The page_menu template tag also attempts to obtain a page for the current URL if no page is in the current context. However, there are a couple of problems with it. The first is that the path used has not been stripped of unnecessary slashes so no page slug will match. The other is that it would only obtain a page associated with the exact URL with no regard to page hierarchy. I have changed the page_menu template tag so that it performs more like PageMiddleware. page_menu will use `Page.objects.with_ascendants_for_slug(slug, for_user=user, include_login_required=True)` to check for the deepest page in the hierarchy. This is needed so that the correct menu item will be listed as current when a user browses a forum, topic, etc.
