### PR TITLE
Fix and test page processor's exact_page argument

### DIFF
--- a/mezzanine/pages/middleware.py
+++ b/mezzanine/pages/middleware.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ImproperlyConfigured, MiddlewareNotUsed
 from django.http import HttpResponse, Http404
 
 from mezzanine.conf import settings
-from mezzanine.pages import page_processors
+from mezzanine.pages import context_processors, page_processors
 from mezzanine.pages.models import Page
 from mezzanine.pages.views import page as page_view
 from mezzanine.utils.importing import import_dotted_path
@@ -78,6 +78,7 @@ class PageMiddleware(object):
         if pages:
             page = pages[0]
             setattr(request, "page", page)
+            context_processors.page(request)
         else:
             return
 


### PR DESCRIPTION
It appears that the `exact_page` argument for page processors broke somewhere around commit a28cdf4 with the removal of the `page.set_helpers` call. This leads to any usage of the `exact_page` argument causing an error in `PageMiddleware` (see build failure for stephenmcd/cartridge#265).

Added a test which confirms it was broken, and fixed by using the page context processor to ensure `is_current` is set correctly during `PageMiddleware`.