### PR TITLE
Switch to a lazy static for Media statics

### DIFF
--- a/mezzanine/conf/admin.py
+++ b/mezzanine/conf/admin.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 from copy import copy
 
 from django.contrib import admin
-from django.contrib.admin.templatetags.admin_static import static
 from django.contrib.messages import info
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
@@ -13,6 +12,7 @@ from mezzanine.core.admin import BaseTranslationModelAdmin
 from mezzanine.conf import settings
 from mezzanine.conf.models import Setting
 from mezzanine.conf.forms import SettingsForm
+from mezzanine.utils.static import static_lazy as static
 from mezzanine.utils.urls import admin_url
 
 

--- a/mezzanine/core/admin.py
+++ b/mezzanine/core/admin.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
-from django.contrib.admin.templatetags.admin_static import static
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
 from django.forms import ValidationError, ModelForm
@@ -14,6 +13,7 @@ from mezzanine.conf import settings
 from mezzanine.core.forms import DynamicInlineAdminForm
 from mezzanine.core.models import (Orderable, SitePermission,
                                    CONTENT_STATUS_PUBLISHED)
+from mezzanine.utils.static import static_lazy as static
 from mezzanine.utils.urls import admin_url
 
 if settings.USE_MODELTRANSLATION:

--- a/mezzanine/core/forms.py
+++ b/mezzanine/core/forms.py
@@ -4,11 +4,11 @@ from future.builtins import str
 from uuid import uuid4
 
 from django import forms
-from django.contrib.admin.templatetags.admin_static import static
 from django.forms.extras.widgets import SelectDateWidget
 from django.utils.safestring import mark_safe
 
 from mezzanine.conf import settings
+from mezzanine.utils.static import static_lazy as static
 
 
 class Html5Mixin(object):

--- a/mezzanine/forms/admin.py
+++ b/mezzanine/forms/admin.py
@@ -10,7 +10,6 @@ from os.path import join
 
 from django.conf.urls import patterns, url
 from django.contrib import admin
-from django.contrib.admin.templatetags.admin_static import static
 from django.contrib.messages import info
 from django.core.files.storage import FileSystemStorage
 from django.http import HttpResponse, HttpResponseRedirect
@@ -23,6 +22,7 @@ from mezzanine.core.admin import TabularDynamicInlineAdmin
 from mezzanine.forms.forms import EntriesForm
 from mezzanine.forms.models import Form, Field, FormEntry, FieldEntry
 from mezzanine.pages.admin import PageAdmin
+from mezzanine.utils.static import static_lazy as static
 from mezzanine.utils.urls import admin_url, slugify
 
 

--- a/mezzanine/galleries/admin.py
+++ b/mezzanine/galleries/admin.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
-from django.contrib.admin.templatetags.admin_static import static
 
 from mezzanine.core.admin import TabularDynamicInlineAdmin
 from mezzanine.pages.admin import PageAdmin
 from mezzanine.galleries.models import Gallery, GalleryImage
+from mezzanine.utils.static import static_lazy as static
 
 
 class GalleryImageInline(TabularDynamicInlineAdmin):

--- a/mezzanine/generic/forms.py
+++ b/mezzanine/generic/forms.py
@@ -4,7 +4,6 @@ from future.builtins import int, str, zip
 from django import forms
 from django_comments.forms import CommentSecurityForm, CommentForm
 from django_comments.signals import comment_was_posted
-from django.contrib.admin.templatetags.admin_static import static
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext, ugettext_lazy as _
 
@@ -13,6 +12,7 @@ from mezzanine.core.forms import Html5Mixin
 from mezzanine.generic.models import Keyword, ThreadedComment, Rating
 from mezzanine.utils.cache import add_cache_bypass
 from mezzanine.utils.email import split_addresses, send_mail_template
+from mezzanine.utils.static import static_lazy as static
 from mezzanine.utils.views import ip_for_request
 
 

--- a/mezzanine/utils/static.py
+++ b/mezzanine/utils/static.py
@@ -8,4 +8,3 @@ from django.utils.functional import lazy
 
 
 static_lazy = lazy(static, str)
-

--- a/mezzanine/utils/static.py
+++ b/mezzanine/utils/static.py
@@ -1,0 +1,11 @@
+"""
+Utils for working with static files.
+"""
+from __future__ import unicode_literals
+
+from django.contrib.admin.templatetags.admin_static import static
+from django.utils.functional import lazy
+
+
+static_lazy = lazy(static, str)
+


### PR DESCRIPTION
This is a mulligan on #1411. After more use, it seems there's a catch-22 situation with the current version. If `DEBUG` is set to `True` then the staticfiles storage just returns the same value it got, but if `DEBUG` is set to `False`, it tries to find the file in `STATIC_ROOT` (at least for the ManifestStaticFilesStorage storage). Since the files will only be in `STATIC_ROOT` if you ran `collectstatics`, you end up not being able to run `collectstatics` with `DEBUG` disabled because Django trips over the `static(...)` calls when loading the models before running the management command.

Long way of saying, lazy version solves this problem and may even be a bit better performing.