### PR TITLE
Amend file location for local settings when advising on contribution.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,7 +180,7 @@ project::
     $ git clone https://github.com/your-github-username/mezzanine/
     $ cd mezzanine
     $ git checkout -b your-new-branch-name
-    $ cp mezzanine/project_template/local_settings.py{.template,}
+    $ cp mezzanine/project_template/project_name/local_settings.py{.template,}
     $ python setup.py develop
     $ python mezzanine/project_template/manage.py createdb --noinput
     $ python mezzanine/project_template/manage.py runserver


### PR DESCRIPTION
The file `local_settings.py.template` does not exist in the directory `mezzanine/project_template/`. Change contribution advisory of the new location at `mezzanine/project_template/project_name`.