### PR TITLE
Don't strip HTML in TinyMCE.

### DIFF
--- a/mezzanine/core/static/mezzanine/js/tinymce_setup.js
+++ b/mezzanine/core/static/mezzanine/js/tinymce_setup.js
@@ -81,7 +81,8 @@ jQuery(function($) {
                       "bullist numlist outdent indent | link image table | " +
                       "code fullscreen"),
             file_browser_callback: custom_file_browser,
-            content_css: window.__tinymce_css
+            content_css: window.__tinymce_css,
+            valid_elements: "*[*]"  // Don't strip anything since this is handled by bleach.
         });
 
     }


### PR DESCRIPTION
Because filtering is handled by bleach.
Reimplement 0f6ab7c.

To quote Paul Whipp on the mailing list:
> If I say 'no filtering' I mean don't mess with my html dammit :)