### PR TITLE
Crop parameter added for the thumbnail template tag.

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -264,14 +264,17 @@ def search_form(context, search_model_names=None):
 
 @register.simple_tag
 def thumbnail(image_url, width, height, upscale=True, quality=95, left=.5,
-              top=.5, padding=False, padding_color="#fff"):
+              top=.5, padding=False, padding_color="#fff", crop=True):
     """
     Given the URL to an image, resizes the image using the given width
     and height on the first time it is requested, and returns the URL
-    to the new resized image. If width or height are zero then original
-    ratio is maintained. When ``upscale`` is False, images smaller than
-    the given size will not be grown to fill that size. The given width
-    and height thus act as maximum dimensions.
+    to the new resized image. If width or height are zero, the original
+    ratio is maintained; when they are not zero, ``crop`` parameter is
+    taken into account: if it's True, the image is cropped to needed
+    ratio, and if it's False, maximum of two dimensions is set to the
+    given value, and the other is set proportionally. When ``upscale``
+    is False, images smaller than the given size will not be grown to
+    fill that size.
     """
 
     if not image_url:
@@ -290,6 +293,8 @@ def thumbnail(image_url, width, height, upscale=True, quality=95, left=.5,
     thumb_name = "%s-%sx%s" % (image_prefix, width, height)
     if not upscale:
         thumb_name += "-no-upscale"
+    if not crop:
+        thumb_name += "-no-crop"
     if left != .5 or top != .5:
         left = min(1, max(0, left))
         top = min(1, max(0, top))
@@ -350,6 +355,12 @@ def thumbnail(image_url, width, height, upscale=True, quality=95, left=.5,
     if not upscale:
         to_width = min(to_width, from_width)
         to_height = min(to_height, from_height)
+
+    if not crop:
+        if from_width > from_height:
+            to_height = 0
+        elif from_height > from_width:
+            to_width = 0
 
     # Set dimensions.
     if to_width == 0:


### PR DESCRIPTION
Sometimes there is a need to resize an image to maximum width and height while keeping its ratio. I think it's a default behaviour in sorl-thumbnail, and I haven't found a way to do it in Mezzanine without padding, so I added this parameter.