### PR TITLE
If keywords do not save allow admin to force save

### DIFF
--- a/mezzanine/core/static/mezzanine/js/admin/keywords_field.js
+++ b/mezzanine/core/static/mezzanine/js/admin/keywords_field.js
@@ -56,6 +56,12 @@ jQuery(function($) {
             });
         };
         submitKeywords();
+        if (keywordsSaved == false){
+            var force_save = confirm("The keywords did not submit successfully, continue saving?");
+            if (force_save == true) {
+                return true;
+            }
+        }
         return false;
     });
 


### PR DESCRIPTION
If keywords fail to submit for some reason clicking any of the save buttons on an admin page will appear to do nothing.  This commit allows the admin user to choose whether or not to continue saving.  It also makes debugging easier as it makes apparent that there is a problem and what the problem is with.

I just ran into this myself when a client asked to change the admin url.  I changed it but initially forgot to add the new url to the SLL_SSL_FORCE_URL_PREFIXES setting.  In this case the site does use SSL so this broke the admin keywords submit because admin pages were insecure and posting to that secure URL.

You can simulate a broken keyword submit by just deleting everything that is inside the submitKeywords function.

I think that the keyword submit being broken for any reason shouldn't stop the rest of an admin form from saving.  This strikes a nice balance by allowing the user to continue saving, but still alerting them that there is a problem.