### PR TITLE
Added padding option for thumbnails

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -320,7 +320,6 @@ def thumbnail(image_url, width, height, quality=95, left=0.5, top=0.5, padding=F
         return image_url
 
     f = default_storage.open(image_url)
-    print image_url
     try:
         image = Image.open(f)
     except:


### PR DESCRIPTION
Added optional keyward parameter to thumbnail tag that pads out the image to the right aspect ratio before resize.  This eliminates the cropping effect if it is not desired.

New files are saved in the .thumbnail dir with -padding appended to the end of the file name.
