### PR TITLE
Fabric enhancements

### DIFF
--- a/docs/fabfile.rst
+++ b/docs/fabfile.rst
@@ -1,7 +1,7 @@
   * ``fab all`` - Installs everything required on a new system and deploy.
   * ``fab apt`` - Installs one or more system packages via apt.
-  * ``fab backup`` - Backs up the database.
-  * ``fab create`` - Create a new virtual environment for a project.
+  * ``fab backup`` - Backs up the project database.
+  * ``fab create`` - Creates the environment needed to host the project.
   * ``fab deploy`` - Deploy latest version of the project.
   * ``fab install`` - Installs the base system and Python requirements for the entire server.
   * ``fab manage`` - Runs a Django management command.
@@ -10,7 +10,8 @@
   * ``fab python`` - Runs Python code in the project's virtual environment, with Django loaded.
   * ``fab remove`` - Blow away the current project.
   * ``fab restart`` - Restart gunicorn worker processes for the project.
-  * ``fab restore`` - Restores the database.
+  * ``fab restore`` - Restores the project database from a previous backup.
   * ``fab rollback`` - Reverts project state to the last deploy.
   * ``fab run`` - Runs a shell comand on the remote server.
-  * ``fab sudo`` - Runs a command as sudo.
+  * ``fab secure`` - Minimal security steps for brand new servers.
+  * ``fab sudo`` - Runs a command as sudo on the remote server.

--- a/mezzanine/project_template/deploy/crontab
+++ b/mezzanine/project_template/deploy/crontab
@@ -1,1 +1,3 @@
+# Poll Twitter every 5 minutes
+# Comment-out if you don't use Mezzanine's Twitter app
 */5 * * * * %(user)s %(manage)s poll_twitter

--- a/mezzanine/project_template/deploy/gunicorn.conf.py.template
+++ b/mezzanine/project_template/deploy/gunicorn.conf.py.template
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 import multiprocessing
 
-bind = "127.0.0.1:%(gunicorn_port)s"
-workers = multiprocessing.cpu_count() * 2 + 1
+bind = "unix:%(proj_path)s/gunicorn.sock"
+workers = %(num_workers)s
+errorlog = "/home/%(user)s/logs/%(proj_name)s_error.log"
 loglevel = "error"
 proc_name = "%(proj_name)s"

--- a/mezzanine/project_template/deploy/nginx.conf
+++ b/mezzanine/project_template/deploy/nginx.conf
@@ -1,6 +1,6 @@
 
 upstream %(proj_name)s {
-    server 127.0.0.1:%(gunicorn_port)s;
+    server unix:%(proj_path)s/gunicorn.sock fail_timeout=0;
 }
 
 server {
@@ -10,6 +10,7 @@ server {
     server_name %(domains_nginx)s;
     client_max_body_size 10M;
     keepalive_timeout    15;
+    error_log /home/%(user)s/logs/%(proj_name)s_error_nginx.log info;
 
     %(ssl_disabled)s ssl_certificate      conf/%(proj_name)s.crt;
     %(ssl_disabled)s ssl_certificate_key  conf/%(proj_name)s.key;
@@ -17,6 +18,11 @@ server {
     %(ssl_disabled)s ssl_session_timeout  10m;
     %(ssl_disabled)s ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
     %(ssl_disabled)s ssl_prefer_server_ciphers on;
+
+    # Deny illegal Host headers
+    if ($host !~* ^(%(domains_regex)s)$) {
+        return 444;
+    }
 
     location / {
         proxy_redirect      off;
@@ -31,6 +37,7 @@ server {
         root            %(proj_path)s;
         access_log      off;
         log_not_found   off;
+        expires 30d;
     }
 
     location /robots.txt {

--- a/mezzanine/project_template/deploy/supervisor.conf
+++ b/mezzanine/project_template/deploy/supervisor.conf
@@ -1,11 +1,9 @@
-[group:%(proj_name)s]
-programs=gunicorn_%(proj_name)s
-
 [program:gunicorn_%(proj_name)s]
-command=%(venv_path)s/bin/gunicorn_django -c gunicorn.conf.py -p gunicorn.pid
+command=%(venv_path)s/bin/gunicorn -c gunicorn.conf.py -p gunicorn.pid wsgi:application
 directory=%(proj_path)s
 user=%(user)s
 autostart=true
+stdout_logfile = /home/%(user)s/logs/%(proj_name)s_supervisor
 autorestart=true
 redirect_stderr=true
 environment=LANG="%(locale)s",LC_ALL="%(locale)s",LC_LANG="%(locale)s"

--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, unicode_literals
-from future.builtins import input, open
+from future.builtins import open
 
 import os
 import re
@@ -10,9 +10,14 @@ from glob import glob
 from contextlib import contextmanager
 from posixpath import join
 
-from fabric.api import env, cd, prefix, sudo as _sudo, run as _run, hide, task
+from fabric.api import abort, env, cd, prefix, sudo as _sudo, run as _run, \
+    hide, task, local
+from fabric.context_managers import settings as fab_settings
+from fabric.contrib.console import confirm
 from fabric.contrib.files import exists, upload_template
+from fabric.contrib.project import rsync_project
 from fabric.colors import yellow, green, blue, red
+from fabric.decorators import hosts
 
 
 ################
@@ -40,23 +45,30 @@ env.key_filename = conf.get("SSH_KEY_PATH", None)
 env.hosts = conf.get("HOSTS", [""])
 
 env.proj_name = conf.get("PROJECT_NAME", os.getcwd().split(os.sep)[-1])
-env.venv_home = conf.get("VIRTUALENV_HOME", "/home/%s" % env.user)
-env.venv_path = "%s/%s" % (env.venv_home, env.proj_name)
-env.proj_dirname = "project"
-env.proj_path = "%s/%s" % (env.venv_path, env.proj_dirname)
-env.manage = "%s/bin/python %s/project/manage.py" % ((env.venv_path,) * 2)
+env.venv_home = conf.get("VIRTUALENV_HOME", "/home/%s/.virtualenvs" % env.user)
+env.venv_path = join(env.venv_home, env.proj_name)
+env.proj_path = "/home/%s/mezzanine/%s" % (env.user, env.proj_name)
+env.manage = "%s/bin/python %s/manage.py" % (env.venv_path, env.proj_path)
 env.domains = conf.get("DOMAINS", [conf.get("LIVE_HOSTNAME", env.hosts[0])])
 env.domains_nginx = " ".join(env.domains)
+env.domains_regex = "|".join(env.domains)
 env.domains_python = ", ".join(["'%s'" % s for s in env.domains])
 env.ssl_disabled = "#" if len(env.domains) > 1 else ""
-env.repo_url = conf.get("REPO_URL", "")
-env.git = env.repo_url.startswith("git") or env.repo_url.endswith(".git")
+env.vcs_tools = ["git", "hg"]
+env.deploy_tool = conf.get("DEPLOY_TOOL", "rsync")
 env.reqs_path = conf.get("REQUIREMENTS_PATH", None)
-env.gunicorn_port = conf.get("GUNICORN_PORT", 8000)
 env.locale = conf.get("LOCALE", "en_US.UTF-8")
+env.num_workers = conf.get("NUM_WORKERS",
+                           "multiprocessing.cpu_count() * 2 + 1")
 
 env.secret_key = conf.get("SECRET_KEY", "")
 env.nevercache_key = conf.get("NEVERCACHE_KEY", "")
+
+# Remote git repos need to be "bare" and reside separated from the project
+if env.deploy_tool == "git":
+    env.repo_path = "/home/%s/git/%s.git" % (env.user, env.proj_name)
+else:
+    env.repo_path = env.proj_path
 
 
 ##################
@@ -76,7 +88,7 @@ templates = {
     "supervisor": {
         "local_path": "deploy/supervisor.conf",
         "remote_path": "/etc/supervisor/conf.d/%(proj_name)s.conf",
-        "reload_command": "supervisorctl reload",
+        "reload_command": "supervisorctl restart gunicorn_%(proj_name)s",
     },
     "cron": {
         "local_path": "deploy/crontab",
@@ -115,7 +127,7 @@ def project():
     Runs commands within the project's directory.
     """
     with virtualenv():
-        with cd(env.proj_dirname):
+        with cd(env.proj_path):
             yield
 
 
@@ -165,25 +177,25 @@ def print_command(command):
 
 
 @task
-def run(command, show=True):
+def run(command, show=True, *args, **kwargs):
     """
     Runs a shell comand on the remote server.
     """
     if show:
         print_command(command)
     with hide("running"):
-        return _run(command)
+        return _run(command, *args, **kwargs)
 
 
 @task
-def sudo(command, show=True):
+def sudo(command, show=True, *args, **kwargs):
     """
-    Runs a command as sudo.
+    Runs a command as sudo on the remote server.
     """
     if show:
         print_command(command)
     with hide("running"):
-        return _sudo(command)
+        return _sudo(command, *args, **kwargs)
 
 
 def log_call(func):
@@ -207,7 +219,7 @@ def get_templates():
 
 def upload_template_and_reload(name):
     """
-    Uploads a template only if it has changed, and if so, reload a
+    Uploads a template only if it has changed, and if so, reload the
     related service.
     """
     template = get_templates()[name]
@@ -242,6 +254,46 @@ def upload_template_and_reload(name):
         sudo(reload_command)
 
 
+def rsync_upload():
+    """
+    Uploads the project with rsync excluding some files and folders.
+    """
+    excludes = ["*.pyc", "*.pyo", "*.db", ".DS_Store", ".coverage",
+                "local_settings.py", "/static", "/.git", "/.hg"]
+    local_dir = os.getcwd() + os.sep
+    return rsync_project(remote_dir=env.proj_path, local_dir=local_dir,
+                         exclude=excludes)
+
+
+def vcs_upload():
+    """
+    Uploads the project with the selected VCS tool.
+    """
+    if env.deploy_tool == "git":
+        remote_path = "ssh://%s@%s%s" % (env.user, env.host_string,
+                                         env.repo_path)
+        if not exists(env.repo_path):
+            run("mkdir -p %s" % env.repo_path)
+            with cd(env.repo_path):
+                run("git init --bare")
+        local("git push -f %s master" % remote_path)
+        with cd(env.repo_path):
+            run("GIT_WORK_TREE=%s git checkout -f master" % env.proj_path)
+            run("GIT_WORK_TREE=%s git reset --hard" % env.proj_path)
+    elif env.deploy_tool == "hg":
+        remote_path = "ssh://%s@%s/%s" % (env.user, env.host_string,
+                                          env.repo_path)
+        with cd(env.repo_path):
+            if not exists("%s/.hg" % env.repo_path):
+                run("hg init")
+                print(env.repo_path)
+            with fab_settings(warn_only=True):
+                push = local("hg push -f %s" % remote_path)
+                if push.return_code == 255:
+                    abort()
+            run("hg update")
+
+
 def db_pass():
     """
     Prompts for the database password if unknown.
@@ -265,7 +317,7 @@ def pip(packages):
     Installs one or more Python packages within the virtual environment.
     """
     with virtualenv():
-        return sudo("pip install %s" % packages)
+        return run("pip install %s" % packages)
 
 
 def postgres(command):
@@ -273,7 +325,7 @@ def postgres(command):
     Runs the given command as the postgres user.
     """
     show = not command.startswith("psql")
-    return run("sudo -u root sudo -u postgres %s" % command, show=show)
+    return sudo(command, show=show, user="postgres")
 
 
 @task
@@ -290,15 +342,19 @@ def psql(sql, show=True):
 @task
 def backup(filename):
     """
-    Backs up the database.
+    Backs up the project database.
     """
-    return postgres("pg_dump -Fc %s > %s" % (env.proj_name, filename))
+    tmp_file = "/tmp/%s" % filename
+    # We dump to /tmp because user "postgres" can't write to other user folders
+    postgres("pg_dump -Fc %s > %s" % (env.proj_name, tmp_file))
+    run("cp %s ." % tmp_file)
+    sudo("rm -f %s" % tmp_file)
 
 
 @task
 def restore(filename):
     """
-    Restores the database.
+    Restores the project database from a previous backup.
     """
     return postgres("pg_restore -c -d %s %s" % (env.proj_name, filename))
 
@@ -333,6 +389,29 @@ def manage(command):
     return run("%s %s" % (env.manage, command))
 
 
+###########################
+# Security best practices #
+###########################
+
+@task
+@log_call
+@hosts(["root@%s" % host for host in env.hosts])
+def secure(new_user=env.user):
+    """
+    Minimal security steps for brand new servers.
+    Installs system updates, creates new user (with sudo privileges) for future
+    usage, and disables root login via SSH.
+    """
+    run("apt-get update -q")
+    run("apt-get upgrade -y -q")
+    run("adduser --gecos '' %s" % new_user)
+    run("usermod -G sudo %s" % new_user)
+    run("sed -i 's:RootLogin yes:RootLogin no:' /etc/ssh/sshd_config")
+    run("service ssh restart")
+    print(green("Security steps completed. Log in to the server as '%s' from "
+                "now on." % new_user, bold=True))
+
+
 #########################
 # Install and configure #
 #########################
@@ -343,43 +422,63 @@ def install():
     """
     Installs the base system and Python requirements for the entire server.
     """
-    locale = "LC_ALL=%s" % env.locale
-    with hide("stdout"):
-        if locale not in sudo("cat /etc/default/locale"):
-            sudo("update-locale %s" % locale)
-            run("exit")
+    # Install system requirements
     sudo("apt-get update -y -q")
     apt("nginx libjpeg-dev python-dev python-setuptools git-core "
-        "postgresql libpq-dev memcached supervisor")
-    sudo("easy_install pip")
-    sudo("pip install virtualenv mercurial")
+        "postgresql libpq-dev memcached supervisor python-pip")
+    run("mkdir -p /home/%s/logs" % env.user)
+
+    # Install Python requirements
+    sudo("pip install -U pip virtualenv virtualenvwrapper mercurial")
+
+    # Set up virtualenv
+    run("mkdir -p %s" % env.venv_home)
+    run("echo 'export WORKON_HOME=%s' >> /home/%s/.bashrc" % (env.venv_home,
+                                                              env.user))
+    run("echo 'source /usr/local/bin/virtualenvwrapper.sh' >> "
+        "/home/%s/.bashrc" % env.user)
+    print(green("Successfully set up git, mercurial, pip, virtualenv, "
+                "supervisor, memcached.", bold=True))
 
 
 @task
 @log_call
 def create():
     """
-    Create a new virtual environment for a project.
-    Pulls the project's repo from version control, adds system-level
-    configs for the project, and initialises the database with the
-    live host.
+    Creates the environment needed to host the project.
+    The environment consists of: system locales, virtualenv, database, project
+    files, SSL certificate, and project-specific Python requirements.
     """
+    # Generate project locale
+    locale = env.locale.replace("UTF-8", "utf8")
+    with hide("stdout"):
+        if locale not in run("locale -a"):
+            sudo("locale-gen %s" % env.locale)
+            sudo("update-locale %s" % env.locale)
+            sudo("service postgresql restart")
+            run("exit")
 
-    # Create virtualenv
+    # Create project path
+    run("mkdir -p %s" % env.proj_path)
+
+    # Set up virtual env
+    run("mkdir -p %s" % env.venv_home)
     with cd(env.venv_home):
         if exists(env.proj_name):
-            prompt = input("\nVirtualenv exists: %s"
-                           "\nWould you like to replace it? (yes/no) "
-                           % env.proj_name)
-            if prompt.lower() != "yes":
-                print("\nAborting!")
-                return False
-            remove()
-        run("virtualenv %s --distribute" % env.proj_name)
-        vcs = "git" if env.git else "hg"
-        run("%s clone %s %s" % (vcs, env.repo_url, env.proj_path))
+            if confirm("Virtualenv already exists in host server: %s"
+                       "\nWould you like to replace it?" % env.proj_name):
+                run("rm -rf %s" % env.proj_name)
+            else:
+                abort()
+        run("virtualenv %s" % env.proj_name)
 
-    # Create DB and DB user.
+    # Upload project files
+    if env.deploy_tool in env.vcs_tools:
+        vcs_upload()
+    else:
+        rsync_upload()
+
+    # Create DB and DB user
     pw = db_pass()
     user_sql_args = (env.proj_name, pw.replace("'", "\'"))
     user_sql = "CREATE USER %s WITH ENCRYPTED PASSWORD '%s';" % user_sql_args
@@ -390,7 +489,7 @@ def create():
          "LC_CTYPE = '%s' LC_COLLATE = '%s' TEMPLATE template0;" %
          (env.proj_name, env.proj_name, env.locale, env.locale))
 
-    # Set up SSL certificate.
+    # Set up SSL certificate
     if not env.ssl_disabled:
         conf_path = "/etc/nginx/conf"
         if not exists(conf_path):
@@ -410,13 +509,14 @@ def create():
                     upload_template(crt_local, crt_file, use_sudo=True)
                     upload_template(key_local, key_file, use_sudo=True)
 
-    # Set up project.
+    # Install project-specific requirements
     upload_template_and_reload("settings")
     with project():
         if env.reqs_path:
             pip("-r %s/%s" % (env.proj_path, env.reqs_path))
         pip("gunicorn setproctitle south psycopg2 "
             "django-compressor python-memcached")
+    # Bootstrap the DB
         manage("createdb --noinput --nodata")
         python("from django.conf import settings;"
                "from django.contrib.sites.models import Site;"
@@ -447,13 +547,18 @@ def remove():
     Blow away the current project.
     """
     if exists(env.venv_path):
-        sudo("rm -rf %s" % env.venv_path)
+        run("rm -rf %s" % env.venv_path)
+    if exists(env.proj_path):
+        run("rm -rf %s" % env.proj_path)
     for template in get_templates().values():
         remote_path = template["remote_path"]
         if exists(remote_path):
             sudo("rm %s" % remote_path)
+    if exists(env.repo_path):
+        run("rm -rf %s" % env.repo_path)
     psql("DROP DATABASE IF EXISTS %s;" % env.proj_name)
     psql("DROP USER IF EXISTS %s;" % env.proj_name)
+    sudo("supervisorctl update")
 
 
 ##############
@@ -465,13 +570,13 @@ def remove():
 def restart():
     """
     Restart gunicorn worker processes for the project.
+    If the processes are not running, they will be started.
     """
     pid_path = "%s/gunicorn.pid" % env.proj_path
     if exists(pid_path):
-        sudo("kill -HUP `cat %s`" % pid_path)
+        run("kill -HUP `cat %s`" % pid_path)
     else:
-        start_args = (env.proj_name, env.proj_name)
-        sudo("supervisorctl start %s:gunicorn_%s" % start_args)
+        sudo("supervisorctl update")
 
 
 @task
@@ -479,31 +584,47 @@ def restart():
 def deploy():
     """
     Deploy latest version of the project.
-    Check out the latest version of the project from version
-    control, install new requirements, sync and migrate the database,
-    collect any new static assets, and restart gunicorn's work
+    Backup current version of the project, push latest version of the project
+    via version control or rsync, install new requirements, sync and migrate
+    the database, collect any new static assets, and restart gunicorn's worker
     processes for the project.
     """
-    if not exists(env.venv_path):
-        prompt = input("\nVirtualenv doesn't exist: %s"
-                       "\nWould you like to create it? (yes/no) "
-                       % env.proj_name)
-        if prompt.lower() != "yes":
-            print("\nAborting!")
-            return False
-        create()
+    if not exists(env.proj_path):
+        if confirm("Project does not exist in host server: %s"
+                   "\nWould you like to create it?" % env.proj_name):
+            create()
+        else:
+            abort()
+
+    # Backup current version of the project
+    with cd(env.proj_path):
+        backup("last.db")
+    if env.deploy_tool in env.vcs_tools:
+        with cd(env.repo_path):
+            if env.deploy_tool == "git":
+                    run("git rev-parse HEAD > %s/last.commit" % env.proj_path)
+            elif env.deploy_tool == "hg":
+                    run("hg id -i > last.commit")
+        with project():
+            static_dir = static()
+            if exists(static_dir):
+                run("tar -cf static.tar --exclude='*.thumbnails' %s" %
+                    static_dir)
+    else:
+        with cd(join(env.proj_path, "..")):
+            excludes = ["*.pyc", "*.pio", "*.thumbnails"]
+            exclude_arg = " ".join("--exclude='%s'" % e for e in excludes)
+            run("tar -cf {0}.tar {1} {0}".format(env.proj_name, exclude_arg))
+
+    # Deploy latest version of the project
     for name in get_templates():
         upload_template_and_reload(name)
+    with update_changed_requirements():
+        if env.deploy_tool in env.vcs_tools:
+            vcs_upload()
+        else:
+            rsync_upload()
     with project():
-        backup("last.db")
-        static_dir = static()
-        if exists(static_dir):
-            run("tar -cf last.tar %s" % static_dir)
-        git = env.git
-        last_commit = "git rev-parse HEAD" if git else "hg id -i"
-        run("%s > last.commit" % last_commit)
-        with update_changed_requirements():
-            run("git pull origin master -f" if git else "hg pull && hg up -C")
         manage("collectstatic -v 0 --noinput")
         manage("syncdb --noinput")
         manage("migrate --noinput")
@@ -517,16 +638,26 @@ def rollback():
     """
     Reverts project state to the last deploy.
     When a deploy is performed, the current state of the project is
-    backed up. This includes the last commit checked out, the database,
-    and all static files. Calling rollback will revert all of these to
-    their state prior to the last deploy.
+    backed up. This includes the project files, the database, and all static
+    files. Calling rollback will revert all of these to their state prior to
+    the last deploy.
     """
-    with project():
-        with update_changed_requirements():
-            update = "git checkout" if env.git else "hg up -C"
-            run("%s `cat last.commit`" % update)
-        with cd(join(static(), "..")):
-            run("tar -xf %s" % join(env.proj_path, "last.tar"))
+    with update_changed_requirements():
+        if env.deploy_tool in env.vcs_tools:
+            with cd(env.repo_path):
+                if env.deploy_tool == "git":
+                        run("GIT_WORK_TREE={0} git checkout -f "
+                            "`cat {0}/last.commit`".format(env.proj_path))
+                elif env.deploy_tool == "hg":
+                        run("hg update -C `cat last.commit`")
+            with project():
+                with cd(join(static(), "..")):
+                    run("tar -xf %s/static.tar" % env.proj_path)
+        else:
+            with cd(env.proj_path.rsplit("/", 1)[0]):
+                run("rm -rf %s" % env.proj_name)
+                run("tar -xf %s.tar" % env.proj_name)
+    with cd(env.proj_path):
         restore("last.db")
     restart()
 

--- a/mezzanine/project_template/local_settings.py.template
+++ b/mezzanine/project_template/local_settings.py.template
@@ -21,3 +21,26 @@ DATABASES = {
         "PORT": "",
     }
 }
+
+###################
+# DEPLOY SETTINGS #
+###################
+
+# Domains for public site
+# ALLOWED_HOSTS = [""]
+
+# These settings are used by the default fabfile.py provided.
+# Check fabfile.py for defaults.
+
+# FABRIC = {
+#     "DEPLOY_TOOL": "rsync",  # Deploy with "git", "hg", or "rsync"
+#     "SSH_USER": "",  # VPS SSH username
+#     "HOSTS": [""],  # The IP address of your VPS
+#     "DOMAINS": ALLOWED_HOSTS,  # Edit domains in ALLOWED_HOSTS
+#     "REQUIREMENTS_PATH": "requirements.txt",  # Project's pip requirements
+#     "LOCALE": "en_US.UTF-8",  # Should end with ".UTF-8"
+#     "DB_PASS": "",  # Live database password
+#     "ADMIN_PASS": "",  # Live admin user password
+#     "SECRET_KEY": SECRET_KEY,
+#     "NEVERCACHE_KEY": NEVERCACHE_KEY,
+# }

--- a/mezzanine/project_template/settings.py
+++ b/mezzanine/project_template/settings.py
@@ -310,30 +310,6 @@ OPTIONAL_APPS = (
     PACKAGE_NAME_GRAPPELLI,
 )
 
-###################
-# DEPLOY SETTINGS #
-###################
-
-# These settings are used by the default fabfile.py provided.
-# Check fabfile.py for defaults.
-
-# FABRIC = {
-#     "SSH_USER": "", # SSH username for host deploying to
-#     "HOSTS": ALLOWED_HOSTS[:1], # List of hosts to deploy to (eg, first host)
-#     "DOMAINS": ALLOWED_HOSTS, # Domains for public site
-#     "REPO_URL": "ssh://hg@bitbucket.org/user/project", # Project's repo URL
-#     "VIRTUALENV_HOME":  "", # Absolute remote path for virtualenvs
-#     "PROJECT_NAME": "", # Unique identifier for project
-#     "REQUIREMENTS_PATH": "requirements.txt", # Project's pip requirements
-#     "GUNICORN_PORT": 8000, # Port gunicorn will listen on
-#     "LOCALE": "en_US.UTF-8", # Should end with ".UTF-8"
-#     "DB_PASS": "", # Live database password
-#     "ADMIN_PASS": "", # Live admin user password
-#     "SECRET_KEY": SECRET_KEY,
-#     "NEVERCACHE_KEY": NEVERCACHE_KEY,
-# }
-
-
 ##################
 # LOCAL SETTINGS #
 ##################

--- a/mezzanine/project_template/wsgi.py
+++ b/mezzanine/project_template/wsgi.py
@@ -1,9 +1,13 @@
 from __future__ import unicode_literals
+
 import os
+import sys
+
 from django.core.wsgi import get_wsgi_application
 
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
-settings_module = "%s.settings" % PROJECT_ROOT.split(os.sep)[-1]
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_module)
+PROJECT_PARENT = PROJECT_ROOT.rsplit("/", 1)[0]
+sys.path.extend([PROJECT_ROOT, PROJECT_PARENT])
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
 application = get_wsgi_application()


### PR DESCRIPTION
My overall goal with this PR is to help developers with none or minimal sys-admin knowledge get Mezzanine sites deployed following best practices. I've tested all new features and made sure existing ones were not broken.

Enhancements over the current fabfile:

- Specifically designed to host multiple sites on the same server.
- Vanilla `gunicorn` is used instead of the the deprecated `gunicorn_django`.
- You don't need to host your repos in external sites (GitHub, Bitbucket). The contents are transferred directly from your dev machine to the server.
- You can upload files to the server via `rsync` instead of `git` or `hg` (in case your project is not under VCS).
- You don't need to know which port Gunicorn is going to use, because the connection from Nginx is to a socket file.
- Operations using `sudo` only require you to type the password once.
- Invalid requests (hosts other than `ALLOWED_HOSTS`) are blocked on Nginx level.
- Static files are set to expire after 30 days in browser cache (best practice).
- Deployment settings have been moved to `local_settings.py` for security concerns (they shouldn't be tracked by VCS) and to make sure `SECRET_KEY` and `NEVERCACHE_KEY` are in scope.
- Mezzanine sites in the server automatically start, even after system reboot.
- Locales are generated for every new site, instead of once per server.
- Added a bunch of comments and updated docstrings to make the whole fabfile more "didactic".

I've written a quick HOWTO (which I recommend is included in the official docs if this gets merged in): https://gist.github.com/jerivas/c36c41d25fc78614b18c. I would like to do a screencast to go along with that.

I have some left over credit on my Digital Ocean account in case Steve or anybody wants to test this out in a real VPS. As far as my own testing goes, I've been using Ubuntu 14.04 and tried out all three deployment methods (git, mercurial and rsync, including the `rollback` and `remove` tasks on each of them).