### PR TITLE
Change redirect to be permanent

### DIFF
--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -290,5 +290,5 @@ class RedirectFallbackMiddleware(object):
                 if not redirect.new_path:
                     response = HttpResponseGone()
                 else:
-                    response = HttpResponseRedirect(redirect.new_path)
+                    response = HttpResponsePermanentRedirect(redirect.new_path)
         return response


### PR DESCRIPTION
The redirect middleware is currently using HttpResponseRedirect, which responds with http status 302.
Django does permanent redirects using HttpResponsePermanentRedirect, which sends a 301 status.

This change makes sense because:

1. This makes the Mezzanine redirection middleware more closely resemble Django
2. I guess this is more of an opinion than a fact, but it's worth mentioning that most changes on CMS-driven sites tend to be because of a re-organization, where path changes are understood to be permanent (301) rather than temporary (302).