### PR TITLE
Remove deprecated Debug Toolbar configuration option

### DIFF
--- a/mezzanine/project_template/settings.py
+++ b/mezzanine/project_template/settings.py
@@ -309,8 +309,6 @@ OPTIONAL_APPS = (
     PACKAGE_NAME_GRAPPELLI,
 )
 
-DEBUG_TOOLBAR_CONFIG = {"INTERCEPT_REDIRECTS": False}
-
 ###################
 # DEPLOY SETTINGS #
 ###################


### PR DESCRIPTION
DEBUG_TOOLBAR_CONFIG.INTERCEPT_REDIRECTS has been deprecated. In fact, the Redirect panel is now disabled by default, so we don't need to define the setting any more.

Deprecation notice: http://django-debug-toolbar.readthedocs.org/en/latest/changes.html#deprecated-features

New default value: http://django-debug-toolbar.readthedocs.org/en/latest/configuration.html#toolbar-options
