### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ try:
         packages=find_packages(),
         install_requires=[
             "django-contrib-comments",
-            "django >= 1.7",
+            "django = 1.7",
             "filebrowser_safe >= 0.3.4",
             "grappelli_safe >= 0.3.12",
             "tzlocal >= 1.0",


### PR DESCRIPTION
Removed the greater-than sign from Line 54; having it say "django >= 1.7" caused the package to install django 1.8.2, which breaks the functionality.