### PR TITLE
Test with Py 3.4, Django 1.7 and default runners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,19 @@ env:
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.5.x.zip
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.6.x.zip
+  - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.7.x.zip
 python:
   - "2.6"
   - "2.7"
   - "3.3"
+  - "3.4"
 matrix:
   exclude:
+     - python: "2.6"
+       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.7.x.zip
      - python: "3.3"
+       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
+     - python: "3.4"
        env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
 install:
   - pip install $DJANGO_VERSION --use-mirrors

--- a/mezzanine/bin/runtests.py
+++ b/mezzanine/bin/runtests.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals
+
 import atexit
 import os
+import shutil
 import sys
+
 import django
 
 
@@ -17,6 +20,10 @@ def main(package="mezzanine"):
     os.environ["DJANGO_SETTINGS_MODULE"] = "project_template.test_settings"
     package_path = path_for_import(package)
     project_path = os.path.join(package_path, "project_template")
+
+    # Create local_settings.py so it is imported by settings.py
+    local_settings_path = os.path.join(project_path, "local_settings.py")
+    shutil.copy(local_settings_path + ".template", local_settings_path)
 
     test_settings_path = os.path.join(project_path, "test_settings.py")
 
@@ -42,18 +49,15 @@ DATABASES = {'default': {'ENGINE': 'django.db.backends.sqlite3'}}
 # needs to be turned on for the contrib.auth tests to pass in Django 1.4.
 PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',
                     'django.contrib.auth.hashers.SHA1PasswordHasher')
-
-# These just need to be defined as something.
-SECRET_KEY = "django_tests_secret_key"
-NEVERCACHE_KEY = "django_tests_nevercache_key"
 """
 
         with open(test_settings_path, "w") as f:
             f.write(test_settings)
 
         def cleanup_test_settings():
-            os.remove(test_settings_path)
-            os.remove(test_settings_path + 'c')
+            for fn in [test_settings_path, local_settings_path]:
+                os.remove(fn)
+                os.remove(fn + 'c')
         atexit.register(cleanup_test_settings)
 
     if django.VERSION >= (1, 7):

--- a/mezzanine/bin/runtests.py
+++ b/mezzanine/bin/runtests.py
@@ -38,8 +38,10 @@ if "mezzanine.accounts" not in settings.INSTALLED_APPS:
 # Use an in-memory database for tests.
 DATABASES = {'default': {'ENGINE': 'django.db.backends.sqlite3'}}
 
-# Use the md5 password hasher for quicker test runs.
-PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',)
+# Use the MD5 password hasher by default for quicker test runs. SHA1 still
+# needs to be turned on for the contrib.auth tests to pass in Django 1.4.
+PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',
+                    'django.contrib.auth.hashers.SHA1PasswordHasher')
 
 # These just need to be defined as something.
 SECRET_KEY = "django_tests_secret_key"

--- a/mezzanine/bin/runtests.py
+++ b/mezzanine/bin/runtests.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 import atexit
 import os
-import shutil
 import sys
 import django
 
@@ -19,26 +18,44 @@ def main(package="mezzanine"):
     package_path = path_for_import(package)
     project_path = os.path.join(package_path, "project_template")
 
-    local_settings_path = os.path.join(project_path, "local_settings.py")
     test_settings_path = os.path.join(project_path, "test_settings.py")
 
     sys.path.insert(0, package_path)
-    sys.path.insert(0, project_path)
     if not os.path.exists(test_settings_path):
-        shutil.copy(local_settings_path + ".template", test_settings_path)
-        with open(test_settings_path, "r") as f:
-            local_settings = f.read()
-        with open(test_settings_path, "w") as f:
-            test_reqs_str = """
+        # Import all our normal settings, and make a few test-specific tweaks.
+        # require Mezzanine's accounts app, use the md5 password hasher to
+        # speed up tests, use in-memory databases, and define an "other" db.
+        test_settings = """
 from project_template import settings
-globals().update(settings.__dict__)
+
+globals().update(i for i in settings.__dict__.items() if i[0].isupper())
+
+# Require the mezzanine.accounts app. We use settings.INSTALLED_APPS here so
+# the syntax test doesn't complain about an undefined name.
 if "mezzanine.accounts" not in settings.INSTALLED_APPS:
     INSTALLED_APPS = list(settings.INSTALLED_APPS) + ["mezzanine.accounts"]
+
+# Use an in-memory database for tests.
+DATABASES = {'default': {'ENGINE': 'django.db.backends.sqlite3'}}
+
+# Use the md5 password hasher for quicker test runs.
+PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',)
+
+# These just need to be defined as something.
+SECRET_KEY = "django_tests_secret_key"
+NEVERCACHE_KEY = "django_tests_nevercache_key"
 """
-            if django.VERSION >= (1, 7):
-                test_reqs_str += "import django\ndjango.setup()"
-            f.write(test_reqs_str + local_settings)
-        atexit.register(lambda: os.remove(test_settings_path))
+
+        with open(test_settings_path, "w") as f:
+            f.write(test_settings)
+
+        def cleanup_test_settings():
+            os.remove(test_settings_path)
+            os.remove(test_settings_path + 'c')
+        atexit.register(cleanup_test_settings)
+
+    if django.VERSION >= (1, 7):
+        django.setup()
 
     from django.core.management.commands import test
     sys.exit(test.Command().execute(verbosity=1))

--- a/mezzanine/project_template/settings.py
+++ b/mezzanine/project_template/settings.py
@@ -343,7 +343,7 @@ OPTIONAL_APPS = (
 # ignored in your version control system allowing for settings to be
 # defined per machine.
 try:
-    from local_settings import *
+    from .local_settings import *
 except ImportError as e:
     if "local_settings" not in str(e):
         raise e

--- a/mezzanine/utils/conf.py
+++ b/mezzanine/utils/conf.py
@@ -203,9 +203,6 @@ def set_dynamic_settings(s):
         except ValueError:
             pass
 
-    # Ensure we have a test runner (removed in Django 1.6)
-    s.setdefault("TEST_RUNNER", "django.test.simple.DjangoTestSuiteRunner")
-
     # Add missing apps if existing apps depend on them.
     if "mezzanine.blog" in s["INSTALLED_APPS"]:
         append("INSTALLED_APPS", "mezzanine.generic")


### PR DESCRIPTION
This commit updates the Travis config to test under Python 3.4 and Django 1.7.

Though not yet necessary for 1.7, it also updates the test script to work with the old ``DjangoTestSuiteRunner`` and the new default ``DiscoverRunner`` introduced in Django 1.6. ``DjangoTestSuiteRunner`` is removed in 1.8. I've removed the line that specifies ``settings.TEST_RUNNER``, so the default runner will be used under each version of Django.

The ``DjangoTestSuiteRunner`` would run all the tests in ``django.contrib`` as well as Mezzanine's tests – ``DiscoverRunner`` doesn't do this.