### PR TITLE
Disable the 'Add' option of comments in the admin

### DIFF
--- a/mezzanine/generic/admin.py
+++ b/mezzanine/generic/admin.py
@@ -28,6 +28,11 @@ class ThreadedCommentAdmin(CommentsAdmin):
         actions.pop("flag_comments")
         return actions
 
+    # Disable the 'Add' action for this model, fixed a crash if you try
+    # to create a comment from admin panel
+    def has_add_permission(self, request):
+        return False
+
 
 generic_comments = getattr(settings, "COMMENTS_APP", "") == "mezzanine.generic"
 if generic_comments and not settings.COMMENTS_DISQUS_SHORTNAME:


### PR DESCRIPTION
I fixed a crash in mezzanine, in the admin comments section, when you try to create a new comment using the panel, the programa crash:

![screen shot 2014-04-03 at 3 41 54 pm](https://cloud.githubusercontent.com/assets/1445792/2610109/424f4b92-bb81-11e3-8325-650440e158a2.png)

crash !!!

![screen shot 2014-04-03 at 3 42 09 pm](https://cloud.githubusercontent.com/assets/1445792/2610110/517bccb2-bb81-11e3-8b72-01466b325438.png)

The solution is easy, remove the add option for this model in the admin, and the problem not exists more :)

I hope that you can include my solution for fix this error in Mezzanine.

Regards. 
Jesus Anaya
