### PR TITLE
Fix createdb to work with Django 1.7 and 1.8.

### DIFF
--- a/mezzanine/core/management/commands/createdb.py
+++ b/mezzanine/core/management/commands/createdb.py
@@ -4,16 +4,13 @@ from future.builtins import int, input
 from optparse import make_option
 from socket import gethostname
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django import VERSION
+from django.core.management.base import BaseCommand, CommandError
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.management import call_command
+from django.core.management.commands import migrate
 from django.db import connection
-
-try:
-    from django.core.management.commands import migrate
-except ImportError:
-    from django.core.management.commands import syncdb as migrate
 
 from mezzanine.conf import settings
 from mezzanine.utils.tests import copy_test_to_media
@@ -24,24 +21,43 @@ DEFAULT_EMAIL = "example@example.com"
 DEFAULT_PASSWORD = "default"
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
 
     help = "Performs initial Mezzanine database setup."
     can_import_settings = True
-    option_list = migrate.Command.option_list + (
-        make_option("--nodata", action="store_true", dest="nodata",
-                    default=False, help="Do not add demo data"),)
 
-    def handle_noargs(self, **options):
+    def __init__(self, *args, **kwargs):
+        """
+        Adds extra command options (executed only by Django <= 1.7).
+        """
+        super(Command, self).__init__(*args, **kwargs)
+        if VERSION[0] == 1 and VERSION[1] <= 7:
+            self.option_list = migrate.Command.option_list + (
+                make_option("--nodata", action="store_true", dest="nodata",
+                    default=False, help="Do not add demo data."),)
+
+    def add_arguments(self, parser):
+        """
+        Adds extra command options (executed only by Django >= 1.8).
+        """
+        parser.add_argument("--nodata", action="store_true", dest="nodata",
+            default=False, help="Do not add demo data.")
+        parser.add_argument("--noinput", action="store_false",
+            dest="interactive", default=True, help="Do not prompt the user "
+            "for input of any kind.")
+
+    def handle(self, **options):
 
         if "conf_setting" in connection.introspection.table_names():
             raise CommandError("Database already created, you probably "
                                "want the migrate command")
-        migrate.Command().execute(**options)
 
         self.verbosity = int(options.get("verbosity", 0))
         self.interactive = int(options.get("interactive", 0))
         self.no_data = int(options.get("nodata", 0))
+
+        call_command("migrate", verbosity=self.verbosity,
+                     interactive=self.interactive)
 
         mapping = [
             [self.create_site, ["django.contrib.sites"]],


### PR DESCRIPTION
[Django 1.8 changed the way optional args are added to management commands](https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/#accepting-optional-arguments). This patch adds optional args "the old way" for Django 1.7 in `Command.__init__()`, and then uses "the new way" for Django 1.8, which is via a call to the new class method `add_arguments()`.

There is a downside. In Django 1.7 we can get all args for `migrate` by simply extending `migrate.Command.option_list`. In Django 1.8, this returns an empty tuple, and I have no idea how to actually get the args from the `migrate` command, so I manually implemented `--noinput` and `--nodata`. This means in the end that `createdb` has less command line options available in Django 1.8 than in 1.7. If you want to have all options available, they are available [here](https://github.com/django/django/blob/master/django/core/management/commands/migrate.py#L27-L48) and can be directly copy-pasted. I do consider that `--noinput` and `--nodata` are good enough for `createdb`, any other task can call `migrate` directly.