### PR TITLE
Allow 'site_id' arg when importing blog

### DIFF
--- a/mezzanine/blog/management/base.py
+++ b/mezzanine/blog/management/base.py
@@ -154,6 +154,14 @@ class BaseImporterCommand(BaseCommand):
         verbosity = int(options.get("verbosity", 1))
         prompt = options.get("interactive")
 
+        # If site id is passed get that site
+        try:
+            site = int(site)
+        except ValueError:
+            pass
+        else:
+            site = Site.objects.get(id=site)
+
         # Validate the Mezzanine user.
         if mezzanine_user is None:
             raise CommandError("No Mezzanine user has been specified")

--- a/mezzanine/blog/management/base.py
+++ b/mezzanine/blog/management/base.py
@@ -150,7 +150,7 @@ class BaseImporterCommand(BaseCommand):
         """
 
         mezzanine_user = options.get("mezzanine_user")
-        site = Site.objects.get_current()
+        site = options.get("site_id", Site.objects.get_current())
         verbosity = int(options.get("verbosity", 1))
         prompt = options.get("interactive")
 

--- a/mezzanine/blog/management/base.py
+++ b/mezzanine/blog/management/base.py
@@ -160,7 +160,10 @@ class BaseImporterCommand(BaseCommand):
         except ValueError:
             pass
         else:
-            site = Site.objects.get(id=site)
+            try:
+                site = Site.objects.get(id=site)
+            except Site.DoesNotExist:
+                raise CommandError("No Site with id %s" % str(site))
 
         # Validate the Mezzanine user.
         if mezzanine_user is None:


### PR DESCRIPTION
- Useful for users running multiple sites from a single mezzanine
  instance to map imports from multiple blogs