### PR TITLE
added pip instructions to install dev version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,10 @@ dependencies mentioned above::
 
     $ pip install mezzanine
 
+Also you can use pip to install the development version::
+
+    $ pip install -e git+https://github.com/stephenmcd/mezzanine.git#egg=mezzanine-dev
+
 If you prefer, you can download Mezzanine and install it directly from
 source::
 


### PR DESCRIPTION
Hi I added instructions on how to pip install the development version of mezzanine.

Thanks
Andrew
