### PR TITLE
Added exception handler for make_dirs() function call in thumbnail() template tag

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -305,7 +305,11 @@ def thumbnail(image_url, width, height, quality=95, left=.5, top=.5,
     thumb_dir = os.path.join(settings.MEDIA_ROOT, image_dir,
                              settings.THUMBNAILS_DIR_NAME, image_name)
     if not os.path.exists(thumb_dir):
-        os.makedirs(thumb_dir)
+        try:
+            os.makedirs(thumb_dir)
+        except OSError:
+            pass
+
     thumb_path = os.path.join(thumb_dir, thumb_name)
     thumb_url = "%s/%s/%s" % (settings.THUMBNAILS_DIR_NAME,
                               quote(image_name.encode("utf-8")),


### PR DESCRIPTION
This change is to deal with `make_dirs` raising exceptions, such as when attempting to write to a read-only directory or when working within an environment with customized Python `os` module, as is the case on Google App Engine.

This is for issue https://github.com/stephenmcd/mezzanine/issues/1228.