### PR TITLE
Allow RichTextField widget to be overridden by forms

### DIFF
--- a/mezzanine/core/fields.py
+++ b/mezzanine/core/fields.py
@@ -37,12 +37,13 @@ class RichTextField(models.TextField):
         """
         if "widget" not in kwargs:
             from mezzanine.conf import settings
+            richtext_widget_path = settings.RICHTEXT_WIDGET_CLASS
             try:
-                widget_class = import_dotted_path(settings.RICHTEXT_WIDGET_CLASS)
+                widget_class = import_dotted_path(richtext_widget_path)
             except ImportError:
                 raise ImproperlyConfigured(_("Could not import the value of "
-                                             "settings.RICHTEXT_WIDGET_CLASS: %s"
-                                             % settings.RICHTEXT_WIDGET_CLASS))
+                                             "settings.RICHTEXT_WIDGET_CLASS: "
+                                             "%s" % richtext_widget_path))
             kwargs["widget"] = widget_class()
         kwargs.setdefault("required", False)
         formfield = super(RichTextField, self).formfield(**kwargs)

--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -346,5 +346,7 @@ class CoreTests(TestCase):
 
         richtext_widget = import_dotted_path(settings.RICHTEXT_WIDGET_CLASS)
 
-        self.assertIsInstance(form.fields['text_default'].widget, richtext_widget)
-        self.assertIsInstance(form.fields['text_overridden'].widget, Textarea)
+        self.assertIsInstance(form.fields['text_default'].widget,
+                              richtext_widget)
+        self.assertIsInstance(form.fields['text_overridden'].widget,
+                              Textarea)


### PR DESCRIPTION
This is a simple change which means that `RichTextField` doesn't pull its widget from `settings.RICHTEXT_WIDGET_CLASS` if the `widget` argument is passed to `RichTextField.formfield()`, as it is when a form specifies a widget in its Meta class. Comes with a test for both the default and overridden behaviour.
