### PR TITLE
Ensure consistent related_model attribute throughout django fields

### DIFF
--- a/mezzanine/generic/fields.py
+++ b/mezzanine/generic/fields.py
@@ -44,7 +44,7 @@ class BaseGenericRelation(GenericRelation):
         try:
             # Check if ``related_model`` has been modified by a subclass
             self.related_model
-        except AppRegistryNotReady:
+        except (AppRegistryNotReady, AttributeError):
             # if not, all is good
             super(BaseGenericRelation, self).__init__(*args, **kwargs)
         else:


### PR DESCRIPTION
Fixes an issue from #1275

Added an exception in case some projects created classes derived from ```BaseGenericRelation``` to warn them about the change.