### PR TITLE
Add "device_group" to context via device middleware

### DIFF
--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -20,7 +20,7 @@ from mezzanine.core.models import SitePermission
 from mezzanine.core.management import DEFAULT_USERNAME, DEFAULT_PASSWORD
 from mezzanine.utils.cache import (cache_key_prefix, nevercache_token,
                                    cache_get, cache_set, cache_installed)
-from mezzanine.utils.device import templates_for_device
+from mezzanine.utils.device import templates_for_device, device_from_request
 from mezzanine.utils.sites import current_site_id, templates_for_host
 from mezzanine.utils.urls import next_url
 
@@ -114,6 +114,8 @@ class TemplateForDeviceMiddleware(object):
                 templates = templates_for_device(request,
                     response.template_name)
                 response.template_name = templates
+                response.context_data["device_group"] =
+                    device_from_request(request)
         return response
 
 


### PR DESCRIPTION
#### Motivation

Sometimes it's more convenient to add device awareness to the main template instead of making a separate one. In situations where you just need to remove or add one small piece of HTML it is overkill to make a new block, and then a new template which extends and overrides the block.
#### Pull Request Change

Adds `device_group` as a context variable in TemplateForDeviceMiddleware to make it easy to do minor device aware template changes in a single main template.

Name could also be `device_type`, group was chosen simply to stay somewhat consistent with the documentation.

A future change could be to add `device_user_agent` as well for more fine-grained control. That could be useful even within the device group specific templates in order to disable or enable features specific to a device.
