### PR TITLE
manage.py path issues

### DIFF
--- a/mezzanine/project_template/manage.py
+++ b/mezzanine/project_template/manage.py
@@ -4,14 +4,6 @@ from __future__ import absolute_import, unicode_literals
 import os
 import sys
 
-
-# Corrects some pathing issues in various contexts, such as cron jobs,
-# and the project layout still being in Django 1.3 format.
-from settings import PROJECT_ROOT, PROJECT_DIRNAME
-os.chdir(PROJECT_ROOT)
-sys.path.append(os.path.abspath(os.path.join(PROJECT_ROOT, "..")))
-
-
 # Add the site ID CLI arg to the environment, which allows for the site
 # used in any site related queries to be manually set for management
 # commands.
@@ -23,7 +15,6 @@ for i, arg in enumerate(sys.argv):
 
 # Run Django.
 if __name__ == "__main__":
-    settings_module = "%s.settings" % PROJECT_DIRNAME
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_module)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)

--- a/mezzanine/project_template/settings.py
+++ b/mezzanine/project_template/settings.py
@@ -189,13 +189,10 @@ import os
 # Full filesystem path to the project.
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 
-# Name of the directory for the project.
-PROJECT_DIRNAME = PROJECT_ROOT.split(os.sep)[-1]
-
 # Every cache key will get prefixed with this value - here we set it to
 # the name of the directory the project is in to try and use something
 # project specific.
-CACHE_MIDDLEWARE_KEY_PREFIX = PROJECT_DIRNAME
+CACHE_MIDDLEWARE_KEY_PREFIX = PROJECT_ROOT
 
 # URL prefix for static files.
 # Example: "http://media.lawrence.com/static/"
@@ -217,7 +214,7 @@ MEDIA_URL = STATIC_URL + "media/"
 MEDIA_ROOT = os.path.join(PROJECT_ROOT, *MEDIA_URL.strip("/").split("/"))
 
 # Package/module name to import the root urlpatterns from for the project.
-ROOT_URLCONF = "%s.urls" % PROJECT_DIRNAME
+ROOT_URLCONF = "urls"
 
 # Put strings here, like "/home/html/django_templates"
 # or "C:/www/django/templates".

--- a/mezzanine/project_template/wsgi.py
+++ b/mezzanine/project_template/wsgi.py
@@ -2,8 +2,7 @@ from __future__ import unicode_literals
 
 import os
 
-PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
-settings_module = "%s.settings" % PROJECT_ROOT.split(os.sep)[-1]
+settings_module = "settings"
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_module)
 
 from django.core.wsgi import get_wsgi_application


### PR DESCRIPTION
Stephen,

The Fusionbox project, django-widgy, ran into path issues when someone added widgy to an existing mezzanine site: https://groups.google.com/a/fusionbox.com/forum/#!topic/widgy/7t8TBTff3UM

These proposed changes seemed to work: tests ran fine, I was able to run a cronjob, and the site seems to work just fine. 

Can you review this request to see what potential issues we would run into?

Here is the test mezzanine site with django-widgy: https://github.com/zmetcalf/mezz-to-widgy

Thank you,

Zach Metcalf
