### PR TITLE
Remove extra SitePermissionInline's. Fix #1366.

### DIFF
--- a/mezzanine/core/admin.py
+++ b/mezzanine/core/admin.py
@@ -297,6 +297,7 @@ class SingletonAdmin(admin.ModelAdmin):
 
 class SitePermissionInline(admin.TabularInline):
     model = SitePermission
+    extra = 0
     max_num = 1
     can_delete = False
 

--- a/mezzanine/core/templates/admin/base_site.html
+++ b/mezzanine/core/templates/admin/base_site.html
@@ -36,7 +36,6 @@
 <script>
 jQuery(function($) {
     $('.admin-title').click(function() {location = window.__admin_url;});
-    $("#id_sitepermissions-__prefix__-sites").parent().parent().parent().remove();
 });
 </script>
 


### PR DESCRIPTION
Extra defaults to max_num (or 3, whichever is lesser) if extra is not set. In this case max_num was 1 so we were getting 1 extra inline.