### PR TITLE
Move footer_scripts.html back to the footer.

### DIFF
--- a/mezzanine/core/templates/base.html
+++ b/mezzanine/core/templates/base.html
@@ -36,7 +36,6 @@
 <script src="{% static "js/bootstrap.js" %}"></script>
 <script src="{% static "js/bootstrap-extras.js" %}"></script>
 {% block extra_js %}{% endblock %}
-{% include "includes/footer_scripts.html" %}
 {% endcompress %}
 
 <!--[if lt IE 9]>
@@ -145,6 +144,8 @@
 </div>
 </div>
 </footer>
+
+{% include "includes/footer_scripts.html" %}
 
 </body>
 </html>


### PR DESCRIPTION
The last commit which reverted the location of js to the head unintentionally moved the footer scripts include to the head as well.  It does belong in the footer as the current location causes front end editing to break on production sites (when django compressor is enabled).
