### PR TITLE
Don't overwrite files options in mezzanine-project command

### DIFF
--- a/mezzanine/bin/management/commands/mezzanine_project.py
+++ b/mezzanine/bin/management/commands/mezzanine_project.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         options['nevercache_key'] = get_random_string(50, chars)
 
         # Indicate that local_settings.py.template should be rendered
-        options['files'] = ['local_settings.py.template']
+        options['files'].append('local_settings.py.template')
 
         super(Command, self).handle(*args, **options)
 


### PR DESCRIPTION
Updating the `files` option here disables the `--name` option, which I need
to render custom template files (i.e. a Makefile) when making a custom
mezzanine template for use with `mezzanine-project`.

This change adds `local_settings.py.template` to the list of files to render instead
of overwriting the list completely. This allows users to specify their own template
files if necessary.

Relevant django code is here: https://github.com/django/django/blob/master/django/core/management/templates.py#L56

And my mezzanine template I'm getting this to work with is here: https://github.com/nikolas/ctlmezzanine