### PR TITLE
Disqus sso encode fix

### DIFF
--- a/mezzanine/generic/templatetags/disqus_tags.py
+++ b/mezzanine/generic/templatetags/disqus_tags.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from future.builtins import bytes, int
+from future.builtins import int
 
 import base64
 import hashlib

--- a/mezzanine/generic/templatetags/disqus_tags.py
+++ b/mezzanine/generic/templatetags/disqus_tags.py
@@ -49,12 +49,12 @@ def _get_disqus_sso(user, public_key, secret_key):
         'email': user.email,
     })
     # encode the data to base64
-    message = base64.b64encode(bytes(data, encoding="utf8"))
+    message = base64.b64encode(data.encode("utf8"))
     # generate a timestamp for signing the message
     timestamp = int(time.time())
     # generate our hmac signature
-    sig = hmac.HMAC(bytes(secret_key, encoding="utf8"),
-                    bytes('%s %s' % (message, timestamp), encoding="utf8"),
+    sig = hmac.HMAC(secret_key.encode("utf8"),
+                    ('%s %s' % (message, timestamp)).encode("utf8"),
                     hashlib.sha1).hexdigest()
 
     # Messages are of the form <message> <signature> <timestamp>

--- a/mezzanine/pages/context_processors.py
+++ b/mezzanine/pages/context_processors.py
@@ -1,5 +1,6 @@
 from mezzanine.pages.models import Page
 
+
 def page(request):
     """
     Adds the current page to the template context and runs its

--- a/mezzanine/pages/context_processors.py
+++ b/mezzanine/pages/context_processors.py
@@ -1,4 +1,4 @@
-
+from mezzanine.pages.models import Page
 
 def page(request):
     """
@@ -10,7 +10,7 @@ def page(request):
     """
     context = {}
     page = getattr(request, "page", None)
-    if page:
+    if page and isinstance(page, Page):
         # set_helpers has always expected the current template context,
         # but here we're just passing in our context dict with enough
         # variables to satisfy it.


### PR DESCRIPTION
SSO did not work with the current encoding for the payload. Using str.encode('utf8') seemed to fix the issue.