### PR TITLE
Added setting to allow custom forms for submitting comments.

### DIFF
--- a/mezzanine/generic/defaults.py
+++ b/mezzanine/generic/defaults.py
@@ -118,6 +118,14 @@ if generic_comments:
         default=True,
     )
 
+    register_setting(
+        name="COMMENT_FORM_CLASS",
+        description=_("The form class to use for adding new comments."),
+        editable=False,
+        default="mezzanine.generic.forms.ThreadedCommentForm",
+    )
+
+
 register_setting(
     name="RATINGS_ACCOUNT_REQUIRED",
     label=_("Accounts required for rating"),

--- a/mezzanine/generic/templatetags/comment_tags.py
+++ b/mezzanine/generic/templatetags/comment_tags.py
@@ -8,7 +8,6 @@ from django.template.defaultfilters import linebreaksbr, urlize
 
 from mezzanine import template
 from mezzanine.conf import settings
-from mezzanine.generic.forms import ThreadedCommentForm
 from mezzanine.generic.models import ThreadedComment
 from mezzanine.utils.importing import import_dotted_path
 
@@ -22,7 +21,8 @@ def comments_for(context, obj):
     Provides a generic context variable name for the object that
     comments are being rendered for.
     """
-    form = ThreadedCommentForm(context["request"], obj)
+    form_class = import_dotted_path(settings.COMMENT_FORM_CLASS)
+    form = form_class(context["request"], obj)
     try:
         context["posted_comment_form"]
     except KeyError:

--- a/mezzanine/generic/views.py
+++ b/mezzanine/generic/views.py
@@ -19,6 +19,7 @@ from mezzanine.generic.models import Keyword
 from mezzanine.utils.cache import add_cache_bypass
 from mezzanine.utils.models import get_model
 from mezzanine.utils.views import render, set_cookie, is_spam
+from mezzanine.utils.importing import import_dotted_path
 
 
 @staff_member_required
@@ -97,7 +98,8 @@ def comment(request, template="generic/comments.html"):
     if isinstance(response, HttpResponse):
         return response
     obj, post_data = response
-    form = ThreadedCommentForm(request, obj, post_data)
+    form_class = import_dotted_path(settings.COMMENT_FORM_CLASS)
+    form = form_class(request, obj, post_data)
     if form.is_valid():
         url = obj.get_absolute_url()
         if is_spam(request, form, url):


### PR DESCRIPTION
With these updates people can just specify the comment form class in their settings.py

    COMMENT_FORM_CLASS = "mezzcaptcha.forms.GuestCommentForm"

This defaults to "mezzanine.generic.forms.ThreadedCommentForm"

( The GuestCommentForm is simple - https://github.com/phookit/phookitmezz-captcha )
