### PR TITLE
Allow all styles used by default tinymce toolbar.

### DIFF
--- a/mezzanine/core/defaults.py
+++ b/mezzanine/core/defaults.py
@@ -290,8 +290,9 @@ register_setting(
     description=_("List of inline CSS styles that won't be stripped from "
         "``RichTextField`` instances."),
     editable=False,
-    default=("margin-top", "margin-bottom", "margin-left", "margin-right",
-        "float", "vertical-align", "border", "margin"),
+    default=("border", "float", "list-style-type", "margin", "margin-bottom",
+        "margin-left", "margin-right", "margin-top", "padding-left",
+        "text-align", "text-decoration", "vertical-align"),
 )
 
 register_setting(


### PR DESCRIPTION
- Add 'text-decoration' for Underline and Strikethrough.
- Add 'padding-left' for Indent.
- Add 'list-style-type' for non-Default Lists.
- Alphabetize for consistency with other settings.