### PR TITLE
Update italian translation of string "Title"

### DIFF
--- a/mezzanine/core/locale/it/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/it/LC_MESSAGES/django.po
@@ -494,7 +494,7 @@ msgstr "Ordine"
 
 #: models.py:56 models.py:110
 msgid "Title"
-msgstr "Title"
+msgstr "Titolo"
 
 #: models.py:57
 msgid "URL"


### PR DESCRIPTION
String "Title" is not translated into italian django.po. Right translation is "Titolo".
