### PR TITLE
Unpin tzlocal version 1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ try:
             "django >= 1.4.10, != 1.6.0, < 1.7",
             "filebrowser_safe >= 0.3.4",
             "grappelli_safe >= 0.3.12",
-            "tzlocal == 1.0",
+            "tzlocal >= 1.0",
             "bleach >= 1.4",
             "beautifulsoup4 == 4.1.3",
             "requests >= 2.1.0",


### PR DESCRIPTION
I can't see any reason for this to be pinned and not other deps; the [changelog](https://github.com/regebro/tzlocal/blob/master/CHANGES.txt) shows no API changes since 1.0.
