### PR TITLE
Fixed smashed editable textarea.

### DIFF
--- a/mezzanine/core/static/mezzanine/css/editable.css
+++ b/mezzanine/core/static/mezzanine/css/editable.css
@@ -43,7 +43,7 @@ a#editable-toolbar-toggle {border-left:0px !important; text-decoration:none;
 .editable-form select {width:auto;}
 .editable-form input[type="file"] {width: 300px;}
 .editable-form p {margin: .5em 0 !important; padding: 0 !important;
-    line-height: 0 !important; border: 0 !important;}
+    border: 0 !important;}
 .editable-form p:first-child {margin-top: 0px;}
 .editable-form .helptext {font-size: 70%; color: #444; font-style: italic;}
 .editable-form label {text-transform: capitalize !important;


### PR DESCRIPTION
Bootstrap sets `textarea {line-height: inherit;}` which smashes the
textarea.

I checked a few different form widgets and as far as I can tell setting
the line-height to zero only affects textarea's.

If it turns out what I removed is necessary, we could alternatively add
`.editable-form p > textarea {line-height: normal;}`.

![smashed-textarea](https://cloud.githubusercontent.com/assets/3280280/9371826/3bf3242e-46a6-11e5-80e2-c5c49cd1927c.jpeg)
