### PR TITLE
Add SECRET_KEY to docs config which fixes broken rtd builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,10 +20,9 @@ import mezzanine
 
 if "DJANGO_SETTINGS_MODULE" not in os.environ:
     docs_path = os.getcwd()
-    parts = (docs_path, "..", "mezzanine")
-    sys.path.insert(0, os.path.join(*parts))
-    sys.path.insert(0, os.path.join(*parts + ("project_template",)))
-    settings_module = "mezzanine.project_template.settings"
+    parts = (docs_path, "..")
+    sys.path.insert(0, os.path.realpath(os.path.join(*parts)))
+    settings_module = "readthedocs_settings"
     os.environ["DJANGO_SETTINGS_MODULE"] = settings_module
     # Django 1.7's setup is required before touching translated strings.
     import django

--- a/docs/docs_settings.py
+++ b/docs/docs_settings.py
@@ -1,0 +1,10 @@
+"""
+This is the local_settings file for Mezzanine's docs.
+"""
+
+from mezzanine.project_template.settings import *
+
+# Generate a SECRET_KEY for this build
+from random import choice
+characters = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
+SECRET_KEY = ''.join([choice(characters) for i in range(50)])


### PR DESCRIPTION
Looking at the build history on RTD, [it hasn't successfully built the docs](https://readthedocs.org/builds/mezzanine/2541300/) in over 3 months. This is because of the change to `SECRET_KEY` in Django, and that setting not being available during the tests.

This patch changes the docs configuration to import a special settings file that provides a random `SECRET_KEY`, so Django's `setup()` can complete successfully.