### PR TITLE
Django 1.8 migrations

### DIFF
--- a/mezzanine/core/managers.py
+++ b/mezzanine/core/managers.py
@@ -334,6 +334,8 @@ class CurrentSiteManager(DjangoCSM):
     to ``settings.SITE_ID`` if none of those match a site.
     """
 
+    use_in_migrations = False
+
     def __init__(self, field_name=None, *args, **kwargs):
         super(DjangoCSM, self).__init__(*args, **kwargs)
         self.__field_name = field_name

--- a/mezzanine/forms/migrations/0003_emailfield.py
+++ b/mezzanine/forms/migrations/0003_emailfield.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import mezzanine.pages.managers
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forms', '0002_auto_20141227_0224'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='form',
+            name='email_from',
+            field=models.EmailField(help_text='The address the email will be sent from', max_length=254, verbose_name='From address', blank=True),
+        ),
+    ]


### PR DESCRIPTION
In Django 1.8 ``CurrentSiteManager`` has the new ``use_in_migrations`` flag set to ``True``. The purpose of the flag is so the correct default manager can be used in RunPython operations, etc.

This means ``makemigrations`` generates a migration to explicitly set the manager on every model that uses it. The alternative is just to turn it off, which is what I've done in the first commit here.

I've also added a migration for Django 1.8's longer emailfield. Should that be wrapped in a version check?