### PR TITLE
Fix 500 error when 'comment' view function receives incomplete POST data

### DIFF
--- a/mezzanine/generic/tests.py
+++ b/mezzanine/generic/tests.py
@@ -12,6 +12,7 @@ from mezzanine.core.models import CONTENT_STATUS_PUBLISHED
 from mezzanine.generic.forms import RatingForm
 from mezzanine.generic.models import (AssignedKeyword, Keyword,
                                       ThreadedComment, Rating)
+from mezzanine.generic.views import comment
 from mezzanine.pages.models import RichTextPage
 from mezzanine.utils.tests import TestCase
 
@@ -121,3 +122,12 @@ class GenericTests(TestCase):
         Keyword.objects.delete_unused()
         self.assertEqual(Keyword.objects.count(), 1)
         self.assertEqual(Keyword.objects.all()[0].id, assigned_keyword.id)
+
+    def test_comment_form_returns_400_when_missing_data(self):
+        """
+        Assert 400 status code response when expected data is missing from
+        the comment form. This simulates typical malicious bot behavior.
+        """
+        request = self._request_factory.post(reverse('comment'))
+        response = comment(request)
+        self.assertEquals(response.status_code, 400)

--- a/mezzanine/generic/views.py
+++ b/mezzanine/generic/views.py
@@ -8,7 +8,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.messages import error
 from django.core.urlresolvers import reverse
 from django.db.models import ObjectDoesNotExist
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.http import require_POST
@@ -71,8 +71,11 @@ def initial_validation(request, prefix):
         elif posted_session_key in request.session:
             post_data = request.session.pop(posted_session_key)
     if not redirect_url:
+        model_data = post_data.get("content_type", "").split(".", 1)
+        if len(model_data) != 2:
+            return HttpResponseBadRequest()
         try:
-            model = get_model(*post_data.get("content_type", "").split(".", 1))
+            model = get_model(*model_data)
             obj = model.objects.get(id=post_data.get("object_pk", None))
         except (TypeError, ObjectDoesNotExist, LookupError):
             redirect_url = "/"


### PR DESCRIPTION
This is related to the problem expressed in issue #1159.

The view which responds to the "/comment/" URL doesn't validate the "content_type" parameter of the POST data it receives before processing it.  As a result, if POST is either missing the "content_type" parameter, or that parameter is malformed, then the view will produce an error.

The fix implemented for issue #1159 avoids the 500 error for GET requests by enforcing that the method only responds to POST.  However, the underlying code problem still exists.  A malicious bot that receives a 405 Method Not Allowed response to a GET request (as it now will for this URL), will typically read the response headers, and if POST is allowed, then attempt a POST request to continue probing the web server for spam opportunities or other weaknesses.

Under the current code, these POST requests will continue to produce 500 server errors.  The web server should respond with a 400 Bad Request response instead.  That's what this patch does.  A related test for the situation is included too.