### PR TITLE
Fix for related items signal when migrating a model rename

### DIFF
--- a/mezzanine/generic/fields.py
+++ b/mezzanine/generic/fields.py
@@ -113,7 +113,7 @@ class BaseGenericRelation(GenericRelation):
         ``related_items_changed`` handler.
         """
         for_model = kwargs["instance"].content_type.model_class()
-        if issubclass(for_model, self.model):
+        if for_model and issubclass(for_model, self.model):
             instance_id = kwargs["instance"].object_pk
             try:
                 instance = for_model.objects.get(id=instance_id)


### PR DESCRIPTION
Presently, if you apply a migration that renames a model using `migrations.RenameModel`, there will be a stale content type for the old model present in the `django_content_types` table. You will be prompted to delete this stale content type, which will cause the `_related_items_changed()` method to be called.

Since the content type has been deleted by Django by the time this method is called, an exception will be raised, as `kwargs["instance"].content_type.model_class()` will return None (as it expects the content type to have changed, not be deleted):

```python
Traceback (most recent call last):
  [snip]
  File "mezzanine/generic/fields.py", line 117, in _related_items_changed
    if issubclass(for_model, self.model):
TypeError: issubclass() arg 1 must be a class
```

This change simply adds a check to ensure the method doesn't fail (there is nothing to be done on delete).