### PR TITLE
Load optional apps when testing

### DIFF
--- a/mezzanine/utils/conf.py
+++ b/mezzanine/utils/conf.py
@@ -127,7 +127,7 @@ def set_dynamic_settings(s):
             else:
                 s["INSTALLED_APPS"].append(app)
 
-    # To support migrations for both Django 1.7 and South, Sotuh's old
+    # To support migrations for both Django 1.7 and South, South's old
     # migrations for each app were moved into "app.migrations.south"
     # packages. Here we assign each of these to SOUTH_MIGRATION_MODULES
     # allowing South to find them.


### PR DESCRIPTION
Consider having an app that is best described as optional, but includes some tests. For instance, imagine adding a test to `filebrowser_safe` ;-) Then you could try to test it using:

``` bash
./manage.py test filebrowser_safe
```

but you'd get just a lookup error. Moreover, disabling optional apps might let the tests succeed, where in reality there would be some integration problem.

There surely was / is some argument for excluding optional apps from testing, so the change may be disputable, but I've hit it a few of times already, so would like to have a clear view on the matter.
