### PR TITLE
Handle new app-loading mechanism for Django 1.7 in fabfile.

### DIFF
--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -364,12 +364,15 @@ def python(code, show=True):
     """
     Runs Python code in the project's virtual environment, with Django loaded.
     """
-    setup = "import os; os.environ[\'DJANGO_SETTINGS_MODULE\']=\'settings\';"
+    # Handle environment variable and special case for Django >= 1.7
+    setup = "import os; os.environ[\'DJANGO_SETTINGS_MODULE\']=\'settings\';" \
+            "import django;" \
+            "django.setup() if django.VERSION[1] >= 7 else None;"
     full_code = 'python -c "%s%s"' % (setup, code.replace("`", "\\\`"))
     with project():
-        result = run(full_code, show=False)
         if show:
             print_command(code)
+        result = run(full_code, show=False)
     return result
 
 


### PR DESCRIPTION
See https://docs.djangoproject.com/en/1.7/releases/1.7/#standalone-scripts
Django 1.7 requires explicitly calling `django.setup()` when using Django outside management commands. I've added an inline "if" statement to support Django 1.6 and 1.7. In my tests this was the only issue with Django 1.7 when deploying. Perhaps the next step is to not automatically bundle South when installing the server reqs.