### PR TITLE
KeyError when excluding first_name, last_name, and username fields

### DIFF
--- a/mezzanine/accounts/forms.py
+++ b/mezzanine/accounts/forms.py
@@ -192,8 +192,9 @@ class ProfileForm(Html5Mixin, forms.ModelForm):
             self.cleaned_data["username"]
         except KeyError:
             if not self.instance.username:
-                username = "%(first_name)s %(last_name)s" % self.cleaned_data
-                if not username.strip():
+                if "first_name" in self.cleaned_data and "last_name" in self.cleaned_data:
+                    username = "%(first_name)s %(last_name)s" % self.cleaned_data
+                else:
                     username = self.cleaned_data["email"].split("@")[0]
                 qs = User.objects.exclude(id=self.instance.id)
                 user.username = unique_slug(qs, "username", slugify(username))


### PR DESCRIPTION
I was using ACCOUNTS_PROFILE_FORM_EXCLUDE_FIELDS and ACCOUNTS_NO_USERNAME settings so that I only needed an email and password.  I got snagged on a key error where save is assuming first_name and last_name are set.