### PR TITLE
unicode_literals shouldn't be used in migrations

### DIFF
--- a/mezzanine/blog/migrations/0001_initial.py
+++ b/mezzanine/blog/migrations/0001_initial.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0002_auto.py
+++ b/mezzanine/blog/migrations/0002_auto.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0003_categories.py
+++ b/mezzanine/blog/migrations/0003_categories.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import DataMigration

--- a/mezzanine/blog/migrations/0004_auto__del_field_blogpost_category.py
+++ b/mezzanine/blog/migrations/0004_auto__del_field_blogpost_category.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0005_auto__del_comment__add_field_blogpost_comments_count__chg_field_blogpo.py
+++ b/mezzanine/blog/migrations/0005_auto__del_comment__add_field_blogpost_comments_count__chg_field_blogpo.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0006_auto__del_field_blogpost__keywords__add_field_blogpost_keywords_string.py
+++ b/mezzanine/blog/migrations/0006_auto__del_field_blogpost__keywords__add_field_blogpost_keywords_string.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0007_auto__add_field_blogpost_site.py
+++ b/mezzanine/blog/migrations/0007_auto__add_field_blogpost_site.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0008_auto__add_field_blogpost_rating_average__add_field_blogpost_rating_cou.py
+++ b/mezzanine/blog/migrations/0008_auto__add_field_blogpost_rating_average__add_field_blogpost_rating_cou.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0009_auto__chg_field_blogpost_content.py
+++ b/mezzanine/blog/migrations/0009_auto__chg_field_blogpost_content.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0010_category_site_allow_comments.py
+++ b/mezzanine/blog/migrations/0010_category_site_allow_comments.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0011_comment_site_data.py
+++ b/mezzanine/blog/migrations/0011_comment_site_data.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import DataMigration

--- a/mezzanine/blog/migrations/0012_auto__add_field_blogpost_featured_image.py
+++ b/mezzanine/blog/migrations/0012_auto__add_field_blogpost_featured_image.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0013_auto__chg_field_blogpost_featured_image.py
+++ b/mezzanine/blog/migrations/0013_auto__chg_field_blogpost_featured_image.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0014_auto__add_field_blogpost_gen_description.py
+++ b/mezzanine/blog/migrations/0014_auto__add_field_blogpost_gen_description.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0015_auto__chg_field_blogcategory_title__chg_field_blogcategory_slug__chg_f.py
+++ b/mezzanine/blog/migrations/0015_auto__chg_field_blogcategory_title__chg_field_blogcategory_slug__chg_f.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/blog/migrations/0016_add_field_blogpost__meta_title.py
+++ b/mezzanine/blog/migrations/0016_add_field_blogpost__meta_title.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/blog/migrations/0017_add_field_blogpost__related_posts.py
+++ b/mezzanine/blog/migrations/0017_add_field_blogpost__related_posts.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/blog/migrations/0018_auto__add_field_blogpost_in_sitemap.py
+++ b/mezzanine/blog/migrations/0018_auto__add_field_blogpost_in_sitemap.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/blog/migrations/0019_auto__add_field_blogpost_rating_sum.py
+++ b/mezzanine/blog/migrations/0019_auto__add_field_blogpost_rating_sum.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/blog/migrations/0020_auto__add_field_blogpost_created__add_field_blogpost_updated.py
+++ b/mezzanine/blog/migrations/0020_auto__add_field_blogpost_created__add_field_blogpost_updated.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/conf/migrations/0001_initial.py
+++ b/mezzanine/conf/migrations/0001_initial.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/conf/migrations/0002_auto__add_field_setting_site.py
+++ b/mezzanine/conf/migrations/0002_auto__add_field_setting_site.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/conf/migrations/0003_update_site_setting.py
+++ b/mezzanine/conf/migrations/0003_update_site_setting.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import DataMigration

--- a/mezzanine/conf/migrations/0004_ssl_account_settings_rename.py
+++ b/mezzanine/conf/migrations/0004_ssl_account_settings_rename.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import DataMigration

--- a/mezzanine/core/migrations/0001_initial.py
+++ b/mezzanine/core/migrations/0001_initial.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/core/migrations/0002_auto__del_keyword.py
+++ b/mezzanine/core/migrations/0002_auto__del_keyword.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/core/migrations/0003_auto__add_sitepermission.py
+++ b/mezzanine/core/migrations/0003_auto__add_sitepermission.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/core/migrations/0004_set_site_permissions.py
+++ b/mezzanine/core/migrations/0004_set_site_permissions.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/core/migrations/0005_auto__chg_field_sitepermission_user__del_unique_sitepermission_user.py
+++ b/mezzanine/core/migrations/0005_auto__chg_field_sitepermission_user__del_unique_sitepermission_user.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/forms/migrations/0001_initial.py
+++ b/mezzanine/forms/migrations/0001_initial.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/forms/migrations/0002_auto__add_field_field_placeholder_text.py
+++ b/mezzanine/forms/migrations/0002_auto__add_field_field_placeholder_text.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/forms/migrations/0003_auto__chg_field_field_field_type.py
+++ b/mezzanine/forms/migrations/0003_auto__chg_field_field_field_type.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 from future.builtins import int, str
 import datetime
 from south.db import db

--- a/mezzanine/forms/migrations/0004_auto__chg_field_form_response__chg_field_form_content.py
+++ b/mezzanine/forms/migrations/0004_auto__chg_field_form_response__chg_field_form_content.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/forms/migrations/0005_auto__chg_field_fieldentry_value.py
+++ b/mezzanine/forms/migrations/0005_auto__chg_field_fieldentry_value.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/galleries/migrations/0001_initial.py
+++ b/mezzanine/galleries/migrations/0001_initial.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/generic/migrations/0001_initial.py
+++ b/mezzanine/generic/migrations/0001_initial.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/generic/migrations/0002_auto__add_keyword__add_assignedkeyword.py
+++ b/mezzanine/generic/migrations/0002_auto__add_keyword__add_assignedkeyword.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/generic/migrations/0003_auto__add_rating.py
+++ b/mezzanine/generic/migrations/0003_auto__add_rating.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/generic/migrations/0004_auto__chg_field_rating_object_pk__chg_field_assignedkeyword_object_pk.py
+++ b/mezzanine/generic/migrations/0004_auto__chg_field_rating_object_pk__chg_field_assignedkeyword_object_pk.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 from future.builtins import int, str
 import datetime
 from south.db import db

--- a/mezzanine/generic/migrations/0005_keyword_site.py
+++ b/mezzanine/generic/migrations/0005_keyword_site.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/generic/migrations/0006_move_keywords.py
+++ b/mezzanine/generic/migrations/0006_move_keywords.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import DataMigration

--- a/mezzanine/generic/migrations/0007_auto__add_field_assignedkeyword__order.py
+++ b/mezzanine/generic/migrations/0007_auto__add_field_assignedkeyword__order.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/generic/migrations/0008_set_keyword_order.py
+++ b/mezzanine/generic/migrations/0008_set_keyword_order.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import DataMigration

--- a/mezzanine/generic/migrations/0009_auto__chg_field_keyword_title__chg_field_keyword_slug.py
+++ b/mezzanine/generic/migrations/0009_auto__chg_field_keyword_title__chg_field_keyword_slug.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/generic/migrations/0009_auto__del_field_threadedcomment_email_hash.py
+++ b/mezzanine/generic/migrations/0009_auto__del_field_threadedcomment_email_hash.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/generic/migrations/0010_auto__chg_field_keyword_slug__chg_field_keyword_title.py
+++ b/mezzanine/generic/migrations/0010_auto__chg_field_keyword_slug__chg_field_keyword_title.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/generic/migrations/0011_auto__add_field_threadedcomment_rating_count__add_field_threadedcommen.py
+++ b/mezzanine/generic/migrations/0011_auto__add_field_threadedcomment_rating_count__add_field_threadedcommen.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/generic/migrations/0012_auto__add_field_rating_rating_date.py
+++ b/mezzanine/generic/migrations/0012_auto__add_field_rating_rating_date.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/generic/migrations/0013_auto__add_field_threadedcomment_rating_sum.py
+++ b/mezzanine/generic/migrations/0013_auto__add_field_threadedcomment_rating_sum.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/generic/migrations/0014_auto__add_field_rating_user.py
+++ b/mezzanine/generic/migrations/0014_auto__add_field_rating_user.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/pages/migrations/0001_initial.py
+++ b/mezzanine/pages/migrations/0001_initial.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/pages/migrations/0002_auto__del_field_page__keywords__add_field_page_keywords_string__chg_fi.py
+++ b/mezzanine/pages/migrations/0002_auto__del_field_page__keywords__add_field_page_keywords_string__chg_fi.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/pages/migrations/0003_auto__add_field_page_site.py
+++ b/mezzanine/pages/migrations/0003_auto__add_field_page_site.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/pages/migrations/0004_auto__del_contentpage__add_richtextpage.py
+++ b/mezzanine/pages/migrations/0004_auto__del_contentpage__add_richtextpage.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/pages/migrations/0005_rename_contentpage.py
+++ b/mezzanine/pages/migrations/0005_rename_contentpage.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import DataMigration

--- a/mezzanine/pages/migrations/0006_auto__add_field_page_gen_description.py
+++ b/mezzanine/pages/migrations/0006_auto__add_field_page_gen_description.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/pages/migrations/0007_auto__chg_field_page_slug__chg_field_page_title.py
+++ b/mezzanine/pages/migrations/0007_auto__chg_field_page_slug__chg_field_page_title.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/pages/migrations/0008_auto__add_link.py
+++ b/mezzanine/pages/migrations/0008_auto__add_link.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/pages/migrations/0009_add_field_page_in_menus.py
+++ b/mezzanine/pages/migrations/0009_add_field_page_in_menus.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/pages/migrations/0010_set_menus.py
+++ b/mezzanine/pages/migrations/0010_set_menus.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/pages/migrations/0011_delete_nav_flags.py
+++ b/mezzanine/pages/migrations/0011_delete_nav_flags.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/pages/migrations/0012_add_field_page__meta_title.py
+++ b/mezzanine/pages/migrations/0012_add_field_page__meta_title.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/pages/migrations/0013_auto__add_field_page_in_sitemap.py
+++ b/mezzanine/pages/migrations/0013_auto__add_field_page_in_sitemap.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/pages/migrations/0014_auto__add_field_page_created__add_field_page_updated.py
+++ b/mezzanine/pages/migrations/0014_auto__add_field_page_created__add_field_page_updated.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/mezzanine/twitter/migrations/0001_initial.py
+++ b/mezzanine/twitter/migrations/0001_initial.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/mezzanine/twitter/migrations/0002_auto__chg_field_query_value.py
+++ b/mezzanine/twitter/migrations/0002_auto__chg_field_query_value.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration


### PR DESCRIPTION
Because strings are passed to type(), which requires a non-unicode string in python 2. Fixes #871 refs toastdriven/django-tastypie#1007.
