### PR TITLE
Bugfix: add support for CKEditor and inline editing

### DIFF
--- a/mezzanine/core/static/mezzanine/js/editable.js
+++ b/mezzanine/core/static/mezzanine/js/editable.js
@@ -10,6 +10,19 @@ jQuery(function($) {
     var toolbarElements = toolbar.find('*[id!=editable-toolbar-toggle]');
     var links = $('.editable-link');
 
+    // ensure any unsaved changes to storage area of inline form are discarded
+    $('.editable-form').find('input[value="Cancel"]').click(function() {
+        var the_form = $(this).parent();
+        if (the_form != null) {
+            var content_id = the_form.attr('id');
+            if (content_id != null) {
+                var orig_content = the_form.find('textarea#content-' + content_id).html();
+                var orig_html = $('<div />').html(orig_content).text();
+                the_form.find('iframe').contents().children('html').children('body').html(orig_html);
+            }
+        }
+    });
+
     // Add AJAX submit handler for each editable form.
     $('.editable-form').submit(function() {
         var form = $(this);
@@ -28,6 +41,11 @@ jQuery(function($) {
         loading.show();
         if (typeof tinyMCE != "undefined" ) {
             tinyMCE.triggerSave();
+        }
+        if (typeof CKEDITOR != "undefined") {
+            var content_id = form.attr('id');
+            if (CKEDITOR.instances["content-" + content_id] != "undefined")
+                CKEDITOR.instances["content-" + content_id].updateElement();
         }
         form.ajaxSubmit({success: function(data) {
             if (data && data != '<head></head><body></body>') {


### PR DESCRIPTION
This fix is for support of inline editing using CKEditor - I installed django-ckeditor to use with Mezzanine, set configuration in settings.py, and it worked within the admin UI with no problems. But inline editing would not work and so these are the patches.  I added lines 13-25 to handle an issue if changes you make in the inline editor are not saved, but then you go back to inline editing the same content. It works with TinyMCE as well.

I thought about making a pluggable thing like you suggested, but it doesn't seem reasonable, given how straightforward using django-ckeditor was. I'll write up a short explanation for the docs, but it's not clear where that ought to live so please tell me.

I mentioned some issue with the overlay blocking the modal dialog - it turns out it is an conflict with Bootstrap and animate.css (not mezzanine).  Removing animate.css solves the problem, and haven't found a solution to that yet.
