### PR TITLE
Dynamic inline JS fixes

### DIFF
--- a/mezzanine/core/static/mezzanine/js/admin/dynamic_inline.js
+++ b/mezzanine/core/static/mezzanine/js/admin/dynamic_inline.js
@@ -68,9 +68,17 @@ jQuery(function($) {
         });
     });
 
+    // Remove extraneous ``template`` forms from inline formsets since
+    // Mezzanine has its own method of dynamic inlines.
+    $(parentSelector + ' > *:has(*[name*=__prefix__])').remove();
+
+    // Remove the "add another" row used in Django's default admin templates
+    $(parentSelector + ' > *.add-row').remove();
+
     // Hide the exta inlines.
-    $(parentSelector + ' > *:not(.has_original)').hide();
-    // Re-show inlines with errors, poetentially hidden by previous line.
+    $(parentSelector + ' > *:not(.has_original):not(.legend)').hide();
+
+    // Re-show inlines with errors, potentially hidden by previous line.
     var errors = $(parentSelector + ' ul[class=errorlist]').parent().parent();
     if (window.__grappelli_installed) {
         errors = errors.parent();
@@ -86,11 +94,8 @@ jQuery(function($) {
         };
         var rows = getRows();
         $(rows[0]).show();
-        // Grappelli's inline header for tabular inlines is
-        // actually part of the selector, so for it we run this twice.
-        if (window.__grappelli_installed && $(rows[0]).hasClass('legend')) {
-            $(rows[1]).show();
-        }
+
+        // If no more hidden inlines remain, hide the "add another" button
         if (getRows().length === 0) {
             $(this).hide();
         }

--- a/mezzanine/core/static/mezzanine/js/admin/navigation.js
+++ b/mezzanine/core/static/mezzanine/js/admin/navigation.js
@@ -16,20 +16,6 @@ jQuery(function($) {
     // Provides link to site.
     $('#user-tools li:last').before('<li>' + window.__home_link + '</li>');
 
-    // Remove extraneous ``template`` forms from inline formsets since
-    // Mezzanine has its own method of dynamic inlines.
-    var removeRows = {};
-    $.each($('*[name*=__prefix__]'), function(i, e) {
-        var row = $(e).parent();
-        if (!row.attr('id')) {
-            row.attr('id', 'remove__prefix__' + i);
-        }
-        removeRows[row.attr('id')] = true;
-    });
-    for (var rowID in removeRows) {
-        $('#' + rowID).remove();
-    }
-
     // Hide all dropdown menus and apply click handlers.
     if (window.__admin_menu_collapsed) {
         $('.dropdown-menu-menu').removeClass('open').hide();

--- a/mezzanine/core/templates/admin/base_site.html
+++ b/mezzanine/core/templates/admin/base_site.html
@@ -24,8 +24,8 @@
     window.__admin_url = '{{ admin_index_url }}';
     window.__static_proxy = '{{ static_proxy_url }}';
     window.__admin_media_prefix__ = '{% static "admin" %}/';
-    window.__grappelli_installed = {{ settings.GRAPPELLI_INSTALLED|default:"true"|lower }};
-    window.__admin_menu_collapsed = {{ settings.ADMIN_MENU_COLLAPSED|default:"false"|lower }};
+    window.__grappelli_installed = {{ settings.GRAPPELLI_INSTALLED|lower }};
+    window.__admin_menu_collapsed = {{ settings.ADMIN_MENU_COLLAPSED|lower }};
     window.__language_code = '{{ LANGUAGE_CODE }}';
 </script>
 


### PR DESCRIPTION
This does a couple of things:
 * Moves some dynamic inline handling code from ``navigation.js`` to ``dynamic_inline.js``.
 * Prevent Mezzanine from deleting inline rows even when its dynamic inlines aren't being used.
 * ``window.__grappelli_installed`` and ``window.__admin_menu_collapsed`` no longer unconditionally ``true``.