### PR TITLE
Delete kwargs for page_view

### DIFF
--- a/mezzanine/pages/middleware.py
+++ b/mezzanine/pages/middleware.py
@@ -107,7 +107,7 @@ class PageMiddleware(object):
                 # Matched a non-page urlpattern, but got a 404
                 # for a URL that matches a valid page slug, so
                 # use the page view.
-                response = page_view(request, slug, **view_kwargs)
+                response = page_view(request, slug)
             else:
                 raise
 


### PR DESCRIPTION
This is strange, pass `view_kwargs` form some view to page_view.

I have error if kwargs contin `slug` key or some keys with not exists in page_view kwargs.
