### PR TITLE
separate basic gallery functionality

### DIFF
--- a/mezzanine/galleries/models.py
+++ b/mezzanine/galleries/models.py
@@ -38,26 +38,25 @@ if settings.PACKAGE_NAME_FILEBROWSER in settings.INSTALLED_APPS:
         pass
 
 
-class Gallery(Page, RichText):
+class BaseGallery(models.Model):
     """
-    Page bucket for gallery photos.
+    Base gallery functionality.
     """
+
+    class Meta:
+        abstract = True
 
     zip_import = models.FileField(verbose_name=_("Zip import"), blank=True,
         upload_to=upload_to("galleries.Gallery.zip_import", "galleries"),
         help_text=_("Upload a zip file containing images, and "
                     "they'll be imported into this gallery."))
 
-    class Meta:
-        verbose_name = _("Gallery")
-        verbose_name_plural = _("Galleries")
-
     def save(self, delete_zip_import=True, *args, **kwargs):
         """
         If a zip file is uploaded, extract any images from it and add
         them to the gallery, before removing the zip file.
         """
-        super(Gallery, self).save(*args, **kwargs)
+        super(BaseGallery, self).save(*args, **kwargs)
         if self.zip_import:
             zip_file = ZipFile(self.zip_import)
             for name in zip_file.namelist():
@@ -104,6 +103,16 @@ class Gallery(Page, RichText):
             if delete_zip_import:
                 zip_file.close()
                 self.zip_import.delete(save=True)
+
+
+class Gallery(BaseGallery, Page, RichText):
+    """
+    Page bucket for gallery photos.
+    """
+
+    class Meta:
+        verbose_name = _("Gallery")
+        verbose_name_plural = _("Galleries")
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
to be more flexible with creating galleries we can separate gallery
functionality so it can be reused if developer wants to create a
gallery but not necessarily a gallery page
