### PR TITLE
Fix EmailField front end editing when FORMS_USE_HTML5 is False

### DIFF
--- a/mezzanine/core/forms.py
+++ b/mezzanine/core/forms.py
@@ -116,8 +116,9 @@ def get_edit_form(obj, field_names, data=None, files=None):
     widget_overrides = {
         forms.DateField: fields.DATE,
         forms.DateTimeField: fields.DATE_TIME,
-        forms.EmailField: fields.EMAIL,
     }
+    if getattr(settings, "FORMS_USE_HTML5", False):
+        widget_overrides[forms.EmailField] = fields.EMAIL
 
     class EditForm(forms.ModelForm):
         """


### PR DESCRIPTION
Currently when FORMS_USE_HTML5 is False trying to edit an EmailField with the editable tag results in a KeyError. This is because widget_overrides contains an entry with no corresponding entry in mezzanine.forms.fields.WIDGETS.
