### PR TITLE
Support custom User model in AdminLoginInterfaceSelectorMiddleware.

### DIFF
--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -59,7 +59,11 @@ class AdminLoginInterfaceSelectorMiddleware(object):
             if request.user.is_authenticated():
                 if login_type == "admin":
                     next = request.get_full_path()
-                    if (request.user.username == DEFAULT_USERNAME and
+                    try:
+                        username = request.user.get_username()
+                    except AttributeError:  # Django < 1.5
+                        username = request.user.username
+                    if (username == DEFAULT_USERNAME and
                             request.user.check_password(DEFAULT_PASSWORD)):
                         error(request, mark_safe(_(
                               "Your account is using the default password, "


### PR DESCRIPTION
Hi,

I upgraded Mezzanine on one of our projects and ran into an error with the AdminLoginInterfaceSelectorMiddleware.   I know that you want to continue to support the Django 1.4 LTS, so I made sure that this code supports both the new Custom User Model contract and the old User model interface.

I realize that I could just turn off the AdminLoginInterfaceSelectorMiddleware, but then logging in at /admin/ redirects to /accounts/profile/ while I'd much rather it redirect back to the /admin/ center.
