### PR TITLE
SiteRelated changed to allow explicit site assignment on creation

### DIFF
--- a/mezzanine/core/models.py
+++ b/mezzanine/core/models.py
@@ -53,7 +53,7 @@ class SiteRelated(models.Model):
         created, or the ``update_site`` argument is explicitly set
         to ``True``.
         """
-        if update_site or not self.id:
+        if update_site or (self.id is None and self.site_id is None):
             self.site_id = current_site_id()
         super(SiteRelated, self).save(*args, **kwargs)
 


### PR DESCRIPTION
Added some logic to check for a configured site attribute when saving a new instance. This fixes #1163 while preserving existing model save behaviours.
