### PR TITLE
Better line break and HTML entities handling in form emails

### DIFF
--- a/mezzanine/forms/templates/email/form_response.html
+++ b/mezzanine/forms/templates/email/form_response.html
@@ -6,7 +6,7 @@
 {% for field, value in fields %}
 <tr>
     <td><b>{{ field }}:</b></td>
-    <td>{{ value }}</td>
+    <td>{{ value|linebreaks }}</td>
 </tr>
 {% endfor %}
 </table>

--- a/mezzanine/forms/templates/email/form_response.txt
+++ b/mezzanine/forms/templates/email/form_response.txt
@@ -4,6 +4,6 @@
 {{ message }}
 
 {% endif %}{% for field, value in fields %}
-{{ field }}: {{ value }}
+{{ field }}: {{ value|safe }}
 {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Support line breaks in HTML email (so that they don't collapse when
rendered) and HTML entities in plain text email (unescape them to make
them legible).
