### PR TITLE
PageMiddleware override

### DIFF
--- a/mezzanine/pages/views.py
+++ b/mezzanine/pages/views.py
@@ -61,10 +61,17 @@ def page(request, slug, template=u"pages/page.html", extra_context=None):
     templates match, the default pages/page.html is used.
     """
 
-    page_middleware = "mezzanine.pages.middleware.PageMiddleware"
+    page_middleware = 'mezzanine.pages.middleware.PageMiddleware'
+
     if page_middleware not in settings.MIDDLEWARE_CLASSES:
         raise ImproperlyConfigured(page_middleware + " is missing from " +
                                    "settings.MIDDLEWARE_CLASSES")
+
+    # Look for PageMiddleware override
+    for middleware in reversed(settings.MIDDLEWARE_CLASSES):
+        if middleware.find('.middleware.PageMiddleware') != -1:
+            page_middleware = middleware
+            break
 
     extra_context = extra_context or {}
     try:


### PR DESCRIPTION
I was trying to use Mako/Plim with Mezzanine but could not find a way to override mezzanine.pages.views.page so I added this.  With this change you can make your own PageMiddleware class that could add templates other than ones with .html extensions. Please correct me if there is a better solution for this.
