### PR TITLE
Make "View site" link to selected site.

### DIFF
--- a/mezzanine/core/templates/admin/base_site.html
+++ b/mezzanine/core/templates/admin/base_site.html
@@ -16,7 +16,7 @@
     {% url "fb_browse" as fb_browse_url %}
     {% url "admin:index" as admin_index_url %}
     {% get_current_language as LANGUAGE_CODE %}
-    window.__home_link = '<a href="{% url "home" %}">{% trans "View site" %}</a>';
+    window.__home_link = '<a href="{{ request.session.site_domain_url }}{% url "home" %}">{% trans "View site" %}</a>';
     window.__csrf_token = '{{ csrf_token }}';
     window.__admin_keywords_submit_url = '{% url "admin_keywords_submit" %}';
     window.__filebrowser_url = '{{ fb_browse_url }}';

--- a/mezzanine/core/views.py
+++ b/mezzanine/core/views.py
@@ -11,6 +11,7 @@ except ImportError:
 
 from django.apps import apps
 from django.contrib import admin
+from django.contrib.sites.models import Site
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.admin.options import ModelAdmin
 from django.contrib.staticfiles import finders
@@ -58,6 +59,8 @@ def set_site(request):
         except SitePermission.DoesNotExist:
             raise PermissionDenied
     request.session["site_id"] = site_id
+    domain = Site.objects.get(pk=site_id).domain
+    request.session["site_domain_url"] = "//%s" % domain
     admin_url = reverse("admin:index")
     next = next_url(request) or admin_url
     # Don't redirect to a change view for an object that won't exist


### PR DESCRIPTION
Currently if you select a different site from the sites dropdown and click "View site" it will take you to the site you're visiting the admin through rather than the selected site. This fix should make the link correctly bring you to the selected site instead.