### PR TITLE
Remove call to set_model_permissions in page admin

### DIFF
--- a/mezzanine/pages/templates/pages/menus/admin.html
+++ b/mezzanine/pages/templates/pages/menus/admin.html
@@ -30,7 +30,6 @@
             <select class="addlist" id="addlink-{{ page.id }}">
                 <option value="">{% trans "Add" %} ...</option>
                 {% for model in page_models %}
-                    {% set_model_permissions model %}
                     {% if model.perms.add %}
                     <option value="{{ model.add_url }}?parent={{ page.id }}"
                         >{{ model.meta_verbose_name|capfirst }}</option>


### PR DESCRIPTION
I think this call is unnecessary, and its omission speeds things up a lot for me. `set_model_permissions` is already called on the same set of objects in page/change_list.html, and is idempotent within a single request.
