### PR TITLE
Update tracking code to use Universal Analytics

### DIFF
--- a/mezzanine/core/templates/base.html
+++ b/mezzanine/core/templates/base.html
@@ -148,7 +148,9 @@
 </div>
 </footer>
 
+{% block footer_js %}
 {% include "includes/footer_scripts.html" %}
+{% endblock %}
 
 </body>
 </html>

--- a/mezzanine/core/templates/includes/footer_scripts.html
+++ b/mezzanine/core/templates/includes/footer_scripts.html
@@ -2,16 +2,14 @@
 
 {% editable_loader %}
 
-<script>
 {% if settings.GOOGLE_ANALYTICS_ID and not request.user.is_staff %}
-var _gaq = _gaq || [['_trackPageview']];
-_gaq.unshift(['_setAccount', '{{ settings.GOOGLE_ANALYTICS_ID }}']);
-(function(d, t) {
-    var g = d.createElement(t),
-        s = d.getElementsByTagName(t)[0];
-    g.async = true;
-    g.src = '//www.google-analytics.com/ga.js';
-    s.parentNode.insertBefore(g, s);
-})(document, 'script');
-{% endif %}
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+ga('create', '{{ settings.GOOGLE_ANALYTICS_ID }}', 'auto');
+ga('send', 'pageview');
 </script>
+{% endif %}

--- a/mezzanine/mobile/templates/mobile/base.html
+++ b/mezzanine/mobile/templates/mobile/base.html
@@ -53,9 +53,11 @@
 </div>
 
 {% compress js %}
+{% block footer_js %}
 <script src="{% static "mezzanine/js/"|add:settings.JQUERY_FILENAME %}"></script>
 <script src="{% static "js/jquery.mobile-1.2.1.min.js" %}"></script>
 {% include "mobile/includes/footer_scripts.html" %}
+{% endblock %}
 {% endcompress %}
 
 </body>

--- a/mezzanine/mobile/templates/mobile/includes/footer_scripts.html
+++ b/mezzanine/mobile/templates/mobile/includes/footer_scripts.html
@@ -1,15 +1,11 @@
-{% if settings.GOOGLE_ANALYTICS_ID %}
-<script> 
+{% if settings.GOOGLE_ANALYTICS_ID and not request.user.is_staff %}
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-var _gaq = [['_setAccount', '{{ settings.GOOGLE_ANALYTICS_ID }}'], ['_trackPageview']];
-
-(function(d, t) {
-    var g = d.createElement(t),
-        s = d.getElementsByTagName(t)[0];
-    g.async = true;
-    g.src = '//www.google-analytics.com/ga.js';
-    s.parentNode.insertBefore(g, s);
-})(document, 'script');
-
+ga('create', '{{ settings.GOOGLE_ANALYTICS_ID }}', 'auto');
+ga('send', 'pageview');
 </script>
 {% endif %}


### PR DESCRIPTION
This is @avery-laird's patch (#1191) with the `if` moved outside of the `<script>` tag, and a new `footer_js` template block, which will let us add the transaction reporting code in Cartridge in the right spot.

Might be worth removing `footer_scripts.html` and just putting all the scripts in the footer inside that block?