### PR TITLE
Only use old_account_redirect if ACCOUNT_URL changed

### DIFF
--- a/mezzanine/accounts/urls.py
+++ b/mezzanine/accounts/urls.py
@@ -43,9 +43,13 @@ urlpatterns = patterns("mezzanine.accounts.views",
         "password_reset_verify", name="password_reset_verify"),
     url("^%s%s$" % (ACCOUNT_URL.strip("/"), _slash),
         "account_redirect", name="account_redirect"),
-    url("^%s(/(?P<url_suffix>.*))?%s$" % (OLD_ACCOUNT_URL.strip("/"), _slash),
-        "old_account_redirect", name="old_account_redirect"),
 )
+
+if ACCOUNT_URL != OLD_ACCOUNT_URL:
+    urlpatterns += patterns("mezzanine.accounts.views",
+        url("^%s(/(?P<url_suffix>.*))?%s$" % (OLD_ACCOUNT_URL.strip("/"), _slash),
+            "old_account_redirect", name="old_account_redirect"),
+    )
 
 if settings.ACCOUNTS_PROFILE_VIEWS_ENABLED:
     urlpatterns += patterns("mezzanine.accounts.views",


### PR DESCRIPTION
Right now `old_account_redirect` will cause an infinite redirect loop if `ACCOUNT_URL` is set to `OLD_ACCOUNT_URL` and a Page under `ACCOUNT_URL` is accessed.

Patch breaks PEP8 for line length but couldn't see a clean way to break it so deferring to @stephenmcd's preference.