### PR TITLE
Backwards-compatible 1.8 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,19 @@ env:
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.5.x.zip
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.6.x.zip
+  - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.7.x.zip
 python:
   - "2.6"
   - "2.7"
   - "3.3"
+  - "3.4"
 matrix:
   exclude:
+     - python: "2.6"
+       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.7.x.zip
      - python: "3.3"
+       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
+     - python: "3.4"
        env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
 install:
   - pip install $DJANGO_VERSION --use-mirrors

--- a/mezzanine/bin/runtests.py
+++ b/mezzanine/bin/runtests.py
@@ -38,8 +38,10 @@ if "mezzanine.accounts" not in settings.INSTALLED_APPS:
 # Use an in-memory database for tests.
 DATABASES = {'default': {'ENGINE': 'django.db.backends.sqlite3'}}
 
-# Use the md5 password hasher for quicker test runs.
-PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',)
+# Use the MD5 password hasher by default for quicker test runs. SHA1 still
+# needs to be turned on for the contrib.auth tests to pass in Django 1.4.
+PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',
+                    'django.contrib.auth.hashers.SHA1PasswordHasher')
 
 # These just need to be defined as something.
 SECRET_KEY = "django_tests_secret_key"

--- a/mezzanine/bin/runtests.py
+++ b/mezzanine/bin/runtests.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 import atexit
 import os
-import shutil
 import sys
 import django
 
@@ -19,26 +18,44 @@ def main(package="mezzanine"):
     package_path = path_for_import(package)
     project_path = os.path.join(package_path, "project_template")
 
-    local_settings_path = os.path.join(project_path, "local_settings.py")
     test_settings_path = os.path.join(project_path, "test_settings.py")
 
     sys.path.insert(0, package_path)
-    sys.path.insert(0, project_path)
     if not os.path.exists(test_settings_path):
-        shutil.copy(local_settings_path + ".template", test_settings_path)
-        with open(test_settings_path, "r") as f:
-            local_settings = f.read()
-        with open(test_settings_path, "w") as f:
-            test_reqs_str = """
+        # Import all our normal settings, and make a few test-specific tweaks.
+        # require Mezzanine's accounts app, use the md5 password hasher to
+        # speed up tests, use in-memory databases, and define an "other" db.
+        test_settings = """
 from project_template import settings
-globals().update(settings.__dict__)
+
+globals().update(i for i in settings.__dict__.items() if i[0].isupper())
+
+# Require the mezzanine.accounts app. We use settings.INSTALLED_APPS here so
+# the syntax test doesn't complain about an undefined name.
 if "mezzanine.accounts" not in settings.INSTALLED_APPS:
     INSTALLED_APPS = list(settings.INSTALLED_APPS) + ["mezzanine.accounts"]
+
+# Use an in-memory database for tests.
+DATABASES = {'default': {'ENGINE': 'django.db.backends.sqlite3'}}
+
+# Use the md5 password hasher for quicker test runs.
+PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',)
+
+# These just need to be defined as something.
+SECRET_KEY = "django_tests_secret_key"
+NEVERCACHE_KEY = "django_tests_nevercache_key"
 """
-            if django.VERSION >= (1, 7):
-                test_reqs_str += "import django\ndjango.setup()"
-            f.write(test_reqs_str + local_settings)
-        atexit.register(lambda: os.remove(test_settings_path))
+
+        with open(test_settings_path, "w") as f:
+            f.write(test_settings)
+
+        def cleanup_test_settings():
+            os.remove(test_settings_path)
+            os.remove(test_settings_path + 'c')
+        atexit.register(cleanup_test_settings)
+
+    if django.VERSION >= (1, 7):
+        django.setup()
 
     from django.core.management.commands import test
     sys.exit(test.Command().execute(verbosity=1))

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -14,10 +14,19 @@ from django.contrib.sites.models import Site
 from django.core.files import File
 from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse, resolve, NoReverseMatch
-from django.template import (Context, Node, TextNode, Template,
-    TemplateSyntaxError, TOKEN_TEXT, TOKEN_VAR, TOKEN_COMMENT, TOKEN_BLOCK)
 from django.db.models import Model
 from django.db.models.loading import get_model
+from django.template import Context, Node, Template, TemplateSyntaxError
+
+try:
+    # Django >= 1.8
+    from django.template.base import (TOKEN_BLOCK, TOKEN_COMMENT,
+                                      TOKEN_TEXT, TOKEN_VAR, TextNode)
+except ImportError:
+    # Django <= 1.7
+    from django.template import (TOKEN_BLOCK, TOKEN_COMMENT,
+                                 TOKEN_TEXT, TOKEN_VAR, TextNode)
+
 from django.template.defaultfilters import escape
 from django.template.loader import get_template
 from django.utils import translation

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -14,9 +14,10 @@ from django.contrib.sites.models import Site
 from django.core.files import File
 from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse, resolve, NoReverseMatch
-from django.db.models import Model, get_model
 from django.template import (Context, Node, TextNode, Template,
     TemplateSyntaxError, TOKEN_TEXT, TOKEN_VAR, TOKEN_COMMENT, TOKEN_BLOCK)
+from django.db.models import Model
+from django.db.models.loading import get_model
 from django.template.defaultfilters import escape
 from django.template.loader import get_template
 from django.utils import translation

--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -406,7 +406,7 @@ class CoreTests(TestCase):
             fields = ('a', '_order', 'b')
 
         request = self._request_factory.get('/admin/')
-        inline = MyModelInline(None, None)
+        inline = MyModelInline(None, AdminSite())
         fields = inline.get_fieldsets(request)[0][1]['fields']
         self.assertSequenceEqual(fields, ('a', 'b', '_order'))
 
@@ -420,7 +420,7 @@ class CoreTests(TestCase):
             fields = ('a', 'b')
 
         request = self._request_factory.get('/admin/')
-        inline = MyModelInline(None, None)
+        inline = MyModelInline(None, AdminSite())
         fields = inline.get_fieldsets(request)[0][1]['fields']
         self.assertSequenceEqual(fields, ('a', 'b', '_order'))
 
@@ -435,7 +435,7 @@ class CoreTests(TestCase):
                          ("Fieldset 3", {'fields': ('c')}))
 
         request = self._request_factory.get('/admin/')
-        inline = MyModelInline(None, None)
+        inline = MyModelInline(None, AdminSite())
         fieldsets = inline.get_fieldsets(request)
         self.assertEqual(fieldsets[-1][1]["fields"][-1], '_order')
         self.assertNotIn('_order', fieldsets[1][1]["fields"])

--- a/mezzanine/generic/fields.py
+++ b/mezzanine/generic/fields.py
@@ -80,8 +80,13 @@ class BaseGenericRelation(GenericRelation):
                 # contribute_to_class needs to be idempotent. We
                 # don't call get_all_field_names() which fill the app
                 # cache get_fields_with_model() is safe.
-                if name_string in [i.name for i, _ in
-                                   cls._meta.get_fields_with_model()]:
+                try:
+                    # Django >= 1.8
+                    extant_fields = cls._meta._forward_fields_map
+                except AttributeError:
+                    # Django <= 1.7
+                    extant_fields = (i.name for i in cls._meta.fields)
+                if name_string in extant_fields:
                     continue
                 if field.verbose_name is None:
                     field.verbose_name = self.verbose_name

--- a/mezzanine/pages/tests.py
+++ b/mezzanine/pages/tests.py
@@ -24,6 +24,14 @@ User = get_user_model()
 
 class PagesTests(TestCase):
 
+    @staticmethod
+    def reset_queries(connection):
+        try:
+            # Django 1.8+ - queries_log is a deque
+            connection.queries_log.clear()
+        except AttributeError:
+            connection.queries = []
+
     def test_page_ascendants(self):
         """
         Test the methods for looking up ascendants efficiently
@@ -44,7 +52,7 @@ class PagesTests(TestCase):
 
         # Test ascendants are returned in order for slug, using
         # a single DB query.
-        connection.queries = []
+        self.reset_queries(connection)
         pages_for_slug = Page.objects.with_ascendants_for_slug(tertiary.slug)
         self.assertEqual(len(connection.queries), 1)
         self.assertEqual(pages_for_slug[0].id, tertiary.id)
@@ -53,7 +61,7 @@ class PagesTests(TestCase):
 
         # Test page.get_ascendants uses the cached attribute,
         # without any more queries.
-        connection.queries = []
+        self.reset_queries(connection)
         ascendants = pages_for_slug[0].get_ascendants()
         self.assertEqual(len(connection.queries), 0)
         self.assertEqual(ascendants[0].id, secondary.id)
@@ -66,7 +74,7 @@ class PagesTests(TestCase):
         secondary.save()
         pages_for_slug = Page.objects.with_ascendants_for_slug(tertiary.slug)
         self.assertEqual(len(pages_for_slug[0]._ascendants), 0)
-        connection.queries = []
+        self.reset_queries(connection)
         ascendants = pages_for_slug[0].get_ascendants()
         self.assertEqual(len(connection.queries), 2)  # 2 parent queries
         self.assertEqual(pages_for_slug[0].id, tertiary.id)

--- a/mezzanine/template/__init__.py
+++ b/mezzanine/template/__init__.py
@@ -110,7 +110,8 @@ class Library(template.Library):
                             else:
                                 ts = templates_for_device(request, name)
                                 t = select_template(ts)
-                            self.nodelist = t.nodelist
+
+                            self.template = t
                         parts = [template.Variable(part).resolve(context)
                                  for part in token.split_contents()[1:]]
                         if takes_context:
@@ -118,7 +119,7 @@ class Library(template.Library):
                         result = tag_func(*parts)
                         autoescape = context.autoescape
                         context = context_class(result, autoescape=autoescape)
-                        return self.nodelist.render(context)
+                        return self.template.render(context)
 
                 return InclusionTagNode()
             return self.tag(tag_wrapper)

--- a/mezzanine/template/loader_tags.py
+++ b/mezzanine/template/loader_tags.py
@@ -5,7 +5,6 @@ import os
 
 from django.template import Template, TemplateSyntaxError, TemplateDoesNotExist
 from django.template.loader_tags import ExtendsNode
-from django.template.loader import find_template_loader
 
 from mezzanine import template
 
@@ -47,7 +46,21 @@ class OverExtendsNode(ExtendsNode):
 
         # These imports want settings, which aren't available when this
         # module is imported to ``add_to_builtins``, so do them here.
-        from django.template.loaders.app_directories import app_template_dirs
+        import django.template.loaders.app_directories as app_directories
+        try:
+            # Django >= 1.8
+            app_template_dirs = app_directories.get_app_template_dirs
+        except AttributeError:
+            # Django <= 1.7
+            app_template_dirs = app_directories.app_template_dirs
+
+        try:
+            # Django >= 1.8
+            find_template_loader = context.engine.find_template_loader
+        except AttributeError:
+            # Django <= 1.7
+            from django.template.loaders import find_template_loader
+
         from mezzanine.conf import settings
 
         # Store a dictionary in the template context mapping template

--- a/mezzanine/utils/conf.py
+++ b/mezzanine/utils/conf.py
@@ -203,9 +203,6 @@ def set_dynamic_settings(s):
         except ValueError:
             pass
 
-    # Ensure we have a test runner (removed in Django 1.6)
-    s.setdefault("TEST_RUNNER", "django.test.simple.DjangoTestSuiteRunner")
-
     # Add missing apps if existing apps depend on them.
     if "mezzanine.blog" in s["INSTALLED_APPS"]:
         append("INSTALLED_APPS", "mezzanine.generic")

--- a/mezzanine/utils/tests.py
+++ b/mezzanine/utils/tests.py
@@ -72,23 +72,37 @@ class TestCase(BaseTestCase):
         self._emailaddress = "example@example.com"
         args = (self._username, self._emailaddress, self._password)
         self._user = User.objects.create_superuser(*args)
-        self._debug_cursor = connection.use_debug_cursor
         self._request_factory = RequestFactory()
-        connection.use_debug_cursor = True
+
+        try:
+            # Django 1.8+
+            self._debug_cursor = connection.force_debug_cursor
+            connection.force_debug_cursor = True
+        except AttributeError:
+            self._debug_cursor = connection.use_debug_cursor
+            connection.use_debug_cursor = True
 
     def tearDown(self):
         """
         Clean up the admin user created and debug cursor.
         """
         self._user.delete()
-        connection.use_debug_cursor = self._debug_cursor
+        try:
+            # Django 1.8+
+            connection.force_debug_cursor = self._debug_cursor
+        except AttributeError:
+            connection.use_debug_cursor = self._debug_cursor
 
     def queries_used_for_template(self, template, **context):
         """
         Return the number of queries used when rendering a template
         string.
         """
-        connection.queries = []
+        try:
+            # Django 1.8+ - queries_log is a deque
+            connection.queries_log.clear()
+        except AttributeError:
+            connection.queries = []
         t = Template(template)
         t.render(Context(context))
         return len(connection.queries)


### PR DESCRIPTION
This is a collection of shims and changes to support Django 1.8 that should all be compatible with existing code and able to be safely merged. This PR also includes the changes in #1200.

Django 1.8's removal of ``django.contrib.comments`` is not easily backward-compatible to 1.4, so is not addressed here.