### PR TITLE
admin: use apps config verbose_name for display

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -562,7 +562,7 @@ def admin_app_list(request):
                         menu_order[model_label]
                 except KeyError:
                     app_index = None
-                    app_title = opts.app_label.title()
+                    app_title = opts.app_config.verbose_name.title()
                     model_index = None
                     model_title = None
                 else:


### PR DESCRIPTION
Works for apps that have no explicit app_config.
Will break with django < 1.7.