### PR TITLE
Made "flake8 ." output less warnings.

### DIFF
--- a/mezzanine/accounts/forms.py
+++ b/mezzanine/accounts/forms.py
@@ -108,7 +108,8 @@ class ProfileForm(Html5Mixin, forms.ModelForm):
                     self.fields[field].required = False
                     if field == "password1":
                         self.fields[field].help_text = ugettext(
-                        "Leave blank unless you want to change your password")
+                                               "Leave blank unless you want "
+                                               "to change your password")
 
         # Add any profile fields to the form.
         try:

--- a/mezzanine/blog/management/commands/import_posterous.py
+++ b/mezzanine/blog/management/commands/import_posterous.py
@@ -23,8 +23,7 @@ class Command(BaseImporterCommand):
         make_option("-p", "--posterous-pass", dest="password",
             help="Posterous Password"),
         make_option("-d", "--posterous-host", dest="hostname",
-            help="Posterous Blog Hostname (no http.. eg. 'foo.com')"
-        ),
+            help="Posterous Blog Hostname (no http.. eg. 'foo.com')"),
     )
     help = "Import Posterous blog posts into the blog app."
 

--- a/mezzanine/core/defaults.py
+++ b/mezzanine/core/defaults.py
@@ -130,8 +130,7 @@ register_setting(
             "TS21i-10", "UP.Browser", "UP.Link", "webOS", "Windows CE",
             "WinWAP", "YahooSeeker/M1A1-R2D2", "iPhone", "iPod", "Android",
             "BlackBerry9530", "LG-TU915 Obigo", "LGE VX", "webOS",
-            "Nokia5800",)
-        ),
+            "Nokia5800",)),
     ),
 )
 

--- a/mezzanine/core/models.py
+++ b/mezzanine/core/models.py
@@ -152,12 +152,12 @@ class MetaData(models.Model):
         for field_type in (RichTextField, models.TextField):
             if not description:
                 for field in self._meta.fields:
-                    if isinstance(field, field_type) and \
-                        field.name != "description":
+                    if (isinstance(field, field_type) and
+                            field.name != "description"):
                         description = getattr(self, field.name)
                         if description:
                             from mezzanine.core.templatetags.mezzanine_tags \
-                            import richtext_filters
+                                                    import richtext_filters
                             description = richtext_filters(description)
                             break
         # Fall back to the title if description couldn't be determined.

--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -397,7 +397,7 @@ class CoreTests(TestCase):
 
     def test_dynamic_inline_admins_fields_tuple(self):
         """
-        Checks if moving the ``_order`` field works with non-mutable sequences.
+        Checks if moving the ``_order`` field works with immutable sequences.
         """
         class MyModelInline(BaseDynamicInlineAdmin, InlineModelAdmin):
             # Any model would work since we're only instantiating the class and

--- a/mezzanine/forms/forms.py
+++ b/mezzanine/forms/forms.py
@@ -356,8 +356,9 @@ class EntriesForm(forms.Form):
 
         # Get the field entries for the given form and filter by entry_time
         # if specified.
-        field_entries = FieldEntry.objects.filter(entry__form=self.form
-            ).order_by("-entry__id").select_related("entry")
+        field_entries = FieldEntry.objects.filter(
+            entry__form=self.form).order_by(
+            "-entry__id").select_related("entry")
         if self.cleaned_data["field_0_filter"] == FILTER_CHOICE_BETWEEN:
             time_from = self.cleaned_data["field_0_from"]
             time_to = self.cleaned_data["field_0_to"]

--- a/mezzanine/project_template/settings.py
+++ b/mezzanine/project_template/settings.py
@@ -152,7 +152,7 @@ AUTHENTICATION_BACKENDS = ("mezzanine.core.auth_backends.MezzanineBackend",)
 STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.FileSystemFinder",
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
-#    'django.contrib.staticfiles.finders.DefaultStorageFinder',
+    # "django.contrib.staticfiles.finders.DefaultStorageFinder",
 )
 
 # The numeric mode to set newly-uploaded files to. The value should be

--- a/mezzanine/twitter/models.py
+++ b/mezzanine/twitter/models.py
@@ -66,7 +66,7 @@ class Query(models.Model):
             QUERY_TYPE_LIST: ("https://api.twitter.com/1.1/lists/statuses.json"
                               "?list_id=%s&include_rts=true" % value),
             QUERY_TYPE_SEARCH: "https://api.twitter.com/1.1/search/tweets.json"
-                                "?q=%s" % value,
+                               "?q=%s" % value,
         }
         try:
             url = urls[self.type]

--- a/mezzanine/utils/docs.py
+++ b/mezzanine/utils/docs.py
@@ -57,14 +57,16 @@ def build_settings_docs(docs_path, prefix=None):
         if isinstance(setting_default, str):
             if gethostname() in setting_default or (
                 setting_default.startswith("/") and
-                os.path.exists(setting_default)):
+                    os.path.exists(setting_default)):
                 setting_default = dynamic
         if setting_default != dynamic:
             setting_default = repr(deep_force_unicode(setting_default))
         lines.extend(["", settings_name, "-" * len(settings_name)])
-        lines.extend(["", urlize(setting["description"] or ""
-            ).replace("<a href=\"", "`"
-            ).replace("\" rel=\"nofollow\">", " <").replace("</a>", ">`_")])
+        lines.extend(["",
+            urlize(setting["description"] or "").replace(
+                "<a href=\"", "`").replace(
+                "\" rel=\"nofollow\">", " <").replace(
+                "</a>", ">`_")])
         if setting["choices"]:
             choices = ", ".join(["%s: ``%s``" % (str(v), force_text(k))
                                  for k, v in setting["choices"]])

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,6 @@
 universal = 1
 
 [flake8]
-exclude = migrations
+exclude = docs/conf.py,migrations
 ignore = E126,E127,E128
-max-complexity = 10
+max-complexity = 20


### PR DESCRIPTION
Mezzanine has syntax checks built into the test suite and that's cool. However, I sometimes run`flake8` manually either due to forgetting about the syntax test or to check some partial changes. This is meant to fix some of its warnings, to make the output easier to scan / scroll.
