### PR TITLE
Added Python 3.5 to trove classifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,14 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+matrix:
+  exclude:
+    - python: "3.5"
+      env: DJANGO="Django>=1.7.0,<1.8.0"
 install:
-  - pip install $DJANGO --use-mirrors
-  - pip install . --use-mirrors
+  - pip install $DJANGO
+  - pip install .
 script:
   - python setup.py test
 notifications:

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ try:
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.3",
             "Programming Language :: Python :: 3.4",
+            "Programming Language :: Python :: 3.5",
             "Topic :: Internet :: WWW/HTTP",
             "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
             "Topic :: Internet :: WWW/HTTP :: WSGI",


### PR DESCRIPTION
As of 9378b07, Mezzanine appears to fully support Python 3.5. I have tested this with a large, functioning Mezzanine+Cartridge site.

The only thing I have not thought to test is `EXTRA_MODEL_FIELDS`, but a quick test on a vanilla project doesn't yield any issues.

Corresponding Cartridge change: [cartridge/#274](https://github.com/stephenmcd/cartridge/pull/274)