### PR TITLE
Check if django.contrib.admin is in INSTALLED_APPS

### DIFF
--- a/mezzanine/utils/conf.py
+++ b/mezzanine/utils/conf.py
@@ -171,8 +171,10 @@ def set_dynamic_settings(s):
 
     # Ensure admin is last in the app order so that admin templates
     # are loaded in the correct order.
-    if "django.contrib.admin" in s["INSTALLED_APPS"]:
+    try:
         move("INSTALLED_APPS", "django.contrib.admin", len(s["INSTALLED_APPS"]))
+    except ValueError:
+        pass
 
     # Ensure we have a test runner (removed in Django 1.6)
     s.setdefault("TEST_RUNNER", "django.test.simple.DjangoTestSuiteRunner")


### PR DESCRIPTION
Make sure django.contrib.admin is in INSTALLED_APPS before moving
it to the end of the list. Adding this enables moving admin app
on a different domain.
