### PR TITLE
Deleting unused keywords as a manager method

### DIFF
--- a/mezzanine/generic/fields.py
+++ b/mezzanine/generic/fields.py
@@ -210,12 +210,8 @@ class KeywordsField(BaseGenericRelation):
         # Convert the data into AssignedKeyword instances.
         if data:
             data = [AssignedKeyword(keyword_id=i) for i in new_ids]
-        # Remove Keyword instances than no longer have a
-        # related AssignedKeyword instance.
-        existing = AssignedKeyword.objects.filter(keyword__id__in=removed_ids)
-        existing_ids = set([str(a.keyword_id) for a in existing])
-        unused_ids = removed_ids - existing_ids
-        Keyword.objects.filter(id__in=unused_ids).delete()
+        # Remove keywords that are no longer assigned to anything.
+        Keyword.objects.delete_unused(removed_ids)
         super(KeywordsField, self).save_form_data(instance, data)
 
     def contribute_to_class(self, cls, name):

--- a/mezzanine/generic/managers.py
+++ b/mezzanine/generic/managers.py
@@ -58,3 +58,14 @@ class KeywordManager(CurrentSiteManager):
             return self.filter(**lookup)[0], False
         except IndexError:
             return self.create(**kwargs), True
+
+    def delete_unused(self, keyword_ids=None):
+        """
+        Removes all instances that are not assigned to any object. Limits
+        processing to ``keyword_ids`` if given.
+        """
+        if keyword_ids is None:
+            keywords = self.all()
+        else:
+            keywords = self.filter(id__in=keyword_ids)
+        keywords.filter(assignments__isnull=True).delete()

--- a/mezzanine/generic/tests.py
+++ b/mezzanine/generic/tests.py
@@ -107,3 +107,17 @@ class GenericTests(TestCase):
         page = RichTextPage.objects.get(id=page.id)
         self.assertEqual(keywords, set(page.keywords_string.split()))
         page.delete()
+
+    def test_delete_unused(self):
+        """
+        Only ``Keyword`` instances without any assignments should be deleted.
+        """
+        assigned_keyword = Keyword.objects.create(title="assigned")
+        Keyword.objects.create(title="unassigned")
+        AssignedKeyword.objects.create(keyword_id=assigned_keyword.id,
+                                       content_object=RichTextPage(pk=1))
+        Keyword.objects.delete_unused(keyword_ids=[assigned_keyword.id])
+        self.assertEqual(Keyword.objects.count(), 2)
+        Keyword.objects.delete_unused()
+        self.assertEqual(Keyword.objects.count(), 1)
+        self.assertEqual(Keyword.objects.all()[0].id, assigned_keyword.id)


### PR DESCRIPTION
The `KeywordField.save_form_data()` method does a bit of maintenance by deleting `Keyword` instances that are no longer assigned to anything. Factoring this out lets one do the clean up independently from the form field (*).

(*) And makes it easier to skip it in `save_form_data()` (the deleting isn't that convenient if your keyword records hold translations).
