### PR TITLE
Import WordPress draft posts correctly

### DIFF
--- a/mezzanine/blog/management/base.py
+++ b/mezzanine/blog/management/base.py
@@ -15,6 +15,7 @@ from django.utils.html import strip_tags
 
 from mezzanine.blog.models import BlogPost, BlogCategory
 from mezzanine.conf import settings
+from mezzanine.core.models import CONTENT_STATUS_DRAFT
 from mezzanine.core.models import CONTENT_STATUS_PUBLISHED
 from mezzanine.generic.models import AssignedKeyword, Keyword, ThreadedComment
 from mezzanine.pages.models import RichTextPage
@@ -175,6 +176,8 @@ class BaseImporterCommand(BaseCommand):
                 "title": post_data.pop("title"),
                 "user": mezzanine_user,
             }
+            if post_data["publish_date"] is None:
+                post_data["status"] = CONTENT_STATUS_DRAFT
             post, created = BlogPost.objects.get_or_create(**initial)
             for k, v in post_data.items():
                 setattr(post, k, v)

--- a/mezzanine/blog/management/commands/import_wordpress.py
+++ b/mezzanine/blog/management/commands/import_wordpress.py
@@ -61,8 +61,9 @@ class Command(BaseImporterCommand):
             # Get the time struct of the published date if possible and
             # the updated date if we can't.
             pub_date = getattr(entry, "published_parsed", entry.updated_parsed)
-            pub_date = datetime.fromtimestamp(mktime(pub_date))
-            pub_date -= timedelta(seconds=timezone)
+            if pub_date:
+                pub_date = datetime.fromtimestamp(mktime(pub_date))
+                pub_date -= timedelta(seconds=timezone)
 
             # Tags and categories are all under "tags" marked with a scheme.
             terms = defaultdict(set)


### PR DESCRIPTION
Currently import_wordpress fails if there are any draft posts due to missing pub_date, as discussed e.g. [here][1]. This patch makes them import correctly as drafts.

Publish date gets set as the current date, which might not be optimal, but changing that would require delving too deep into the code and this seems to work OK.

[1]: https://groups.google.com/forum/#!topic/mezzanine-users/P9NnwfAjvKs