### PR TITLE
Don't titlecase group name for ADMIN_MENU_ORDER

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -529,7 +529,6 @@ def admin_app_list(request):
     menu_order = {}
     for (group_index, group) in enumerate(settings.ADMIN_MENU_ORDER):
         group_title, items = group
-        group_title = group_title.title()
         for (item_index, item) in enumerate(items):
             if isinstance(item, (tuple, list)):
                 item_title, item = item


### PR DESCRIPTION
Since the group title is user-specified it is counterintuitive to apply titlecase to it since it will display differently than what was specified in settings.