### PR TITLE
Twitter: Fix parsing of email addresses as Twitter usernames

### DIFF
--- a/mezzanine/twitter/models.py
+++ b/mezzanine/twitter/models.py
@@ -25,10 +25,10 @@ from mezzanine.twitter import get_auth_settings
 from mezzanine.twitter.managers import TweetManager
 
 
-re_usernames = re.compile("@([0-9a-zA-Z+_]+)", re.IGNORECASE)
+re_usernames = re.compile("(^|\W)@([0-9a-zA-Z+_]+)", re.IGNORECASE)
 re_hashtags = re.compile("#([0-9a-zA-Z+_]+)", re.IGNORECASE)
 replace_hashtags = "<a href=\"http://twitter.com/search?q=%23\\1\">#\\1</a>"
-replace_usernames = "<a href=\"http://twitter.com/\\1\">@\\1</a>"
+replace_usernames = "\\1<a href=\"http://twitter.com/\\2\">@\\2</a>"
 
 
 class TwitterQueryException(Exception):


### PR DESCRIPTION
The current regular expression that "linkifies" Twitter @mentions will also parse email addresses (example@not-a-mention.com). This is a potentially critical problem because it generates nested `<a>` tags that can break the whole HTML of a rendered page.

For example, consider this text returned from querying Twitter: "Contact us: foo@bar.com". The tweet is first run through Django's `urlize()`, which returns: `<a href="mailto:foo@bar.com">foo@bar.com</a>`. Then, the regex substitution comes in and replaces pretty much anything starting with the `@` character, which returns: `<a href="mailto:foo<a href="http://twitter.com/bar">@bar</a>.com">foo<a href="http://twitter.com/bar">@bar</a>.com</a>`. At this point, it's already invalid HTML.

The fix modifies the regex to only catch the `@` character when it is the first thing in the string or preceded by whitespace. In my tests it ignores email addresses fine.

*Note: Perhaps we need to do the same for the hashtag regex. However, the only instance where the `#` character is used is when linking to anchors in pages, and Twitter already shortens all url's, so it shouldn't be an issue.*