### PR TITLE
Added USE_L10N check for language dropdowns in admin.

### DIFF
--- a/mezzanine/core/templates/admin/includes/dropdown_menu.html
+++ b/mezzanine/core/templates/admin/includes/dropdown_menu.html
@@ -16,7 +16,7 @@
     {% endfor %}
 </ul>
 
-{% if LANGUAGES|length > 1 %}
+{% if USE_L10N and LANGUAGES|length > 1 %}
 {% get_language_info_list for LANGUAGES as languages %}
 <form>
     <select id="id_language" onchange="window.location.href=this.value;">

--- a/mezzanine/core/templates/admin/login.html
+++ b/mezzanine/core/templates/admin/login.html
@@ -36,7 +36,7 @@
             <input type="password" required  name="password" id="id_password">
             <input type="hidden" name="this_is_the_login_form" value="1" />
         </div>
-        {% if LANGUAGES|length > 1 %}
+        {% if USE_L10N and LANGUAGES|length > 1 %}
         {% get_language_info_list for LANGUAGES as languages %}
         <div class="form-row">
             <label for="id_language" class="required">{% trans "Language" %}:</label>


### PR DESCRIPTION
Checking if LANGUAGES is longer than 1 is a good idea, but I don't think it's enough because when unset the LANGUAGES setting defaults to the full range of languages that Django supports.  When people don't want l10n or i18n, they don't set the LANGUAGES setting, they set USE_L10N to False or USE_I18N to False.  So I made sure the language dropdowns also respect USE_L10N.  I'm pretty sure that USE_L10N is the right setting to check, but let me know if it should be something else.
