### PR TITLE
Fix DoesNotExist when non admin visits /admin

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -600,15 +600,16 @@ def admin_dropdown_menu(context):
     """
     Renders the app list for the admin dropdown menu navigation.
     """
-    context["dropdown_menu_app_list"] = admin_app_list(context["request"])
     user = context["request"].user
-    if user.is_superuser:
-        sites = Site.objects.all()
-    else:
-        sites = user.sitepermissions.get().sites.all()
-    context["dropdown_menu_sites"] = list(sites)
-    context["dropdown_menu_selected_site_id"] = current_site_id()
-    return context
+    if user.is_staff:
+        context["dropdown_menu_app_list"] = admin_app_list(context["request"])
+        if user.is_superuser:
+            sites = Site.objects.all()
+        else:
+            sites = user.sitepermissions.get().sites.all()
+        context["dropdown_menu_sites"] = list(sites)
+        context["dropdown_menu_selected_site_id"] = current_site_id()
+        return context
 
 
 @register.inclusion_tag("admin/includes/app_list.html", takes_context=True)


### PR DESCRIPTION
SitePermission objects are only added when staff users are created.  If a non admin user (with no manually assigned site permissions) visits the admin a DoesNotExist is raised since no site permissions exist for the user.  Therefore the templatetags logic should only run if the user is staff.
