### PR TITLE
Allow overriding fabric ENVS, create sync task.

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -83,6 +83,7 @@ for more information on working with these:
 
 Environments
 ------------
+
 Multiple environments can be configured to work with a fabfile.  To do so, add
 additional dictionaries, like ``DEFAUL`` above to the ``FABRIC`` dictionary.
 For example::

--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -49,10 +49,10 @@ if sys.argv[0].split(os.sep)[-1] in ("fab", "fab-script.py"):
 
 
 def conf_lookup(default_conf, conf_overrides, key, fallback=None):
-    '''
+    """
     Returns the value of the specified key in the passed FABENV,
     falling back to defaults
-    '''
+    """
     return conf_overrides.get(key, default_conf.get(key, fallback)) or fallback
 
 def setup_env(env_string=None):

--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -779,6 +779,12 @@ def sync_to(to_env):
     except KeyError:
         abort('ENV %s does not exist in the FABRIC dict' % to_env)
 
+    if not confirm(
+        red("You're about to overwrite the database and uploaded media in "
+            "%s with database and uploaded media from %s. Are you "
+            "sure?" % (to_env, from_env), bold=True)):
+        abort();
+
     current_dt_string = str(datetime.now()).replace(' ', '_').replace(':', '-')
 
     print("Syncing database and static files from %s to %s" % (from_env,

--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -766,7 +766,7 @@ def sync_restore(to_env, from_env, db_filename, static_filename):
 
 @task
 @log_call
-def sync_to(to_env):
+def sync_to(to_env, no_input=False):
     """
     Syncs datbase and media from the current ENV to to_env
     """
@@ -779,11 +779,11 @@ def sync_to(to_env):
     except KeyError:
         abort('ENV %s does not exist in the FABRIC dict' % to_env)
 
-    if not confirm(
-        red("You're about to overwrite the database and uploaded media in "
-            "%s with database and uploaded media from %s. Are you "
-            "sure?" % (to_env, from_env), bold=True)):
-        abort("Sync canceled")
+    if no_input != 'True' and not confirm(
+            red("You're about to overwrite the database and uploaded media in "
+                "%s with database and uploaded media from %s. Are you "
+                "sure?" % (to_env, from_env), bold=True)):
+        abort('Sync canceled')
 
     current_dt_string = str(datetime.now()).replace(' ', '_').replace(':', '-')
 

--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -783,7 +783,7 @@ def sync_to(to_env):
         red("You're about to overwrite the database and uploaded media in "
             "%s with database and uploaded media from %s. Are you "
             "sure?" % (to_env, from_env), bold=True)):
-        abort();
+        abort("Sync canceled")
 
     current_dt_string = str(datetime.now()).replace(' ', '_').replace(':', '-')
 

--- a/mezzanine/project_template/project_name/local_settings.py.template
+++ b/mezzanine/project_template/project_name/local_settings.py.template
@@ -33,14 +33,16 @@ DATABASES = {
 # Check fabfile.py for defaults.
 
 # FABRIC = {
-#     "DEPLOY_TOOL": "rsync",  # Deploy with "git", "hg", or "rsync"
-#     "SSH_USER": "",  # VPS SSH username
-#     "HOSTS": [""],  # The IP address of your VPS
-#     "DOMAINS": ALLOWED_HOSTS,  # Edit domains in ALLOWED_HOSTS
-#     "REQUIREMENTS_PATH": "requirements.txt",  # Project's pip requirements
-#     "LOCALE": "en_US.UTF-8",  # Should end with ".UTF-8"
-#     "DB_PASS": "",  # Live database password
-#     "ADMIN_PASS": "",  # Live admin user password
-#     "SECRET_KEY": SECRET_KEY,
-#     "NEVERCACHE_KEY": NEVERCACHE_KEY,
+#     "DEFAULT": {
+#         "DEPLOY_TOOL": "rsync",  # Deploy with "git", "hg", or "rsync"
+#         "SSH_USER": "",  # VPS SSH username
+#         "HOSTS": [""],  # The IP address of your VPS
+#         "DOMAINS": ALLOWED_HOSTS,  # Edit domains in ALLOWED_HOSTS
+#         "REQUIREMENTS_PATH": "requirements.txt",  # Project's pip requirements
+#         "LOCALE": "en_US.UTF-8",  # Should end with ".UTF-8"
+#         "DB_PASS": "",  # Live database password
+#         "ADMIN_PASS": "",  # Live admin user password
+#         "SECRET_KEY": SECRET_KEY,
+#         "NEVERCACHE_KEY": NEVERCACHE_KEY,
+#     }
 # }


### PR DESCRIPTION
This is a bit of a work in progress.

Update the FABRIC dictionary to be expected to look like this (the old style will still work as well):

```
FABRIC = {
    "DEFAULT": {
        "SSH_USER": "", # SSH username for host deploying to
        "HOSTS": ALLOWED_HOSTS[:1], # List of hosts to deploy to (eg, first host)
        "DOMAINS": ALLOWED_HOSTS, # Domains for public site
        "REPO_URL": "git@github.joshcartme/amezzproj.git", # Project's repo URL
        "VIRTUALENV_HOME":  "", # Absolute remote path for virtualenvs
        "PROJECT_NAME": "", # Unique identifier for project
        "REQUIREMENTS_PATH": "requirements.txt", # Project's pip requirements
        "LOCALE": "en_US.UTF-8", # Should end with ".UTF-8"
        "DB_PASS": "this-is-not-a-real-password", # Live database password
        "ADMIN_PASS": "this-is-not-a-real-password", # Live admin user password
        "SECRET_KEY": SECRET_KEY,
        "NEVERCACHE_KEY": NEVERCACHE_KEY,
    },
    'DEV': {
        "SSH_USER": "dev",
        "HOSTS": ['dev.example.com'],
        "VIRTUALENV_HOME": "/home/dev",
    },
    'PROD': {
        "SSH_USER": "prod",
        "HOSTS": ['www.example.com'],
        "VIRTUALENV_HOME": "/home/prod",
        "DB_PASS": "xyz---abc---zyx",
    }
}
```

In the above `DEV` and `PROD` are optional dictionaries that can override values in the `DEFAULT` dictionary.  `DEV` and `PROD` are not required and any other names or number of dictionaries can be used.

To have a non default dictionary override pass `--set FABENV=ENV` to any fabric command where ENV is a key in the `FABRIC` dictionary. **For example**:

```
$ fab all --set FABENV=DEV
```

would call the `all` task and override any values in `DEFAULT` that are also in `DEV` with the values from `DEV`.

If no overrides are desired call fabric commands like normal, i.e.:

```
$ fab all
```

My motivation for the above changes was to create a sync command that will sync the database and static files from one environment to another (this command is also included in the pull request).  The usage of it would be:

```
$ fab sync_to:PROD --set FABENV=DEV
```

Fabric hosts can technically be a list of hosts, I don't think this will support that as is so if that should be supported it will take some more work.  If anyone has thoughts on the best way to do that let me know!
