### PR TITLE
Do not throw away next parameter on login

### DIFF
--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -59,7 +59,7 @@ class AdminLoginInterfaceSelectorMiddleware(object):
             response = view_func(request, *view_args, **view_kwargs)
             if request.user.is_authenticated():
                 if login_type == "admin":
-                    next = request.get_full_path()
+                    next = next_url(request) or request.get_full_path()
                     username = request.user.get_username()
                     if (username == DEFAULT_USERNAME and
                             request.user.check_password(DEFAULT_PASSWORD)):


### PR DESCRIPTION
get_full_path() throws away the ``next`` URL parameter, breaking
vanilla Django redirection behavior. The login form should redirect
to the ``next`` parameter on a successful login.

I would be willing to go farther and say that when the ``next`` parameter is present then the Admin and Site buttons should not be present and the page should unconditionally redirect to the next destination.