### PR TITLE
Add "fields" argument to a "modelform_factory" in a test

### DIFF
--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -343,9 +343,10 @@ class CoreTests(TestCase):
             text_default = RichTextField()
             text_overridden = RichTextField()
 
-        form_class = modelform_factory(RichTextModel,
-                                       fields="__all__",
-                                       widgets={'text_overridden': Textarea})
+        form_class = modelform_factory(
+            RichTextModel,
+            fields=('text_default', 'text_overridden'),
+            widgets={'text_overridden': Textarea})
         form = form_class()
 
         richtext_widget = import_dotted_path(settings.RICHTEXT_WIDGET_CLASS)


### PR DESCRIPTION
Probably the only 1.8 deprecation warning I'm able to fix without breaking compatibility with 1.5.

The argument is [becoming mandatory](https://docs.djangoproject.com/en/1.7/releases/1.6/#modelform-without-fields-or-exclude). Please note that in general it's not a good idea to patch such cases by adding `fields="__all__"` or `exclude=[]`, but instead one should explicitly specify the used fields (so adding a field to the model later bears no risk of creating a mass-assignment vulnerability). 
