### PR TITLE
[#1004] Move Javascript to the Bottom of the Body

### DIFF
--- a/mezzanine/core/templates/base.html
+++ b/mezzanine/core/templates/base.html
@@ -31,17 +31,6 @@
 {% block extra_css %}{% endblock %}
 {% endcompress %}
 
-{% compress js %}
-<script src="{% static "mezzanine/js/"|add:settings.JQUERY_FILENAME %}"></script>
-<script src="{% static "js/bootstrap.js" %}"></script>
-<script src="{% static "js/bootstrap-extras.js" %}"></script>
-{% block extra_js %}{% endblock %}
-{% endcompress %}
-<!--[if lt IE 9]>
-<script src="{% static "js/html5shiv.js" %}"></script>
-<script src="{% static "js/respond.min.js" %}"></script>
-<![endif]-->
-
 {% block extra_head %}{% endblock %}
 </head>
 
@@ -144,7 +133,18 @@
 </div>
 </footer>
 
-{% include "includes/footer_scripts.html" %}
 
+{% compress js %}
+<script src="{% static "mezzanine/js/"|add:settings.JQUERY_FILENAME %}"></script>
+<script src="{% static "js/bootstrap.js" %}"></script>
+<script src="{% static "js/bootstrap-extras.js" %}"></script>
+{% block extra_js %}{% endblock %}
+{% include "includes/footer_scripts.html" %}
+{% endcompress %}
+
+<!--[if lt IE 9]>
+<script src="{% static "js/html5shiv.js" %}"></script>
+<script src="{% static "js/respond.min.js" %}"></script>
+<![endif]-->
 </body>
 </html>

--- a/mezzanine/forms/templates/pages/form.html
+++ b/mezzanine/forms/templates/pages/form.html
@@ -2,13 +2,6 @@
 
 {% load mezzanine_tags %}
 
-{% block extra_js %}
-{{ block.super }}
-<script>
-$(function() {$('.mezzanine-form :input:visible:enabled:first').focus();});
-</script>
-{% endblock %}
-
 {% block main %}
 {{ block.super }}
 {% if request.GET.sent %}
@@ -34,3 +27,10 @@ $(function() {$('.mezzanine-form :input:visible:enabled:first').focus();});
 
 {% endblock %}
 
+
+{% block extra_js %}
+{{ block.super }}
+<script>
+$(function() {$('.mezzanine-form :input:visible:enabled:first').focus();});
+</script>
+{% endblock %}

--- a/mezzanine/galleries/templates/pages/gallery.html
+++ b/mezzanine/galleries/templates/pages/gallery.html
@@ -6,22 +6,6 @@
 <link rel="stylesheet" href="{% static "mezzanine/css/magnific-popup.css" %}">
 {% endblock extra_css %}
 
-{% block extra_js %}
-{{ block.super }}
-<script src="{% static "mezzanine/js/magnific-popup.js" %}"></script>
-<script>
-$(document).ready(function() {
-    $('.gallery').magnificPopup({
-        delegate: 'a',
-        type: 'image',
-        gallery: {
-            enabled: true,
-        }
-    });
-});
-</script>
-{% endblock %}
-
 {% block main %}
 {{ block.super }}
 
@@ -42,3 +26,18 @@ $(document).ready(function() {
 </div>
 {% endblock %}
 
+{% block extra_js %}
+{{ block.super }}
+<script src="{% static "mezzanine/js/magnific-popup.js" %}"></script>
+<script>
+$(document).ready(function() {
+    $('.gallery').magnificPopup({
+        delegate: 'a',
+        type: 'image',
+        gallery: {
+            enabled: true,
+        }
+    });
+});
+</script>
+{% endblock %}

--- a/mezzanine/mobile/templates/mobile/base.html
+++ b/mezzanine/mobile/templates/mobile/base.html
@@ -25,11 +25,6 @@
 {% block extra_css %}{% endblock %}
 {% endcompress %}
 
-{% compress js %}
-<script src="{% static "mezzanine/js/"|add:settings.JQUERY_FILENAME %}"></script>
-<script src="{% static "js/jquery.mobile-1.0a2.js" %}"></script>
-{% endcompress %}
-
 {% block extra_head %}{% endblock %}
 
 </head>
@@ -57,7 +52,11 @@
 
 </div>
 
+{% compress js %}
+<script src="{% static "mezzanine/js/"|add:settings.JQUERY_FILENAME %}"></script>
+<script src="{% static "js/jquery.mobile-1.0a2.js" %}"></script>
 {% include "mobile/includes/footer_scripts.html" %}
+{% endcompress %}
 
 </body>
 </html>


### PR DESCRIPTION
- Move all Javascript includes to the bottom of the base.html and
  mobile/base.html templates.
- Move extra_js blocks below main blocks in the pages/form.html and
  pages/gallery.html templates.

closes #1004: JS should be at the bottom of body
