### PR TITLE
Decouple the Blog Post List from RichTextPages

### DIFF
--- a/mezzanine/blog/templates/blog/blog_post_list.html
+++ b/mezzanine/blog/templates/blog/blog_post_list.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load i18n future mezzanine_tags blog_tags keyword_tags disqus_tags %}
 
-{% block meta_title %}{% if page %}{{ page.richtextpage.meta_title }}{% else %}{% trans "Blog" %}{% endif %}{% endblock %}
+{% block meta_title %}{% if page.richtextpage %}{{ page.richtextpage.meta_title }}{% else %}{% trans "Blog" %}{% endif %}{% endblock %}
 
 {% block meta_keywords %}{% metablock %}
 {% keywords_for page as keywords %}
@@ -62,9 +62,11 @@
 {% else %}
     {% if page %}
     {% block blog_post_list_pagecontent %}
-    {% editable page.richtextpage.content %}
-    {{ page.richtextpage.content|richtext_filters|safe }}
-    {% endeditable %}
+    {% if page.richtextpage %}
+        {% editable page.richtextpage.content %}
+        {{ page.richtextpage.content|richtext_filters|safe }}
+        {% endeditable %}
+    {% endif %}
     {% endblock %}
     {% endif %}
 {% endif %}

--- a/mezzanine/blog/tests.py
+++ b/mezzanine/blog/tests.py
@@ -12,7 +12,7 @@ from mezzanine.blog.models import BlogPost
 from mezzanine.conf import settings
 
 from mezzanine.core.models import CONTENT_STATUS_PUBLISHED
-from mezzanine.pages.models import RichTextPage
+from mezzanine.pages.models import Page, RichTextPage
 from mezzanine.utils.tests import TestCase
 
 
@@ -49,3 +49,10 @@ class BlogTests(TestCase):
         self.assertTrue(len(response.redirect_chain) > 0)
         redirect_path = urlparse(response.redirect_chain[0][0]).path
         self.assertEqual(redirect_path, settings.LOGIN_URL)
+
+    def test_blog_post_list_can_use_any_page_type(self):
+        """Test that the blog post list can use any Page type."""
+        slug = settings.BLOG_SLUG or "/"
+        Page.objects.create(title="blog", slug=slug)
+        response = self.client.get(reverse("blog_post_list"))
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
The blog_post_list.html template currently requires that any `page`
context variable passed to it has a `richtextpage` attribute.

These changes modify the template, making the `richtextpage` attribute
optional. This allows users to create other Page types pointing to the
URL of the Blog Post List.
