### PR TITLE
Don't assume INSTALLED_APPS is all modules as Django 1.7 adds AppConfig

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -49,6 +49,13 @@ page, we would define the following in ``authors.defaults``::
         default=10,
     )
 
+.. note::
+
+    If you are using Django 1.7 or greater and your app is included in your
+    INSTALLED_APPS as an AppConfig (eg authors.apps.MyCrazyConfig), Mezzanine
+    won't import your defaults.py automatically. Instead you must import it
+    manually in your AppConfig's ready() method.
+
 Reading Settings
 ================
 

--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -200,11 +200,15 @@ class Settings(object):
 
 mezz_first = lambda app: not app.startswith("mezzanine.")
 for app in sorted(django_settings.INSTALLED_APPS, key=mezz_first):
-    module = import_module(app)
     try:
-        import_module("%s.defaults" % app)
-    except:
-        if module_has_submodule(module, "defaults"):
-            raise
+        module = import_module(app)
+    except ImportError:
+        pass
+    else:
+        try:
+            import_module("%s.defaults" % app)
+        except:
+            if module_has_submodule(module, "defaults"):
+                raise
 
 settings = Settings()

--- a/mezzanine/pages/page_processors.py
+++ b/mezzanine/pages/page_processors.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from django.utils.importlib import import_module
 from django.utils.module_loading import module_has_submodule
 
-from mezzanine.conf import settings
 from mezzanine.pages.models import Page
 from mezzanine.utils.models import get_model
 from mezzanine.utils.importing import get_app_name_list

--- a/mezzanine/pages/page_processors.py
+++ b/mezzanine/pages/page_processors.py
@@ -9,6 +9,7 @@ from django.utils.module_loading import module_has_submodule
 from mezzanine.conf import settings
 from mezzanine.pages.models import Page
 from mezzanine.utils.models import get_model
+from mezzanine.utils.importing import get_app_name_list
 
 
 processors = defaultdict(list)
@@ -64,10 +65,14 @@ def autodiscover():
     if LOADED:
         return
     LOADED = True
-    for app in settings.INSTALLED_APPS:
-        module = import_module(app)
+    for app in get_app_name_list():
         try:
-            import_module("%s.page_processors" % app)
-        except:
-            if module_has_submodule(module, "page_processors"):
-                raise
+            module = import_module(app)
+        except ImportError:
+            pass
+        else:
+            try:
+                import_module("%s.page_processors" % app)
+            except:
+                if module_has_submodule(module, "page_processors"):
+                    raise

--- a/mezzanine/utils/importing.py
+++ b/mezzanine/utils/importing.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import os
 
+import django
 from django.utils.importlib import import_module
 
 
@@ -23,3 +24,14 @@ def import_dotted_path(path):
         return getattr(module, member_name)
     except (ValueError, ImportError, AttributeError) as e:
         raise ImportError("Could not import the name: %s: %s" % (path, e))
+
+
+def get_app_name_list():
+    if django.VERSION >= (1, 7):
+        from django.apps import apps as django_apps
+        for app in django_apps.get_app_configs():
+            yield app.name
+    else:
+        from django.conf import settings
+        for app in settings.INSTALLED_APPS:
+            yield app


### PR DESCRIPTION
As in https://github.com/stephenmcd/mezzanine/pull/941 - we should just ignore INSTALLED_APPS which are appconfig classes to avoid crashes.