### PR TITLE
Confirmation prompts without "return"

### DIFF
--- a/mezzanine/core/management/__init__.py
+++ b/mezzanine/core/management/__init__.py
@@ -69,12 +69,12 @@ def create_pages(app, created_models, verbosity, interactive, **kwargs):
             confirm = input("\nWould you like to install some initial "
                               "demo pages?\nEg: About us, Contact form, "
                               "Gallery. (yes/no): ")
-            while True:
-                if confirm == "yes":
-                    break
-                elif confirm == "no":
-                    return
+            while confirm not in ("yes", "no"):
                 confirm = input("Please enter either 'yes' or 'no': ")
+            install_optional = (confirm == "yes")
+        else:
+            install_optional = True
+        if install_optional:
             install_optional_data(verbosity)
 
 

--- a/mezzanine/core/management/commands/collecttemplates.py
+++ b/mezzanine/core/management/commands/collecttemplates.py
@@ -83,6 +83,7 @@ class Command(BaseCommand):
                                   "\nFrom:    %s"
                                   "\nTo:      %s"
                                   "\n" % (name, path, dest))
+            copy = True
             if options.get("interactive") and os.path.exists(dest):
                 if name in template_src:
                     prev = ' [copied from %s]' % template_src[name]
@@ -92,23 +93,23 @@ class Command(BaseCommand):
                                   (name, app))
                 self.stdout.write("Template exists%s.\n" % prev)
                 confirm = input("Overwrite?  (yes/no/abort): ")
-                while True:
-                    if confirm in ("yes", "no"):
-                        break
-                    elif confirm == "abort":
-                        self.stdout.write("Aborted\n")
-                        return
-                    confirm = input("Please enter either 'yes' or 'no': ")
-                if confirm == "no":
+                while confirm not in ("yes", "no", "abort"):
+                    confirm = input(
+                        "Please enter either 'yes', 'no' or 'abort': ")
+                if confirm == "abort":
+                    self.stdout.write("Aborted\n")
+                    break  # exit templates copying loop
+                elif confirm == "no":
                     self.stdout.write("[Skipped]\n")
-                    continue
-            try:
-                os.makedirs(os.path.dirname(dest))
-            except OSError:
-                pass
-            shutil.copy2(path, dest)
-            template_src[name] = app
-            count += 1
+                    copy = False
+            if copy:
+                try:
+                    os.makedirs(os.path.dirname(dest))
+                except OSError:
+                    pass
+                shutil.copy2(path, dest)
+                template_src[name] = app
+                count += 1
         if verbosity >= 1:
             s = "s" if count != 1 else ""
             self.stdout.write("\nCopied %s template%s\n" % (count, s))

--- a/mezzanine/core/management/commands/createdb.py
+++ b/mezzanine/core/management/commands/createdb.py
@@ -40,14 +40,14 @@ class Command(NoArgsCommand):
                 confirm = input("\nSouth is installed for this project."
                                     "\nWould you like to fake initial "
                                     "migrations? (yes/no): ")
-                while True:
-                    if confirm == "yes":
-                        break
-                    elif confirm == "no":
-                        return
+                while confirm not in ("yes", "no"):
                     confirm = input("Please enter either 'yes' or 'no': ")
-            if verbosity >= 1:
-                print()
-                print("Faking initial migrations ...")
-                print()
-            migrate.Command().execute(fake=True)
+                fake_migrations = (confirm == "yes")
+            else:
+                fake_migrations = True
+            if fake_migrations:
+                if verbosity >= 1:
+                    print()
+                    print("Faking initial migrations ...")
+                    print()
+                migrate.Command().execute(fake=True)


### PR DESCRIPTION
In `create_pages`, `createdb` and `collecttemplates` the user is asked to confirm something (respectively loading initial data, faking initial migrations or overwriting a template). When the user enters "no" / "abort" as the answer the function is returned from. This hinders adding more code at the end of the handler / command.

(In `create_pages` updating translation fields is needed after loading initial data, in the `collecttemplates` the change allows printing "Copied n templates" after an abort.)
