### PR TITLE
Add several new overridable blocks to the base template.

### DIFF
--- a/mezzanine/core/templates/base.html
+++ b/mezzanine/core/templates/base.html
@@ -57,12 +57,14 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
     </button>
+    {% block navbar_title %}
     {% if settings.SITE_TITLE %}<a class="navbar-brand" href="/">{{ settings.SITE_TITLE }}</a>{% endif %}
     {% if settings.SITE_TAGLINE %}<p class="navbar-text visible-lg">{{ settings.SITE_TAGLINE }}</p>{% endif %}
+    {% endblock%}
 </div>
 <div class="navbar-collapse collapse">
-    {% search_form "all" %}
-    {% page_menu "pages/menus/dropdown.html" %}
+    {% block navbar_search_form %}{% search_form "all" %}{% endblock %}
+    {% block navbar_dropdown_menu %}{% page_menu "pages/menus/dropdown.html" %}{% endblock%}
 </div>
 </div>
 </div>


### PR DESCRIPTION
New blocks:

* a navbar_title block, to make it easy to replace the site title with an image logo, for instance.
* a navbar_search_form block. I found that I didn't want the "all" dropdown choices, and this makes it easy to invoke your own search_form tag.
* and a navbar_dropdown_menu block, in case you need to change that behavior (or just remove it) as well.