### PR TITLE
Use the response context during two-phase rendering

### DIFF
--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -189,7 +189,14 @@ class UpdateCacheMiddleware(object):
                 pass
         if csrf_token:
             request.META["CSRF_COOKIE"] = csrf_token
-        context = RequestContext(request)
+
+        # Use the response context_data if it exists in order to avoid
+        # running all of the context processors again if unnecessary
+        if hasattr(response, "context_data"):
+            context = response.context_data
+        else:
+            context = RequestContext(request)
+
         for i, part in enumerate(parts):
             if i % 2:
                 part = Template(part).render(context).encode("utf-8")


### PR DESCRIPTION
If a response has `context_data` use that instead of creating a new
context and running context processors again.

Running context processors a second time can hurt performance, especially if they cause a round-trip to the database. I believe it should be safe to use the `context_data` from the response, and in fact it may be preferable as it removes the risk of the context changing before the second phase of rendering, which could lead to quirky bugs.
