### PR TITLE
encoding value before response.set_cookie()

### DIFF
--- a/mezzanine/utils/views.py
+++ b/mezzanine/utils/views.py
@@ -181,6 +181,6 @@ def set_cookie(response, name, value, expiry_seconds=None, secure=False):
     # https://code.djangoproject.com/ticket/19802
     try:
         response.set_cookie(name, value, expires=expires, secure=secure)
-    except (KeyError, TypeError):
-        response.set_cookie(name.encode('utf-8'), value, expires=expires,
+    except (KeyError, TypeError, UnicodeEncodeError):
+        response.set_cookie(name.encode('utf-8'), value.encode('utf-8'), expires=expires,
                             secure=secure)


### PR DESCRIPTION
only encoding name is not enough.
encoding value is also required.
