### PR TITLE
Improve handling of non-ASCII characters in import_wordpress script

### DIFF
--- a/mezzanine/blog/management/commands/import_wordpress.py
+++ b/mezzanine/blog/management/commands/import_wordpress.py
@@ -39,7 +39,7 @@ class Command(BaseImporterCommand):
                     decoded_string += decoded
                 else:
                     print "Dropping an undecodable char."
-                    return  ""
+                    return ""
 
         return decoded_string
 


### PR DESCRIPTION
The `import_wordpress` management command crashed on several UTF-8 characters I had in my Wordpress XML export file.

This code runs the relevant bits of XML through a try/catch that attempts to decode to ASCII, then asks the user to manually translate to ASCII if it can't.

Open to suggestions on an automated way to do this - I don't quite understand the mapping of UTF-8 onto ASCII, but doing it manually was sufficient for my purposes.
