### PR TITLE
Prevent inline order setting vs. admin form submission race condition

### DIFF
--- a/mezzanine/core/static/mezzanine/js/admin/dynamic_inline.js
+++ b/mezzanine/core/static/mezzanine/js/admin/dynamic_inline.js
@@ -47,8 +47,7 @@ jQuery(function($) {
     $('.ordering').css({cursor: 'move'});
 
     // Set the value of the _order fields on submit.
-    $('input[type=submit]').click(function(e) {
-        e.preventDefault();
+    $('.dynamic-inline').closest("form").submit(function() {
         if (typeof tinyMCE != 'undefined') {
             tinyMCE.triggerSave();
         }
@@ -67,7 +66,6 @@ jQuery(function($) {
                 }
             });
         });
-        $(this).closest('form').submit();
     });
 
     // Hide the exta inlines.


### PR DESCRIPTION
If the js that sets the order of inlines on an admin page runs slow for any reason the admin form can submit before the order has been set.

This can be simulated by setting a breakpoint inside the current version of the modified click function and clicking save. Although the debugger will hit the breakpoint the page will almost immediately reload since the form continues submitting and the order will not be set.  Setting a breakpoint inside the modified version will work since the default is prevented and the form isn't resubmitted until after ordering has been set.

 An alternative method of fixing this would be to have the order update when inline fields are moved.
