### PR TITLE
Travis test the latest versions of Django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 env:
-  - DJANGO_VERSION=1.4.13
-  - DJANGO_VERSION=1.5.8
-  - DJANGO_VERSION=1.6.5
+  - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
+  - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.5.x.zip
+  - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.6.x.zip
 python:
   - "2.6"
   - "2.7"
@@ -10,7 +10,7 @@ python:
 matrix:
   exclude:
      - python: "3.3"
-       env: DJANGO_VERSION=1.4.13
+       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
 install:
   - pip install django==$DJANGO_VERSION --use-mirrors
   - pip install . --use-mirrors


### PR DESCRIPTION
This way you don't have to update every time a security release comes
out. I know it's kind of ugly, but this is what we're doing in
https://github.com/fusionbox/django-widgy and it works pretty well for us.

If you want to do this a different way I would understand.
