### PR TITLE
Change way PostgreSQL version is displayed

### DIFF
--- a/mezzanine/core/management/commands/runserver.py
+++ b/mezzanine/core/management/commands/runserver.py
@@ -55,9 +55,9 @@ def banner():
     # to join with dots.
     db_version_func = {
         "postgresql": lambda: (
-            conn.pg_version / 10000,
-            conn.pg_version % 10000 / 100,
-            conn.pg_version % 10000 % 100,
+            conn.pg_version // 10000,
+            conn.pg_version // 100 % 100,
+            conn.pg_version % 100,
         ),
         "mysql": lambda: conn.mysql_version,
         "sqlite": lambda: conn.Database.sqlite_version_info,


### PR DESCRIPTION
For example
PostgreSQL 9.3.6
instead of PostgreSQL 9.0306.3.06.6