### PR TITLE
Load editable settings once per request

### DIFF
--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -116,9 +116,9 @@ class Settings(object):
         """
         self._loaded = True
         self._editable_cache = {}
-        
+
         request = current_request()
-        
+
         if request:
             request._loaded_editable_settings = False
             request._editable_settings = {}
@@ -184,9 +184,9 @@ class Settings(object):
                  % ", ".join(conflicting_settings))
         self._editable_cache = new_cache
         self._loaded = True
-        
+
         request = current_request()
-        
+
         if request:
             request._loaded_editable_settings = True
             request._editable_settings = new_cache
@@ -201,7 +201,7 @@ class Settings(object):
             return getattr(django_settings, name)
 
         loaded = self._loaded
-        
+
         if request:
             loaded = getattr(request, "_loaded_editable_settings", False)
 


### PR DESCRIPTION
**NOTE:** This is not a full pull request, I don't expect this to be merged. I just want to start a discussion, and the best way to start a discussion is bring working code to the table.

Currently editable settings are loaded from the database any time `settings.use_editable()` is called. This can be several times during the same request, depending on the view and functions called. Some views I see it happen 4 or 5 times.

It seems undesirable to load editable settings from the database several times per request for several reasons:
 1. Not idempotent - can lead to weird results for a request that is being processed when an editable setting is changed
 2. Inefficient - extra trips to the database that can be eliminated help with performance
 3. Inconsistent - settings available in template contexts are currently cached in the cache long-term while the settings object may reload settings from the database, causing a mismatch between the two

I suggest that editable settings are at the very least cached per-request, as this pull request does (in an ugly way). I think a more complete solution would be to also put the editable settings in the cache like the context settings are, and invalidate the key if modified from the admin area (as #1212 implemented).

The combination of a per-request and global caching would resolve the three issues I mentioned above. The per-request caching would first check the cache, then hit the DB and populate the cache if necessary. This fulfills 1 as a single request will be entirely rendered with one view of the settings, and 2 as database dips will only be necessary upon the double caching miss.

It mostly resolves 3, although the separate caching may still lead to an inconsistency between the template context and the request's view of the settings if the settings are changed from the admin area mid-request (resulting in the template context having the newer settings and the request having the older settings).

Perhaps a most complete solution would have the settings context processor also check the request's cache of the editable settings and use those if available.

Thoughts?