### PR TITLE
Mentioning PAGE_MENU_TEMPLATES_DEFAULT

### DIFF
--- a/docs/content-architecture.rst
+++ b/docs/content-architecture.rst
@@ -351,6 +351,12 @@ the template path. For example in your ``settings.py`` module::
         (3, "Footer", "pages/menus/footer.html"),
     )
 
+Which of these entries is selected for new pages (all are selected by default)
+is controlled by the ``PAGE_MENU_TEMPLATES_DEFAULT`` setting. For example,
+``PAGE_MENU_TEMPLATES_DEFAULT = (1, 3)`` will cause the admin section 
+to pre-select the "Top navigation bar" and the "Footer" when using 
+the example above.
+
 The selections made for the ``in_menus`` field on each page don't
 actually filter a page from being included in the ``page_branch``
 variable that contains the list of pages for the current branch. Instead


### PR DESCRIPTION
Updated the _Filtering Menus_ section to mention the `PAGE_MENU_TEMPLATES_DEFAULT` setting which controls what entries get pre-selected in the admin section.
