### PR TITLE
Clean leading/trailing slashes from page admin slugs.

### DIFF
--- a/mezzanine/pages/admin.py
+++ b/mezzanine/pages/admin.py
@@ -11,7 +11,7 @@ from django.shortcuts import get_object_or_404
 from mezzanine.conf import settings
 from mezzanine.core.admin import DisplayableAdmin, DisplayableAdminForm
 from mezzanine.pages.models import Page, RichTextPage, Link
-from mezzanine.utils.urls import admin_url
+from mezzanine.utils.urls import admin_url, clean_slashes
 
 
 # Add extra fields for pages to the Displayable fields.
@@ -27,10 +27,14 @@ class PageAdminForm(DisplayableAdminForm):
     def clean_slug(self):
         """
         Save the old slug to be used later in PageAdmin.save_model()
-        to make the slug change propagate down the page tree.
+        to make the slug change propagate down the page tree, and clean
+        leading and trailing slashes which are added on elsewhere.
         """
         self.instance._old_slug = self.instance.slug
-        return self.cleaned_data['slug']
+        if not isinstance(self.instance, Link):
+            return clean_slashes(self.cleaned_data['slug'])
+        else:
+            return self.cleaned_data['slug']
 
 
 class PageAdmin(DisplayableAdmin):

--- a/mezzanine/pages/tests.py
+++ b/mezzanine/pages/tests.py
@@ -16,6 +16,7 @@ from mezzanine.conf import settings
 from mezzanine.core.models import CONTENT_STATUS_PUBLISHED
 from mezzanine.core.request import current_request
 from mezzanine.pages.models import Page, RichTextPage
+from mezzanine.pages.admin import PageAdminForm
 from mezzanine.urls import PAGES_SLUG
 from mezzanine.utils.tests import TestCase
 
@@ -344,3 +345,23 @@ class PagesTests(TestCase):
         activate(default_language)
         self.assertEqual(page.title, title_1)
         page.delete()
+
+    def test_clean_slug(self):
+        """
+        Test that PageAdminForm strips leading and trailing slashes from slugs
+        or returns `/`.
+        """
+        class TestPageAdminForm(PageAdminForm):
+            class Meta:
+                fields = ["slug"]
+                model = Page
+
+        data = {'slug': '/'}
+        submitted_form = TestPageAdminForm(data=data)
+        self.assertTrue(submitted_form.is_valid())
+        self.assertEqual(submitted_form.cleaned_data['slug'], "/")
+
+        data = {'slug': '/hello/world/'}
+        submitted_form = TestPageAdminForm(data=data)
+        self.assertTrue(submitted_form.is_valid())
+        self.assertEqual(submitted_form.cleaned_data['slug'], 'hello/world')

--- a/mezzanine/utils/urls.py
+++ b/mezzanine/utils/urls.py
@@ -133,5 +133,17 @@ def path_to_slug(path):
     for prefix in (lang_code, settings.SITE_PREFIX, PAGES_SLUG):
         if prefix:
             path = path.replace(prefix, "", 1)
-    path = path.strip("/") if settings.APPEND_SLASH else path.lstrip("/")
-    return path or "/"
+    path = clean_slashes(path)
+    return path
+
+
+def clean_slashes(path):
+    """
+    Canonicalize path by removing leading slashes and conditionally
+    removing trailing slashes.
+    """
+    if settings.APPEND_SLASH:
+        cleaned_path = path.strip("/")
+    else:
+        cleaned_path = path.lstrip("/")
+    return cleaned_path or "/"


### PR DESCRIPTION
[`path_to_slug`](https://github.com/fusionbox/mezzanine/blob/7ca7a48ded1d831756995082f5803fce6211b2f1/mezzanine/utils/urls.py#L125-L137) strips leading and trailing slashes from a URL path. Allowing leading and trailing slashes in the `slug` field of a page will result in a page that will never be accessible. The leading and trailing slashes should be cleaned in the page form. 