### PR TITLE
settings.py: additional checks for ImportError when importing local_settings

### DIFF
--- a/mezzanine/project_template/settings.py
+++ b/mezzanine/project_template/settings.py
@@ -342,8 +342,9 @@ OPTIONAL_APPS = (
 # defined per machine.
 try:
     from local_settings import *
-except ImportError:
-    pass
+except ImportError as e:
+    if "local_settings" not in e.message:
+        raise e
 
 
 ####################


### PR DESCRIPTION
In its current state, settings.py catches and ignores all ImportErrors when loading the local settings. While this behavior was intended to deal with a missing local_settings.py, it also hides ImportErrors caused by import
statements _inside_ local_settings.py, e.g.  for setting up deployment-specific ldap authentication.

This simple fix will rethrow any ImportErrors that don't have "local_settings" in their message.
