### PR TITLE
Delete cached context settings on settings update

### DIFF
--- a/mezzanine/conf/admin.py
+++ b/mezzanine/conf/admin.py
@@ -8,6 +8,7 @@ from django.utils.encoding import force_text
 
 from mezzanine.conf.models import Setting
 from mezzanine.conf.forms import SettingsForm
+from mezzanine.utils.cache import cache_delete, cache_installed
 from mezzanine.utils.urls import admin_url
 
 
@@ -37,6 +38,8 @@ class SettingsAdmin(admin.ModelAdmin):
         if settings_form.is_valid():
             settings_form.save()
             info(request, _("Settings were successfully updated."))
+            if cache_installed():
+                cache_delete("context-settings")
             return self.changelist_redirect()
         extra_context["settings_form"] = settings_form
         extra_context["title"] = u"%s %s" % (

--- a/mezzanine/conf/admin.py
+++ b/mezzanine/conf/admin.py
@@ -8,7 +8,8 @@ from django.utils.encoding import force_text
 
 from mezzanine.conf.models import Setting
 from mezzanine.conf.forms import SettingsForm
-from mezzanine.utils.cache import cache_delete, cache_installed
+from mezzanine.utils.cache import (cache_delete, cache_installed,
+                                   cache_key_prefix)
 from mezzanine.utils.urls import admin_url
 
 
@@ -39,7 +40,9 @@ class SettingsAdmin(admin.ModelAdmin):
             settings_form.save()
             info(request, _("Settings were successfully updated."))
             if cache_installed():
-                cache_delete("context-settings")
+                cache_key = (cache_key_prefix(request, ignore_device=True) +
+                             "context-settings")
+                cache_delete(cache_key)
             return self.changelist_redirect()
         extra_context["settings_form"] = settings_form
         extra_context["title"] = u"%s %s" % (

--- a/mezzanine/conf/context_processors.py
+++ b/mezzanine/conf/context_processors.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
-from mezzanine.utils.cache import (cache_key_prefix, cache_installed,
-                                   cache_get, cache_set)
+from mezzanine.utils.cache import cache_installed, cache_get, cache_set
 
 
 # Deprecated settings and their defaults.

--- a/mezzanine/conf/context_processors.py
+++ b/mezzanine/conf/context_processors.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
-from mezzanine.utils.cache import cache_installed, cache_get, cache_set
+from mezzanine.utils.cache import (cache_key_prefix, cache_installed,
+                                   cache_get, cache_set)
 
 
 # Deprecated settings and their defaults.
@@ -35,7 +36,8 @@ def settings(request=None):
     settings_dict = None
     cache_settings = request and cache_installed()
     if cache_settings:
-        cache_key = "context-settings"
+        cache_key = (cache_key_prefix(request, ignore_device=True) +
+            "context-settings")
         settings_dict = cache_get(cache_key)
     if not settings_dict:
         settings.use_editable()

--- a/mezzanine/conf/context_processors.py
+++ b/mezzanine/conf/context_processors.py
@@ -36,7 +36,7 @@ def settings(request=None):
     settings_dict = None
     cache_settings = request and cache_installed()
     if cache_settings:
-        cache_key = cache_key_prefix(request) + "context-settings"
+        cache_key = "context-settings"
         settings_dict = cache_get(cache_key)
     if not settings_dict:
         settings.use_editable()

--- a/mezzanine/utils/cache.py
+++ b/mezzanine/utils/cache.py
@@ -55,6 +55,13 @@ def cache_get(key):
     return value
 
 
+def cache_delete(key):
+    """
+    Wrapper for ``cache.delete``.
+    """
+    return cache.delete(_hashed_key(key))
+
+
 def cache_installed():
     """
     Returns ``True`` if a cache backend is configured, and the

--- a/mezzanine/utils/cache.py
+++ b/mezzanine/utils/cache.py
@@ -74,16 +74,20 @@ def cache_installed():
     )).issubset(set(settings.MIDDLEWARE_CLASSES))
 
 
-def cache_key_prefix(request):
+def cache_key_prefix(request, ignore_device=False):
     """
     Cache key for Mezzanine's cache middleware. Adds the current
-    device and site ID.
+    device and site ID, unless ignore_device is True in which case
+    it will only add the current site ID.
     """
-    cache_key = "%s.%s.%s." % (
+    cache_key = "%s.%s." % (
         settings.CACHE_MIDDLEWARE_KEY_PREFIX,
         current_site_id(),
-        device_from_request(request) or "default",
     )
+
+    if not ignore_device:
+        cache_key += (device_from_request(request) or "default") + "."
+
     return _i18n_cache_key_suffix(request, cache_key)
 
 


### PR DESCRIPTION
#### Overview

With editable settings it is best to invalidate the context settings cache key when settings have been changed via the admin panel so that they can take effect immediately.

#### Discussion

There's a change here to the name of the key under which context settings are cached. This was so that it could be deleted from the admin changelist. I don't **think** there is anything wrong with the key name change. Before it would be prefixed with the device type and the site ID, but I don't believe either of those would result in different settings values? I don't know of any way to make a setting device type or site specific. If that holds true, then this will also increase cache hits for different device types.