### PR TITLE
Thumbnails generation with S3BotoStorage

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -319,21 +319,18 @@ def thumbnail(image_url, width, height, upscale=True, quality=95, left=.5,
     if image_url_path:
         thumb_url = "%s/%s" % (image_url_path, thumb_url)
 
-    try:
-        thumb_exists = os.path.exists(thumb_path)
-    except UnicodeEncodeError:
-        # The image that was saved to a filesystem with utf-8 support,
-        # but somehow the locale has changed and the filesystem does not
-        # support utf-8.
-        from mezzanine.core.exceptions import FileSystemEncodingChanged
-        raise FileSystemEncodingChanged()
-    if thumb_exists:
-        # Thumbnail exists, don't generate it.
-        return thumb_url
-    elif not default_storage.exists(image_url):
+    if not default_storage.exists(image_url):
         # Requested image does not exist, just return its URL.
         return image_url
 
+    if default_storage.exists(thumb_url):
+        thumb_modified_time = default_storage.modified_time(thumb_url)
+        image_modified_time = default_storage.modified_time(image_url)
+        if thumb_modified_time >= image_modified_time:
+            # Thumbnail already exists in storage and is up to date
+            return thumb_url
+
+    # Thumbnail has to be generated
     f = default_storage.open(image_url)
     try:
         image = Image.open(f)


### PR DESCRIPTION
I'm using S3BotoStorage as the default file storage for media files.

When uploading a new image from the admin panel, this is stored in S3. Then a thumbnail is generated and stored locally and in S3, so we have 2 copies of the same thumbnail.

The problem happens when deleting the image and uploading it again. When deleting the image, the image and the thumbnail are deleted from S3 but not the local thumbnail. Then, when uploading the same image again, a new thumbnail is not being generated or uploaded to S3 because there is already a local thumbnail generated.