### PR TITLE
Switch forms admin to use the object-tools-items block in template

### DIFF
--- a/mezzanine/forms/templates/admin/forms/change_form.html
+++ b/mezzanine/forms/templates/admin/forms/change_form.html
@@ -1,16 +1,9 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
 
-{% block object-tools %}
-{% if change %}
-{% if not is_popup %}
-    <ul class="object-tools">
+{% block object-tools-items %}
     <li><a href="{% url "admin:form_entries" object_id %}">{% trans "View entries" %}</a></li>
-    <li><a href="history/" class="historylink">{% trans "History" %}</a></li>
-    {% if has_absolute_url %}<li><a href="../../../r/{{ content_type_id }}/{{ object_id }}/" class="viewsitelink">{% trans "View on site" %}</a></li>{% endif%}
-    </ul>
-{% endif %}
-{% endif %}
+    {{ block.super }}
 {% endblock %}
 
 


### PR DESCRIPTION
Can't currently test this, but it's nothing too complicated.