### PR TITLE
Fix typo in settings_module for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ if "DJANGO_SETTINGS_MODULE" not in os.environ:
     docs_path = os.getcwd()
     parts = (docs_path, "..")
     sys.path.insert(0, os.path.realpath(os.path.join(*parts)))
-    settings_module = "readthedocs_settings"
+    settings_module = "docs_settings"
     os.environ["DJANGO_SETTINGS_MODULE"] = settings_module
     # Django 1.7's setup is required before touching translated strings.
     import django


### PR DESCRIPTION
Refactor fail - the correct `settings_module` name this time.