### PR TITLE
Lazier, more consistent editable settings

### DIFF
--- a/mezzanine/accounts/forms.py
+++ b/mezzanine/accounts/forms.py
@@ -221,7 +221,6 @@ class ProfileForm(Html5Mixin, forms.ModelForm):
             pass
 
         if self._signup:
-            settings.use_editable()
             if (settings.ACCOUNTS_VERIFICATION_REQUIRED or
                     settings.ACCOUNTS_APPROVAL_REQUIRED):
                 user.is_active = False

--- a/mezzanine/blog/feeds.py
+++ b/mezzanine/blog/feeds.py
@@ -45,7 +45,6 @@ class PostsRSS(Feed):
         else:
             self._public = not page.login_required
         if self._public:
-            settings.use_editable()
             if page is not None:
                 self._title = "%s | %s" % (page.title, settings.SITE_TITLE)
                 self._description = strip_tags(page.description)

--- a/mezzanine/blog/views.py
+++ b/mezzanine/blog/views.py
@@ -25,7 +25,6 @@ def blog_post_list(request, tag=None, year=None, month=None, username=None,
     ``blog/blog_post_list_XXX.html`` where ``XXX`` is either the
     category slug or author's username if given.
     """
-    settings.use_editable()
     templates = []
     blog_posts = BlogPost.objects.published(for_user=request.user)
     if tag is not None:

--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -94,11 +94,11 @@ class Settings(object):
     of access for all settings.
     """
 
-    class Sentinel(object):
-        """A Weakly-referable wrapper of 'object'."""
+    class Placeholder(object):
+        """A Weakly-referable wrapper of ``object``."""
         pass
 
-    NULL_REQUEST = Sentinel()
+    NULL_REQUEST = Placeholder()
 
     # These functions map setting types to the functions that should be
     # used to convert them from the Unicode string stored in the database.

--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -232,10 +232,9 @@ class Settings(object):
         if not setting["editable"]:
             return getattr(django_settings, name, setting["default"])
 
-        # Use cached editable setting if found, otherwise use the
-        # value defined in the project's settings.py module if it
-        # exists, finally falling back to the default defined when
-        # registered.
+        # Use cached editable setting if found, otherwise use the value
+        # defined in the project's settings.py module if it exists,
+        # finally falling back to the default defined when registered.
         editable_cache = self._get_editable(request=self._current_request)
         try:
             return editable_cache[name]

--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -5,6 +5,7 @@ or Django itself. Settings can also be made editable via the admin.
 """
 
 from __future__ import unicode_literals
+from weakref import WeakKeyDictionary
 from future.builtins import bytes, str
 
 from functools import partial
@@ -16,7 +17,7 @@ from django.utils.functional import Promise
 from django.utils.module_loading import module_has_submodule
 
 from mezzanine import __version__
-
+from mezzanine.core.request import current_request
 
 registry = {}
 
@@ -93,6 +94,12 @@ class Settings(object):
     of access for all settings.
     """
 
+    class Sentinel(object):
+        """A Weakly-referable wrapper of 'object'."""
+        pass
+
+    NULL_REQUEST = Sentinel()
+
     # These functions map setting types to the functions that should be
     # used to convert them from the Unicode string stored in the database.
     # If a type doesn't appear in this map, the type itself will be used.
@@ -103,18 +110,12 @@ class Settings(object):
 
     def __init__(self):
         """
-        The ``_loaded`` attribute is a flag for defining whether
-        editable settings have been loaded from the database. It
-        defaults to ``True`` here to avoid errors when the DB table
-        is first created. It's then set to ``False`` whenever the
-        ``use_editable`` method is called, which should be called
-        before using editable settings in the database.
-        ``_editable_cache`` is the dict that stores the editable
-        settings once they're loaded from the database, the first
-        time an editable setting is accessed.
+        The ``_editable_caches`` attribute maps Request objects to dicts of
+        editable settings loaded from the database. We cache settings per-
+        request to ensure that the database is hit at most once per request,
+        and that each request sees the same settings for its duration.
         """
-        self._loaded = True
-        self._editable_cache = {}
+        self._editable_caches = WeakKeyDictionary({self.NULL_REQUEST: {}})
 
     def use_editable(self):
         """
@@ -123,13 +124,34 @@ class Settings(object):
         installed then set the loaded flag to ``True`` in order to
         bypass DB lookup entirely.
         """
-        self._loaded = __name__ not in getattr(self, "INSTALLED_APPS")
+        self.clear_cache()
+        warn(
+            "Settings.use_editable() is deprecated in favour of "
+            "Settings.clear_cache(). Please update your code.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+
+    def clear_cache(self, request=None):
+        """Clear the settings cache for a given request (or no request)."""
+        try:
+            del self._editable_caches[request or self.NULL_REQUEST]
+        except KeyError:
+            pass
+
+    def _editable(self, request=None):
+        request = request or self.NULL_REQUEST
+        try:
+            editable_settings = self._editable_caches[request]
+        except KeyError:
+            editable_settings = self._editable_caches[request] = self._load()
+        return editable_settings
 
     def _load(self):
         """
-        Load settings from the database into cache. Delete any
-        settings from the database that are no longer registered, and
-        emit a warning if there are settings that are defined in
+        Load editable settings from the database and return them as a dict.
+        Delete any settings from the database that are no longer registered,
+        and emit a warning if there are settings that are defined in both
         settings.py and the database.
         """
         from mezzanine.conf.models import Setting
@@ -175,8 +197,8 @@ class Settings(object):
             warn("These settings are defined in both settings.py and "
                  "the database: %s. The settings.py values will be used."
                  % ", ".join(conflicting_settings))
-        self._editable_cache = new_cache
-        self._loaded = True
+
+        return new_cache
 
     def __getattr__(self, name):
 
@@ -186,16 +208,17 @@ class Settings(object):
         except KeyError:
             return getattr(django_settings, name)
 
-        # First access for an editable setting - load from DB into cache.
-        if setting["editable"] and not self._loaded:
-            self._load()
+        # If the setting isn't editable, just return it
+        if not setting["editable"]:
+            return getattr(django_settings, name, setting["default"])
 
         # Use cached editable setting if found, otherwise use the
         # value defined in the project's settings.py module if it
         # exists, finally falling back to the default defined when
         # registered.
+        editable_cache = self._editable(request=current_request())
         try:
-            return self._editable_cache[name]
+            return editable_cache[name]
         except KeyError:
             return getattr(django_settings, name, setting["default"])
 

--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -124,20 +124,15 @@ class Settings(object):
         installed then set the loaded flag to ``True`` in order to
         bypass DB lookup entirely.
         """
-        self.clear_cache()
-        warn(
-            "Settings.use_editable() is deprecated in favour of "
-            "Settings.clear_cache(). Please update your code.",
-            DeprecationWarning,
-            stacklevel=2
-        )
+        self.clear_cache(current_request())
+        warn("Settings.use_editable() is deprecated in favour of "
+             "Settings.clear_cache(). Please update your code.",
+             DeprecationWarning,
+             stacklevel=2)
 
     def clear_cache(self, request=None):
         """Clear the settings cache for a given request (or no request)."""
-        try:
-            del self._editable_caches[request or self.NULL_REQUEST]
-        except KeyError:
-            pass
+        self._editable_caches.pop(request or self.NULL_REQUEST, None)
 
     def _editable(self, request=None):
         request = request or self.NULL_REQUEST

--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -168,7 +168,7 @@ class Settings(object):
                  "retrieved from the database (%s) could not be converted. "
                  "Using the default instead: %s"
                  % (setting["name"], setting["type"].__name__,
-                    raw_value, setting["default"]))
+                    repr(raw_value), repr(setting["default"])))
             value = setting["default"]
 
         return value

--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -128,13 +128,15 @@ class Settings(object):
         is the default, so this is deprecated in favour of ``clear_cache()``.
         """
         self.clear_cache()
-        warn("Settings.use_editable() is deprecated in favour of "
-             "Settings.clear_cache(). Please update your code.",
+        warn("Because editable settings are now used by default, "
+             "settings.use_editable() is deprecated. If you need to re-load "
+             "settings from the database during a request, please use "
+             "settings.clear_cache() instead.",
              DeprecationWarning,
              stacklevel=2)
 
     def clear_cache(self):
-        """Clear the settings cache for a given request (or no request)."""
+        """Clear the settings cache for the current request."""
         self._editable_caches.pop(self._current_request, None)
 
     def _get_editable(self, request):

--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -115,7 +115,7 @@ class Settings(object):
         request to ensure that the database is hit at most once per request,
         and that each request sees the same settings for its duration.
         """
-        self._editable_caches = WeakKeyDictionary({self.NULL_REQUEST: {}})
+        self._editable_caches = WeakKeyDictionary()
 
     @property
     def _current_request(self):

--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -134,7 +134,13 @@ class Settings(object):
         """Clear the settings cache for a given request (or no request)."""
         self._editable_caches.pop(request or self.NULL_REQUEST, None)
 
-    def _editable(self, request=None):
+    def _get_editable(self, request=None):
+        """
+        Get the dictionary of editable settings for a given request. Settings
+        are fetched from the database once per request and then stored in
+        ``_editable_caches``, a WeakKeyDictionary that will automatically
+        discard each entry when no more references to the request exist.
+        """
         request = request or self.NULL_REQUEST
         try:
             editable_settings = self._editable_caches[request]
@@ -211,7 +217,7 @@ class Settings(object):
         # value defined in the project's settings.py module if it
         # exists, finally falling back to the default defined when
         # registered.
-        editable_cache = self._editable(request=current_request())
+        editable_cache = self._get_editable(request=current_request())
         try:
             return editable_cache[name]
         except KeyError:

--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -119,10 +119,9 @@ class Settings(object):
 
     def use_editable(self):
         """
-        Sets the ``_loaded`` flag to ``False`` so that settings will
-        be loaded from the DB on next access. If the conf app is not
-        installed then set the loaded flag to ``True`` in order to
-        bypass DB lookup entirely.
+        Clear the cache for the current request so that editable settings are
+        fetched from the database on next access. Using editable settings
+        is the default, so this is deprecated in favour of ``clear_cache()``.
         """
         self.clear_cache(current_request())
         warn("Settings.use_editable() is deprecated in favour of "

--- a/mezzanine/conf/admin.py
+++ b/mezzanine/conf/admin.py
@@ -11,8 +11,6 @@ from django.utils.encoding import force_text
 from mezzanine.core.admin import BaseTranslationModelAdmin
 from mezzanine.conf.models import Setting
 from mezzanine.conf.forms import SettingsForm
-from mezzanine.utils.cache import (cache_delete, cache_installed,
-                                   cache_key_prefix)
 from mezzanine.utils.urls import admin_url
 
 
@@ -46,10 +44,6 @@ class SettingsAdmin(admin.ModelAdmin):
         if settings_form.is_valid():
             settings_form.save()
             info(request, _("Settings were successfully updated."))
-            if cache_installed():
-                cache_key = (cache_key_prefix(request, ignore_device=True) +
-                             "context-settings")
-                cache_delete(cache_key)
             return self.changelist_redirect()
         extra_context["settings_form"] = settings_form
         extra_context["title"] = u"%s %s" % (

--- a/mezzanine/conf/admin.py
+++ b/mezzanine/conf/admin.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import force_text
 
 from mezzanine.core.admin import BaseTranslationModelAdmin
+from mezzanine.conf import settings
 from mezzanine.conf.models import Setting
 from mezzanine.conf.forms import SettingsForm
 from mezzanine.utils.urls import admin_url
@@ -43,6 +44,7 @@ class SettingsAdmin(admin.ModelAdmin):
         settings_form = SettingsForm(request.POST or None)
         if settings_form.is_valid():
             settings_form.save()
+            settings.clear_cache()
             info(request, _("Settings were successfully updated."))
             return self.changelist_redirect()
         extra_context["settings_form"] = settings_form

--- a/mezzanine/conf/context_processors.py
+++ b/mezzanine/conf/context_processors.py
@@ -12,6 +12,10 @@ class TemplateSettings(dict):
     Dict wrapper for template settings. This exists to enforce
     the restriction of settings in templates to those named in
     TEMPLATE_ACCESSIBLE_SETTINGS, and to warn about deprecated settings.
+
+    Django's template system attempts a dict-style index lookup before an
+    attribute lookup when resolving dot notation in template variables, so we
+    use ``__getitem__()`` this as the primary way of getting at the settings.
     """
 
     def __init__(self, settings, allowed_settings, *args, **kwargs):
@@ -32,7 +36,7 @@ class TemplateSettings(dict):
 
         if k in DEPRECATED:
             from warnings import warn
-            warn("%s is deprecated. Please remove it from your templates" % k)
+            warn("%s is deprecated. Please remove it from your templates." % k)
 
         try:
             return getattr(self.settings, k)

--- a/mezzanine/conf/context_processors.py
+++ b/mezzanine/conf/context_processors.py
@@ -1,6 +1,4 @@
 from __future__ import unicode_literals
-from mezzanine.utils.cache import (cache_key_prefix, cache_installed,
-                                   cache_get, cache_set)
 
 
 # Deprecated settings and their defaults.
@@ -11,21 +9,35 @@ DEPRECATED = {
 
 class TemplateSettings(dict):
     """
-    Dict wrapper for template settings. This exists only to warn when
-    deprecated settings are accessed in templates.
+    Dict wrapper for template settings. This exists to enforce
+    the restriction of settings in templates to those named in
+    TEMPLATE_ACCESSIBLE_SETTINGS, and to warn about deprecated settings.
     """
 
-    def __getitem__(self, k):
-        if k in DEPRECATED:
-            from warnings import warn
-            warn("%s is deprecated, please remove it from your templates" % k)
-        return super(TemplateSettings, self).__getitem__(k)
+    def __init__(self, settings, allowed_settings, *args, **kwargs):
+        super(TemplateSettings, self).__init__(*args, **kwargs)
+        self.settings = settings
+        self.allowed_settings = set(allowed_settings)
 
-    def __getattr__(self, name):
+    def __getattr__(self, k):
         try:
-            return self.__getitem__(name)
+            return self.__getitem__(k)
         except KeyError:
             raise AttributeError
+
+    def __getitem__(self, k):
+
+        if k not in self.allowed_settings:
+            raise KeyError
+
+        if k in DEPRECATED:
+            from warnings import warn
+            warn("%s is deprecated. Please remove it from your templates" % k)
+
+        try:
+            return getattr(self.settings, k)
+        except AttributeError:
+            return super(TemplateSettings, self).__getitem__(k)
 
 
 def settings(request=None):
@@ -33,28 +45,18 @@ def settings(request=None):
     Add the settings object to the template context.
     """
     from mezzanine.conf import settings
-    settings_dict = None
-    cache_settings = request and cache_installed()
-    if cache_settings:
-        cache_key = (cache_key_prefix(request, ignore_device=True) +
-            "context-settings")
-        settings_dict = cache_get(cache_key)
-    if not settings_dict:
-        settings.use_editable()
-        settings_dict = TemplateSettings()
-        for k in settings.TEMPLATE_ACCESSIBLE_SETTINGS:
-            settings_dict[k] = getattr(settings, k, "")
-        for k in DEPRECATED:
-            settings_dict[k] = getattr(settings, k, DEPRECATED)
-        if cache_settings:
-            cache_set(cache_key, settings_dict)
+
+    allowed_settings = settings.TEMPLATE_ACCESSIBLE_SETTINGS
+
+    template_settings = TemplateSettings(settings, allowed_settings)
+    template_settings.update(DEPRECATED)
+
     # This is basically the same as the old ADMIN_MEDIA_PREFIX setting,
     # we just use it in a few spots in the admin to optionally load a
     # file from either grappelli or Django admin if grappelli isn't
     # installed. We don't call it ADMIN_MEDIA_PREFIX in order to avoid
     # any confusion.
-    if settings.GRAPPELLI_INSTALLED:
-        settings_dict["MEZZANINE_ADMIN_PREFIX"] = "grappelli/"
-    else:
-        settings_dict["MEZZANINE_ADMIN_PREFIX"] = "admin/"
-    return {"settings": settings_dict}
+    admin_prefix = "grappelli/" if settings.GRAPPELLI_INSTALLED else "admin/"
+    template_settings["MEZZANINE_ADMIN_PREFIX"] = admin_prefix
+
+    return {"settings": template_settings}

--- a/mezzanine/conf/forms.py
+++ b/mezzanine/conf/forms.py
@@ -54,7 +54,6 @@ class SettingsForm(forms.Form):
         Initialize a field wether it is built with a custom name for a
         specific translation language or not.
         """
-        settings.use_editable()
         kwargs = {
             "label": setting["label"] + ":",
             "required": setting["type"] in (int, float),

--- a/mezzanine/conf/tests.py
+++ b/mezzanine/conf/tests.py
@@ -82,7 +82,7 @@ class ConfTests(TestCase):
         unsupported types are defined for editable settings.
         """
 
-        settings.clear_cache(current_request())
+        settings.clear_cache()
 
         # Find an editable setting for each supported type.
         names_by_type = {}
@@ -116,7 +116,7 @@ class ConfTests(TestCase):
         setting of the same name.
         """
 
-        settings.clear_cache(current_request())
+        settings.clear_cache()
 
         Setting.objects.all().delete()
         django_settings.FOO = "Set in settings.py"
@@ -129,7 +129,7 @@ class ConfTests(TestCase):
 
     def test_bytes_conversion(self):
 
-        settings.clear_cache(current_request())
+        settings.clear_cache()
 
         register_setting(name="BYTES_TEST_SETTING", editable=True, default=b"")
         Setting.objects.create(name="BYTES_TEST_SETTING",

--- a/mezzanine/core/fields.py
+++ b/mezzanine/core/fields.py
@@ -66,7 +66,6 @@ class RichTextField(models.TextField):
         from mezzanine.conf import settings
         from mezzanine.core.defaults import (RICHTEXT_FILTER_LEVEL_NONE,
                                              RICHTEXT_FILTER_LEVEL_LOW)
-        settings.use_editable()
         if settings.RICHTEXT_FILTER_LEVEL == RICHTEXT_FILTER_LEVEL_NONE:
             return value
         tags = settings.RICHTEXT_ALLOWED_TAGS

--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -237,7 +237,6 @@ class SSLRedirectMiddleware(object):
     to HTTPS, and redirect all other URLs to HTTP if on HTTPS.
     """
     def process_request(self, request):
-        settings.use_editable()
         force_host = settings.SSL_FORCE_HOST
         response = None
         if force_host and request.get_host().split(":")[0] != force_host:

--- a/mezzanine/core/models.py
+++ b/mezzanine/core/models.py
@@ -311,7 +311,6 @@ class Displayable(Slugged, MetaData, TimeStamped):
         service have been specified.
         """
         from mezzanine.conf import settings
-        settings.use_editable()
         if settings.BITLY_ACCESS_TOKEN:
             url = "https://api-ssl.bit.ly/v3/shorten?%s" % urlencode({
                 "access_token": settings.BITLY_ACCESS_TOKEN,

--- a/mezzanine/core/views.py
+++ b/mezzanine/core/views.py
@@ -108,7 +108,6 @@ def search(request, template="search_results.html", extra_context=None):
     Display search results. Takes an optional "contenttype" GET parameter
     in the form "app-name.ModelName" to limit search results to a single model.
     """
-    settings.use_editable()
     query = request.GET.get("q", "")
     page = request.GET.get("page", 1)
     per_page = settings.SEARCH_PER_PAGE

--- a/mezzanine/generic/admin.py
+++ b/mezzanine/generic/admin.py
@@ -2,10 +2,14 @@ from __future__ import unicode_literals
 
 from django.contrib import admin
 from django_comments.admin import CommentsAdmin
+from django.db.utils import OperationalError
 from django.utils.translation import ugettext_lazy as _
 
 from mezzanine.conf import settings
 from mezzanine.generic.models import ThreadedComment
+
+
+__all__ = ('ThreadedCommentAdmin',)
 
 
 class ThreadedCommentAdmin(CommentsAdmin):
@@ -35,5 +39,15 @@ class ThreadedCommentAdmin(CommentsAdmin):
 
 
 generic_comments = getattr(settings, "COMMENTS_APP", "") == "mezzanine.generic"
-if generic_comments and not settings.COMMENTS_DISQUS_SHORTNAME:
+
+try:
+    using_disqus = bool(settings.COMMENTS_DISQUS_SHORTNAME)
+except OperationalError as e:
+    # COMMENTS_DISQUS_SHORTNAME is editable, so this exception is raised when
+    # this file is imported before any database tables have been created.
+    if str(e) != "no such table: conf_setting":
+        raise
+    using_disqus = False
+
+if generic_comments and not using_disqus:
     admin.site.register(ThreadedComment, ThreadedCommentAdmin)

--- a/mezzanine/generic/admin.py
+++ b/mezzanine/generic/admin.py
@@ -1,11 +1,10 @@
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.contrib import admin
 from django_comments.admin import CommentsAdmin
-from django.db.utils import OperationalError
 from django.utils.translation import ugettext_lazy as _
 
-from mezzanine.conf import settings
 from mezzanine.generic.models import ThreadedComment
 
 
@@ -39,15 +38,7 @@ class ThreadedCommentAdmin(CommentsAdmin):
 
 
 generic_comments = getattr(settings, "COMMENTS_APP", "") == "mezzanine.generic"
-
-try:
-    using_disqus = bool(settings.COMMENTS_DISQUS_SHORTNAME)
-except OperationalError as e:
-    # COMMENTS_DISQUS_SHORTNAME is editable, so this exception is raised when
-    # this file is imported before any database tables have been created.
-    if str(e) != "no such table: conf_setting":
-        raise
-    using_disqus = False
+using_disqus = bool(getattr(settings, "COMMENTS_DISQUS_SHORTNAME", False))
 
 if generic_comments and not using_disqus:
     admin.site.register(ThreadedComment, ThreadedCommentAdmin)

--- a/mezzanine/generic/managers.py
+++ b/mezzanine/generic/managers.py
@@ -20,7 +20,6 @@ class CommentManager(CurrentSiteManager, DjangoCM):
         that shouldn't be shown, and are given placeholders in
         the template ``generic/includes/comment.html``.
         """
-        settings.use_editable()
         visible = self.all()
         if not settings.COMMENTS_UNAPPROVED_VISIBLE:
             visible = visible.filter(is_public=True)

--- a/mezzanine/generic/templatetags/keyword_tags.py
+++ b/mezzanine/generic/templatetags/keyword_tags.py
@@ -47,7 +47,6 @@ def keywords_for(*args):
     keywords = keywords.annotate(item_count=Count("assignments"))
     if not keywords:
         return []
-    settings.use_editable()
     counts = [keyword.item_count for keyword in keywords]
     min_count, max_count = min(counts), max(counts)
     factor = (settings.TAG_CLOUD_SIZES - 1.)

--- a/mezzanine/generic/views.py
+++ b/mezzanine/generic/views.py
@@ -59,7 +59,6 @@ def initial_validation(request, prefix):
     ratings view functions to deal with as needed.
     """
     post_data = request.POST
-    settings.use_editable()
     login_required_setting_name = prefix.upper() + "S_ACCOUNT_REQUIRED"
     posted_session_key = "unauthenticated_" + prefix
     redirect_url = ""

--- a/mezzanine/twitter/__init__.py
+++ b/mezzanine/twitter/__init__.py
@@ -26,7 +26,6 @@ def get_auth_settings():
     only if they're all defined.
     """
     from mezzanine.conf import settings
-    settings.use_editable()
     try:
         auth_settings = (settings.TWITTER_CONSUMER_KEY,
                          settings.TWITTER_CONSUMER_SECRET,

--- a/mezzanine/twitter/models.py
+++ b/mezzanine/twitter/models.py
@@ -72,7 +72,6 @@ class Query(models.Model):
             url = urls[self.type]
         except KeyError:
             raise TwitterQueryException("Invalid query type: %s" % self.type)
-        settings.use_editable()
         auth_settings = get_auth_settings()
         if not auth_settings:
             from mezzanine.conf import registry

--- a/mezzanine/twitter/templatetags/twitter_tags.py
+++ b/mezzanine/twitter/templatetags/twitter_tags.py
@@ -65,7 +65,6 @@ def tweets_default(*args):
     """
     Tweets for the default settings.
     """
-    settings.use_editable()
     query_type = settings.TWITTER_DEFAULT_QUERY_TYPE
     args = (settings.TWITTER_DEFAULT_QUERY,
             settings.TWITTER_DEFAULT_NUM_TWEETS)

--- a/mezzanine/utils/cache.py
+++ b/mezzanine/utils/cache.py
@@ -55,13 +55,6 @@ def cache_get(key):
     return value
 
 
-def cache_delete(key):
-    """
-    Wrapper for ``cache.delete``.
-    """
-    return cache.delete(_hashed_key(key))
-
-
 def cache_installed():
     """
     Returns ``True`` if a cache backend is configured, and the
@@ -74,20 +67,16 @@ def cache_installed():
     )).issubset(set(settings.MIDDLEWARE_CLASSES))
 
 
-def cache_key_prefix(request, ignore_device=False):
+def cache_key_prefix(request):
     """
     Cache key for Mezzanine's cache middleware. Adds the current
-    device and site ID, unless ignore_device is True in which case
-    it will only add the current site ID.
+    device and site ID.
     """
-    cache_key = "%s.%s." % (
+    cache_key = "%s.%s.%s." % (
         settings.CACHE_MIDDLEWARE_KEY_PREFIX,
         current_site_id(),
+        device_from_request(request) or "default",
     )
-
-    if not ignore_device:
-        cache_key += (device_from_request(request) or "default") + "."
-
     return _i18n_cache_key_suffix(request, cache_key)
 
 

--- a/mezzanine/utils/email.py
+++ b/mezzanine/utils/email.py
@@ -97,7 +97,6 @@ def send_approve_mail(request, user):
     ``ACCOUNTS_APPROVAL_EMAILS``, when a new user signs up and the
     ``ACCOUNTS_APPROVAL_REQUIRED`` setting is ``True``.
     """
-    settings.use_editable()
     approval_emails = split_addresses(settings.ACCOUNTS_APPROVAL_EMAILS)
     if not approval_emails:
         return


### PR DESCRIPTION
This incorporates the changes in behaviour proposed by @dsanders11 in #1323 and @frankier in #1305. Can you two please test this branch in your projects to confirm that it does what it's meant to?

Overview:
 * we now automatically use database-backed settings.
  * ``settings.use_editable()`` is out (it's still there, but comes with a deprecation message).
  * ``settings.clear_cache()`` is in, for when code needs to explicitly refresh database-backed settings
 * settings are consistent for the duration of each request (unless ``settings.clear_cache()`` is called)
 * the template context settings cache is gone, and the associated changes from #1212 reverted
 * a few more tests now nail down the behaviour of editable settings more precisely
 * settings accessed in templates are now lazily fetched, instead of being fetched upfront

@stephenmcd would be great if you could cast an eye over this when you have some time.