### PR TITLE
Resolve css/js Media paths using static templatetag

### DIFF
--- a/mezzanine/conf/admin.py
+++ b/mezzanine/conf/admin.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from copy import copy
 
 from django.contrib import admin
+from django.contrib.admin.templatetags.admin_static import static
 from django.contrib.messages import info
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
@@ -23,9 +24,9 @@ class SettingsAdmin(admin.ModelAdmin):
 
     class Media(BaseTranslationModelAdmin.Media):
         css = copy(BaseTranslationModelAdmin.Media.css)
-        css["all"] += ("mezzanine/css/admin/settings.css",)
-        js = [js.replace("tabbed_translation_fields.js",
-                         "tabbed_translatable_settings.js")
+        css["all"] += (static("mezzanine/css/admin/settings.css"),)
+        js = [js.replace(static("tabbed_translation_fields.js"),
+                         static("tabbed_translatable_settings.js"))
               for js in BaseTranslationModelAdmin.Media.js]
 
     def changelist_redirect(self):

--- a/mezzanine/core/admin.py
+++ b/mezzanine/core/admin.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
+from django.contrib.admin.templatetags.admin_static import static
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
 from django.forms import ValidationError, ModelForm
@@ -28,12 +29,12 @@ if settings.USE_MODELTRANSLATION:
         """
         class Media:
             js = (
-                "modeltranslation/js/force_jquery.js",
-                "mezzanine/js/%s" % settings.JQUERY_UI_FILENAME,
-                "mezzanine/js/admin/tabbed_translation_fields.js",
+                static("modeltranslation/js/force_jquery.js"),
+                static("mezzanine/js/%s" % settings.JQUERY_UI_FILENAME),
+                static("mezzanine/js/admin/tabbed_translation_fields.js"),
             )
             css = {
-                "all": ("mezzanine/css/admin/tabbed_translation_fields.css",),
+                "all": (static("mezzanine/css/admin/tabbed_translation_fields.css"),),
             }
 
 else:

--- a/mezzanine/core/forms.py
+++ b/mezzanine/core/forms.py
@@ -4,6 +4,7 @@ from future.builtins import str
 from uuid import uuid4
 
 from django import forms
+from django.contrib.admin.templatetags.admin_static import static
 from django.forms.extras.widgets import SelectDateWidget
 from django.utils.safestring import mark_safe
 
@@ -41,8 +42,8 @@ class TinyMceWidget(forms.Textarea):
     """
 
     class Media:
-        js = ("mezzanine/tinymce/tinymce.min.js", settings.TINYMCE_SETUP_JS)
-        css = {'all': ("mezzanine/tinymce/tinymce.css",)}
+        js = (static("mezzanine/tinymce/tinymce.min.js"), static(settings.TINYMCE_SETUP_JS))
+        css = {'all': (static("mezzanine/tinymce/tinymce.css"),)}
 
     def __init__(self, *args, **kwargs):
         super(TinyMceWidget, self).__init__(*args, **kwargs)
@@ -74,8 +75,8 @@ class DynamicInlineAdminForm(forms.ModelForm):
     """
 
     class Media:
-        js = ("mezzanine/js/%s" % settings.JQUERY_UI_FILENAME,
-              "mezzanine/js/admin/dynamic_inline.js",)
+        js = (static("mezzanine/js/%s" % settings.JQUERY_UI_FILENAME),
+              static("mezzanine/js/admin/dynamic_inline.js"),)
 
 
 class SplitSelectDateTimeWidget(forms.SplitDateTimeWidget):

--- a/mezzanine/forms/admin.py
+++ b/mezzanine/forms/admin.py
@@ -10,6 +10,7 @@ from os.path import join
 
 from django.conf.urls import patterns, url
 from django.contrib import admin
+from django.contrib.admin.templatetags.admin_static import static
 from django.contrib.messages import info
 from django.core.files.storage import FileSystemStorage
 from django.http import HttpResponse, HttpResponseRedirect
@@ -50,7 +51,7 @@ class FormAdmin(PageAdmin):
     """
 
     class Media:
-        css = {"all": ("mezzanine/css/admin/form.css",)}
+        css = {"all": (static("mezzanine/css/admin/form.css"),)}
 
     inlines = (FieldAdmin,)
     list_display = ("title", "status", "email_copies",)

--- a/mezzanine/galleries/admin.py
+++ b/mezzanine/galleries/admin.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
+from django.contrib.admin.templatetags.admin_static import static
 
 from mezzanine.core.admin import TabularDynamicInlineAdmin
 from mezzanine.pages.admin import PageAdmin
@@ -14,7 +15,7 @@ class GalleryImageInline(TabularDynamicInlineAdmin):
 class GalleryAdmin(PageAdmin):
 
     class Media:
-        css = {"all": ("mezzanine/css/admin/gallery.css",)}
+        css = {"all": (static("mezzanine/css/admin/gallery.css"),)}
 
     inlines = (GalleryImageInline,)
 

--- a/mezzanine/generic/forms.py
+++ b/mezzanine/generic/forms.py
@@ -4,6 +4,7 @@ from future.builtins import int, str, zip
 from django import forms
 from django_comments.forms import CommentSecurityForm, CommentForm
 from django_comments.signals import comment_was_posted
+from django.contrib.admin.templatetags.admin_static import static
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext, ugettext_lazy as _
 
@@ -33,7 +34,7 @@ class KeywordsWidget(forms.MultiWidget):
     """
 
     class Media:
-        js = ("mezzanine/js/admin/keywords_field.js",)
+        js = (static("mezzanine/js/admin/keywords_field.js"),)
 
     def __init__(self, attrs=None):
         """


### PR DESCRIPTION
When running Mezzanine with a CDN for CSS/JavaScript (or even just browser side caching) it's important to use some form of cache-busting names for static files like those generated by CachedStaticFileStorage.

Static files listed under `class Media:` do not automatically get these benefits, so it is required to manually convert them to their static file names. Django's admin does this in several places.

Otherwise caching (via CDN or browser) can wreak some havoc when these files change and old versions are used.