### PR TITLE
Small css fix for settings admin page.

### DIFF
--- a/mezzanine/core/static/mezzanine/css/admin/global.css
+++ b/mezzanine/core/static/mezzanine/css/admin/global.css
@@ -283,7 +283,7 @@ td, th, th a, label, .help, p.help {
     float: left;
 }
 #settings-form .module {
-    width: 50%;
+    width: 60%;
 }
 #settings-form .help {
     margin-right: 10px;


### PR DESCRIPTION
This is what I get in the settings admin:

![screen shot 2014-05-05 at 12 13 04 pm](https://cloud.githubusercontent.com/assets/94764/2880047/463e930e-d470-11e3-8321-64896f519b5d.png)

This pull request fixes this.
