### PR TITLE
Check for FORMS_USE_HTML5 on the admin instead of the model

### DIFF
--- a/mezzanine/forms/admin.py
+++ b/mezzanine/forms/admin.py
@@ -35,6 +35,10 @@ form_fieldsets = list(form_fieldsets)
 form_fieldsets.insert(1, (_("Email"), {"fields": ("send_email", "email_from",
     "email_copies", "email_subject", "email_message")}))
 
+inline_field_excludes = []
+if not settings.FORMS_USE_HTML5:
+    inline_field_excludes += ["placeholder_text"]
+
 
 class FieldAdmin(TabularDynamicInlineAdmin):
     """
@@ -42,6 +46,7 @@ class FieldAdmin(TabularDynamicInlineAdmin):
     add dynamic "Add another" link and drag/drop ordering.
     """
     model = Field
+    exclude = inline_field_excludes
 
 
 class FormAdmin(PageAdmin):

--- a/mezzanine/forms/migrations/0005_auto_20151026_1600.py
+++ b/mezzanine/forms/migrations/0005_auto_20151026_1600.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forms', '0004_auto_20150517_0510'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='field',
+            name='placeholder_text',
+            field=models.CharField(max_length=100, verbose_name='Placeholder Text', blank=True),
+        ),
+    ]

--- a/mezzanine/forms/models.py
+++ b/mezzanine/forms/models.py
@@ -65,7 +65,7 @@ class Field(Orderable):
     default = models.CharField(_("Default value"), blank=True,
         max_length=settings.FORMS_FIELD_MAX_LENGTH)
     placeholder_text = models.CharField(_("Placeholder Text"), blank=True,
-        max_length=100, editable=settings.FORMS_USE_HTML5)
+        max_length=100)
     help_text = models.CharField(_("Help text"), blank=True, max_length=100)
 
     objects = FieldManager()


### PR DESCRIPTION
Fixes #1399.

I decided to go with the the `exclude` attribute since this is an inline model admin. It's let's verbose too and if new fields are added to the Field model, they will just show up without having to explicitly include them.

I tested with modeltranslation enabled and it works fine.