### PR TITLE
Proxy model doesn't show up in the "Add..." dropdown

### DIFF
--- a/mezzanine/pages/models.py
+++ b/mezzanine/pages/models.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from future.builtins import filter, str
+from future.builtins import str
 try:
     from urllib.parse import urljoin
 except ImportError:  # Python 2

--- a/mezzanine/pages/models.py
+++ b/mezzanine/pages/models.py
@@ -136,9 +136,8 @@ class Page(BasePage):
         """
         Return all Page subclasses.
         """
-        def is_content_model(m):
-            return m is not Page and issubclass(m, Page)
-        return list(filter(is_content_model, apps.get_models()))
+        return [m for m in apps.get_models()
+                if m is not Page and issubclass(m, Page)]
 
     def get_content_model(self):
         """

--- a/mezzanine/pages/models.py
+++ b/mezzanine/pages/models.py
@@ -137,7 +137,7 @@ class Page(BasePage):
         Return all Page subclasses.
         """
         def is_content_model(m):
-            return m is not Page and issubclass(m, Page) and not m._meta.proxy
+            return m is not Page and issubclass(m, Page)
         return list(filter(is_content_model, apps.get_models()))
 
     def get_content_model(self):

--- a/mezzanine/pages/templatetags/pages_tags.py
+++ b/mezzanine/pages/templatetags/pages_tags.py
@@ -50,7 +50,7 @@ def page_menu(context, token):
             slug = ""
         num_children = lambda id: lambda: len(context["menu_pages"][id])
         has_children = lambda id: lambda: num_children(id)() > 0
-        rel = [m.__name__.lower() for m in Page.get_content_models()]
+        rel = [m.__name__.lower() for m in Page.get_content_models() if not m._meta.proxy]
         published = Page.objects.published(for_user=user).select_related(*rel)
         # Store the current page being viewed in the context. Used
         # for comparisons in page.set_menu_helpers.

--- a/mezzanine/pages/templatetags/pages_tags.py
+++ b/mezzanine/pages/templatetags/pages_tags.py
@@ -50,7 +50,9 @@ def page_menu(context, token):
             slug = ""
         num_children = lambda id: lambda: len(context["menu_pages"][id])
         has_children = lambda id: lambda: num_children(id)() > 0
-        rel = [m.__name__.lower() for m in Page.get_content_models() if not m._meta.proxy]
+        rel = [m.__name__.lower()
+               for m in Page.get_content_models()
+               if not m._meta.proxy]
         published = Page.objects.published(for_user=user).select_related(*rel)
         # Store the current page being viewed in the context. Used
         # for comparisons in page.set_menu_helpers.


### PR DESCRIPTION
I have a proxy model with a different Admin, but I don't see it in the "Add..." dropdown.

This fixes the bug. (I added a style fix commit, if you don't like it, let me know, I can remove the second commit)