### PR TITLE
Support comments under Django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,19 @@ env:
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.5.x.zip
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.6.x.zip
+  - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.7.x.zip
 python:
   - "2.6"
   - "2.7"
   - "3.3"
+  - "3.4"
 matrix:
   exclude:
+     - python: "2.6"
+       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.7.x.zip
      - python: "3.3"
+       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
+     - python: "3.4"
        env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
 install:
   - pip install $DJANGO_VERSION --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.5.x.zip
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.6.x.zip
   - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.7.x.zip
+  - DJANGO_VERSION=https://github.com/django/django/archive/stable/1.8.x.zip
 python:
   - "2.6"
   - "2.7"
@@ -13,6 +14,8 @@ matrix:
   exclude:
      - python: "2.6"
        env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.7.x.zip
+     - python: "2.6"
+       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.8.x.zip
      - python: "3.3"
        env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
      - python: "3.4"

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -96,8 +96,8 @@ Threaded Comments
 =================
 
 Threaded comments provided by the ``mezzanine.generic`` app are an
-extension of Django's `django.contrib.comments
-<https://docs.djangoproject.com/en/dev/ref/contrib/comments/>`_ app.
+extension of Django's `django_comments
+<https://github.com/django/django-contrib-comments>`_ app.
 Mezzanine's threaded comments fundamentally extend Django's comments
 to allow for threaded conversations, where comments can be made in
 reply to other comments.

--- a/mezzanine/bin/runtests.py
+++ b/mezzanine/bin/runtests.py
@@ -38,8 +38,10 @@ if "mezzanine.accounts" not in settings.INSTALLED_APPS:
 # Use an in-memory database for tests.
 DATABASES = {'default': {'ENGINE': 'django.db.backends.sqlite3'}}
 
-# Use the md5 password hasher for quicker test runs.
-PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',)
+# Use the MD5 password hasher by default for quicker test runs. SHA1 still
+# needs to be turned on for the contrib.auth tests to pass in Django 1.4.
+PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',
+                    'django.contrib.auth.hashers.SHA1PasswordHasher')
 
 # These just need to be defined as something.
 SECRET_KEY = "django_tests_secret_key"

--- a/mezzanine/bin/runtests.py
+++ b/mezzanine/bin/runtests.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 import atexit
 import os
-import shutil
 import sys
 import django
 
@@ -19,26 +18,44 @@ def main(package="mezzanine"):
     package_path = path_for_import(package)
     project_path = os.path.join(package_path, "project_template")
 
-    local_settings_path = os.path.join(project_path, "local_settings.py")
     test_settings_path = os.path.join(project_path, "test_settings.py")
 
     sys.path.insert(0, package_path)
-    sys.path.insert(0, project_path)
     if not os.path.exists(test_settings_path):
-        shutil.copy(local_settings_path + ".template", test_settings_path)
-        with open(test_settings_path, "r") as f:
-            local_settings = f.read()
-        with open(test_settings_path, "w") as f:
-            test_reqs_str = """
+        # Import all our normal settings, and make a few test-specific tweaks.
+        # require Mezzanine's accounts app, use the md5 password hasher to
+        # speed up tests, use in-memory databases, and define an "other" db.
+        test_settings = """
 from project_template import settings
-globals().update(settings.__dict__)
+
+globals().update(i for i in settings.__dict__.items() if i[0].isupper())
+
+# Require the mezzanine.accounts app. We use settings.INSTALLED_APPS here so
+# the syntax test doesn't complain about an undefined name.
 if "mezzanine.accounts" not in settings.INSTALLED_APPS:
     INSTALLED_APPS = list(settings.INSTALLED_APPS) + ["mezzanine.accounts"]
+
+# Use an in-memory database for tests.
+DATABASES = {'default': {'ENGINE': 'django.db.backends.sqlite3'}}
+
+# Use the md5 password hasher for quicker test runs.
+PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',)
+
+# These just need to be defined as something.
+SECRET_KEY = "django_tests_secret_key"
+NEVERCACHE_KEY = "django_tests_nevercache_key"
 """
-            if django.VERSION >= (1, 7):
-                test_reqs_str += "import django\ndjango.setup()"
-            f.write(test_reqs_str + local_settings)
-        atexit.register(lambda: os.remove(test_settings_path))
+
+        with open(test_settings_path, "w") as f:
+            f.write(test_settings)
+
+        def cleanup_test_settings():
+            os.remove(test_settings_path)
+            os.remove(test_settings_path + 'c')
+        atexit.register(cleanup_test_settings)
+
+    if django.VERSION >= (1, 7):
+        django.setup()
 
     from django.core.management.commands import test
     sys.exit(test.Command().execute(verbosity=1))

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -14,10 +14,19 @@ from django.contrib.sites.models import Site
 from django.core.files import File
 from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse, resolve, NoReverseMatch
-from django.template import (Context, Node, TextNode, Template,
-    TemplateSyntaxError, TOKEN_TEXT, TOKEN_VAR, TOKEN_COMMENT, TOKEN_BLOCK)
 from django.db.models import Model
 from django.db.models.loading import get_model
+from django.template import Context, Node, Template, TemplateSyntaxError
+
+try:
+    # Django >= 1.8
+    from django.template.base import (TOKEN_BLOCK, TOKEN_COMMENT,
+                                      TOKEN_TEXT, TOKEN_VAR, TextNode)
+except ImportError:
+    # Django <= 1.7
+    from django.template import (TOKEN_BLOCK, TOKEN_COMMENT,
+                                 TOKEN_TEXT, TOKEN_VAR, TextNode)
+
 from django.template.defaultfilters import escape
 from django.template.loader import get_template
 from django.utils import translation

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -14,9 +14,10 @@ from django.contrib.sites.models import Site
 from django.core.files import File
 from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse, resolve, NoReverseMatch
-from django.db.models import Model, get_model
 from django.template import (Context, Node, TextNode, Template,
     TemplateSyntaxError, TOKEN_TEXT, TOKEN_VAR, TOKEN_COMMENT, TOKEN_BLOCK)
+from django.db.models import Model
+from django.db.models.loading import get_model
 from django.template.defaultfilters import escape
 from django.template.loader import get_template
 from django.utils import translation

--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -406,7 +406,7 @@ class CoreTests(TestCase):
             fields = ('a', '_order', 'b')
 
         request = self._request_factory.get('/admin/')
-        inline = MyModelInline(None, None)
+        inline = MyModelInline(None, AdminSite())
         fields = inline.get_fieldsets(request)[0][1]['fields']
         self.assertSequenceEqual(fields, ('a', 'b', '_order'))
 
@@ -420,7 +420,7 @@ class CoreTests(TestCase):
             fields = ('a', 'b')
 
         request = self._request_factory.get('/admin/')
-        inline = MyModelInline(None, None)
+        inline = MyModelInline(None, AdminSite())
         fields = inline.get_fieldsets(request)[0][1]['fields']
         self.assertSequenceEqual(fields, ('a', 'b', '_order'))
 
@@ -435,7 +435,7 @@ class CoreTests(TestCase):
                          ("Fieldset 3", {'fields': ('c')}))
 
         request = self._request_factory.get('/admin/')
-        inline = MyModelInline(None, None)
+        inline = MyModelInline(None, AdminSite())
         fieldsets = inline.get_fieldsets(request)
         self.assertEqual(fieldsets[-1][1]["fields"][-1], '_order')
         self.assertNotIn('_order', fieldsets[1][1]["fields"])

--- a/mezzanine/generic/__init__.py
+++ b/mezzanine/generic/__init__.py
@@ -5,7 +5,7 @@ contenttypes framework, such as comments, keywords/tags and voting.
 """
 from __future__ import unicode_literals
 
-# These methods are part of the API for django.contrib.comments
+# These methods are part of the API for django_comments
 
 
 def get_model():

--- a/mezzanine/generic/admin.py
+++ b/mezzanine/generic/admin.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
-from django.contrib.comments.admin import CommentsAdmin
+from django_comments.admin import CommentsAdmin
 from django.utils.translation import ugettext_lazy as _
 
 from mezzanine.conf import settings

--- a/mezzanine/generic/fields.py
+++ b/mezzanine/generic/fields.py
@@ -80,8 +80,13 @@ class BaseGenericRelation(GenericRelation):
                 # contribute_to_class needs to be idempotent. We
                 # don't call get_all_field_names() which fill the app
                 # cache get_fields_with_model() is safe.
-                if name_string in [i.name for i, _ in
-                                   cls._meta.get_fields_with_model()]:
+                try:
+                    # Django >= 1.8
+                    extant_fields = cls._meta._forward_fields_map
+                except AttributeError:
+                    # Django <= 1.7
+                    extant_fields = (i.name for i in cls._meta.fields)
+                if name_string in extant_fields:
                     continue
                 if field.verbose_name is None:
                     field.verbose_name = self.verbose_name

--- a/mezzanine/generic/forms.py
+++ b/mezzanine/generic/forms.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 from future.builtins import int, str, zip
 
 from django import forms
-from django.contrib.comments.forms import CommentSecurityForm, CommentForm
-from django.contrib.comments.signals import comment_was_posted
+from django_comments.forms import CommentSecurityForm, CommentForm
+from django_comments.signals import comment_was_posted
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext, ugettext_lazy as _
 

--- a/mezzanine/generic/managers.py
+++ b/mezzanine/generic/managers.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from django.contrib.comments.managers import CommentManager as DjangoCM
+from django_comments.managers import CommentManager as DjangoCM
 
 from mezzanine.conf import settings
 from mezzanine.core.managers import CurrentSiteManager

--- a/mezzanine/generic/migrations/0001_initial.py
+++ b/mezzanine/generic/migrations/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ('sites', '0001_initial'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('comments', '__first__'),
+        ('django_comments', '__first__'),
         ('contenttypes', '0001_initial'),
     ]
 
@@ -61,7 +61,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ThreadedComment',
             fields=[
-                ('comment_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='comments.Comment')),
+                ('comment_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='django_comments.Comment')),
                 ('rating_count', models.IntegerField(default=0, editable=False)),
                 ('rating_sum', models.IntegerField(default=0, editable=False)),
                 ('rating_average', models.FloatField(default=0, editable=False)),
@@ -72,7 +72,7 @@ class Migration(migrations.Migration):
                 'verbose_name': 'Comment',
                 'verbose_name_plural': 'Comments',
             },
-            bases=('comments.comment',),
+            bases=('django_comments.comment',),
         ),
         migrations.AddField(
             model_name='assignedkeyword',

--- a/mezzanine/generic/models.py
+++ b/mezzanine/generic/models.py
@@ -1,12 +1,13 @@
 from __future__ import unicode_literals
 from future.builtins import map, str
 
-from django.contrib.comments.models import Comment
 from django.contrib.contenttypes.generic import GenericForeignKey
 from django.db import models
 from django.template.defaultfilters import truncatewords_html
 from django.utils.translation import ugettext, ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
+
+from django_comments import Comment
 
 from mezzanine.generic.fields import RatingField
 from mezzanine.generic.managers import CommentManager, KeywordManager
@@ -18,7 +19,7 @@ from mezzanine.utils.sites import current_site_id
 
 class ThreadedComment(Comment):
     """
-    Extend the ``Comment`` model from ``django.contrib.comments`` to
+    Extend the ``Comment`` model from ``django_comments`` to
     add comment threading. ``Comment`` provides its own site foreign key,
     so we can't inherit from ``SiteRelated`` in ``mezzanine.core``, and
     therefore need to set the site on ``save``. ``CommentManager``

--- a/mezzanine/pages/tests.py
+++ b/mezzanine/pages/tests.py
@@ -24,6 +24,14 @@ User = get_user_model()
 
 class PagesTests(TestCase):
 
+    @staticmethod
+    def reset_queries(connection):
+        try:
+            # Django 1.8+ - queries_log is a deque
+            connection.queries_log.clear()
+        except AttributeError:
+            connection.queries = []
+
     def test_page_ascendants(self):
         """
         Test the methods for looking up ascendants efficiently
@@ -44,7 +52,7 @@ class PagesTests(TestCase):
 
         # Test ascendants are returned in order for slug, using
         # a single DB query.
-        connection.queries = []
+        self.reset_queries(connection)
         pages_for_slug = Page.objects.with_ascendants_for_slug(tertiary.slug)
         self.assertEqual(len(connection.queries), 1)
         self.assertEqual(pages_for_slug[0].id, tertiary.id)
@@ -53,7 +61,7 @@ class PagesTests(TestCase):
 
         # Test page.get_ascendants uses the cached attribute,
         # without any more queries.
-        connection.queries = []
+        self.reset_queries(connection)
         ascendants = pages_for_slug[0].get_ascendants()
         self.assertEqual(len(connection.queries), 0)
         self.assertEqual(ascendants[0].id, secondary.id)
@@ -66,7 +74,7 @@ class PagesTests(TestCase):
         secondary.save()
         pages_for_slug = Page.objects.with_ascendants_for_slug(tertiary.slug)
         self.assertEqual(len(pages_for_slug[0]._ascendants), 0)
-        connection.queries = []
+        self.reset_queries(connection)
         ascendants = pages_for_slug[0].get_ascendants()
         self.assertEqual(len(connection.queries), 2)  # 2 parent queries
         self.assertEqual(pages_for_slug[0].id, tertiary.id)

--- a/mezzanine/template/__init__.py
+++ b/mezzanine/template/__init__.py
@@ -110,7 +110,8 @@ class Library(template.Library):
                             else:
                                 ts = templates_for_device(request, name)
                                 t = select_template(ts)
-                            self.nodelist = t.nodelist
+
+                            self.template = t
                         parts = [template.Variable(part).resolve(context)
                                  for part in token.split_contents()[1:]]
                         if takes_context:
@@ -118,7 +119,7 @@ class Library(template.Library):
                         result = tag_func(*parts)
                         autoescape = context.autoescape
                         context = context_class(result, autoescape=autoescape)
-                        return self.nodelist.render(context)
+                        return self.template.render(context)
 
                 return InclusionTagNode()
             return self.tag(tag_wrapper)

--- a/mezzanine/template/loader_tags.py
+++ b/mezzanine/template/loader_tags.py
@@ -5,7 +5,6 @@ import os
 
 from django.template import Template, TemplateSyntaxError, TemplateDoesNotExist
 from django.template.loader_tags import ExtendsNode
-from django.template.loader import find_template_loader
 
 from mezzanine import template
 
@@ -47,7 +46,21 @@ class OverExtendsNode(ExtendsNode):
 
         # These imports want settings, which aren't available when this
         # module is imported to ``add_to_builtins``, so do them here.
-        from django.template.loaders.app_directories import app_template_dirs
+        import django.template.loaders.app_directories as app_directories
+        try:
+            # Django >= 1.8
+            app_template_dirs = app_directories.get_app_template_dirs
+        except AttributeError:
+            # Django <= 1.7
+            app_template_dirs = app_directories.app_template_dirs
+
+        try:
+            # Django >= 1.8
+            find_template_loader = context.engine.find_template_loader
+        except AttributeError:
+            # Django <= 1.7
+            from django.template.loaders import find_template_loader
+
         from mezzanine.conf import settings
 
         # Store a dictionary in the template context mapping template

--- a/mezzanine/utils/conf.py
+++ b/mezzanine/utils/conf.py
@@ -203,9 +203,6 @@ def set_dynamic_settings(s):
         except ValueError:
             pass
 
-    # Ensure we have a test runner (removed in Django 1.6)
-    s.setdefault("TEST_RUNNER", "django.test.simple.DjangoTestSuiteRunner")
-
     # Add missing apps if existing apps depend on them.
     if "mezzanine.blog" in s["INSTALLED_APPS"]:
         append("INSTALLED_APPS", "mezzanine.generic")

--- a/mezzanine/utils/conf.py
+++ b/mezzanine/utils/conf.py
@@ -208,7 +208,7 @@ def set_dynamic_settings(s):
         append("INSTALLED_APPS", "mezzanine.generic")
     if "mezzanine.generic" in s["INSTALLED_APPS"]:
         s.setdefault("COMMENTS_APP", "mezzanine.generic")
-        append("INSTALLED_APPS", "django.contrib.comments")
+        append("INSTALLED_APPS", "django_comments")
 
     # Ensure mezzanine.boot is first.
     try:

--- a/mezzanine/utils/tests.py
+++ b/mezzanine/utils/tests.py
@@ -72,23 +72,37 @@ class TestCase(BaseTestCase):
         self._emailaddress = "example@example.com"
         args = (self._username, self._emailaddress, self._password)
         self._user = User.objects.create_superuser(*args)
-        self._debug_cursor = connection.use_debug_cursor
         self._request_factory = RequestFactory()
-        connection.use_debug_cursor = True
+
+        try:
+            # Django 1.8+
+            self._debug_cursor = connection.force_debug_cursor
+            connection.force_debug_cursor = True
+        except AttributeError:
+            self._debug_cursor = connection.use_debug_cursor
+            connection.use_debug_cursor = True
 
     def tearDown(self):
         """
         Clean up the admin user created and debug cursor.
         """
         self._user.delete()
-        connection.use_debug_cursor = self._debug_cursor
+        try:
+            # Django 1.8+
+            connection.force_debug_cursor = self._debug_cursor
+        except AttributeError:
+            connection.use_debug_cursor = self._debug_cursor
 
     def queries_used_for_template(self, template, **context):
         """
         Return the number of queries used when rendering a template
         string.
         """
-        connection.queries = []
+        try:
+            # Django 1.8+ - queries_log is a deque
+            connection.queries_log.clear()
+        except AttributeError:
+            connection.queries = []
         t = Template(template)
         t.render(Context(context))
         return len(connection.queries)

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ try:
         packages=find_packages(),
         install_requires=[
             "django >= 1.4.10, != 1.6.0",
+            "django-contrib-comments",
             "filebrowser_safe >= 0.3.4",
             "grappelli_safe >= 0.3.12",
             "tzlocal >= 1.0",


### PR DESCRIPTION
The comments app has been broken out into an external package in Django 1.8, available at https://github.com/django/django-contrib-comments.

However, the new standalone comments app requires Django 1.5 or above, so if we include django-contrib-comments as a dependency, we can't use Django 1.4 as it will be automatically upgraded. I've posted to the distutils-sig mailing list to see if there's any easy solution.

In the meantime, this PR will need to be modified to use whichever comments app is available instead of only using the external package as it does now. This might cause a bit of a headache with migrations, because the app name is different: ``"comments"`` in the contrib version, and ``"django_comments"`` in the standalone version.