### PR TITLE
add IPv6 config to nginx.conf in project template

### DIFF
--- a/mezzanine/project_template/deploy/nginx.conf
+++ b/mezzanine/project_template/deploy/nginx.conf
@@ -6,7 +6,9 @@ upstream %(proj_name)s {
 server {
 
     listen 80;
+    listen [::]:80;
     %(ssl_disabled)s listen 443 ssl;
+    %(ssl_disabled)s listen [::]:443 ssl;
     server_name %(domains_nginx)s;
     client_max_body_size 10M;
     keepalive_timeout    15;


### PR DESCRIPTION
was doing a deploy on a new linode (which supports IPv6) and discovered this problem. 
After trying some solutions, this was the only one that worked both for IPv4 and IPv6. 

tested with nginx 1.4.6
