### PR TITLE
Move SingletonAdmin to utils. Resolve #1480.

### DIFF
--- a/docs/admin-customization.rst
+++ b/docs/admin-customization.rst
@@ -220,7 +220,7 @@ from your custom widget, by doing the following:
 Singleton Admin
 ===============
 
-The admin class :class:`mezzanine.core.admin.SingletonAdmin` is a utility
+The admin class :class:`mezzanine.utils.admin.SingletonAdmin` is a utility
 that can be used to create an admin interface for managing the case
 where only a single instance of a model should exist. Some cases
 include a single page site, where only a few fixed blocks of text
@@ -246,7 +246,7 @@ Here's a model with a text field for managing the alert::
 
 Here's our ``admin.py`` module in the same app::
 
-    from mezzanine.core.admin import SingletonAdmin
+    from mezzanine.utils.admin import SingletonAdmin
     from .models import SiteAlert
 
     # Subclassing allows us to customize the admin class,

--- a/mezzanine/core/admin.py
+++ b/mezzanine/core/admin.py
@@ -4,17 +4,15 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
 from django.forms import ValidationError, ModelForm
-from django.http import HttpResponseRedirect
-from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.models import User as AuthUser
 
 from mezzanine.conf import settings
+from mezzanine.utils.admin import SingletonAdmin  # Deprecated import path.
 from mezzanine.core.forms import DynamicInlineAdminForm
 from mezzanine.core.models import (Orderable, SitePermission,
                                    CONTENT_STATUS_PUBLISHED)
 from mezzanine.utils.static import static_lazy as static
-from mezzanine.utils.urls import admin_url
 
 if settings.USE_MODELTRANSLATION:
     from django.utils.datastructures import SortedDict
@@ -235,62 +233,6 @@ class OwnableAdmin(admin.ModelAdmin):
         if request.user.is_superuser or model_name in models_all_editable:
             return qs
         return qs.filter(user__id=request.user.id)
-
-
-class SingletonAdmin(admin.ModelAdmin):
-    """
-    Admin class for models that should only contain a single instance
-    in the database. Redirect all views to the change view when the
-    instance exists, and to the add view when it doesn't.
-    """
-
-    def handle_save(self, request, response):
-        """
-        Handles redirect back to the dashboard when save is clicked
-        (eg not save and continue editing), by checking for a redirect
-        response, which only occurs if the form is valid.
-        """
-        form_valid = isinstance(response, HttpResponseRedirect)
-        if request.POST.get("_save") and form_valid:
-            return redirect("admin:index")
-        return response
-
-    def add_view(self, *args, **kwargs):
-        """
-        Redirect to the change view if the singleton instance exists.
-        """
-        try:
-            singleton = self.model.objects.get()
-        except (self.model.DoesNotExist, self.model.MultipleObjectsReturned):
-            kwargs.setdefault("extra_context", {})
-            kwargs["extra_context"]["singleton"] = True
-            response = super(SingletonAdmin, self).add_view(*args, **kwargs)
-            return self.handle_save(args[0], response)
-        return redirect(admin_url(self.model, "change", singleton.id))
-
-    def changelist_view(self, *args, **kwargs):
-        """
-        Redirect to the add view if no records exist or the change
-        view if the singleton instance exists.
-        """
-        try:
-            singleton = self.model.objects.get()
-        except self.model.MultipleObjectsReturned:
-            return super(SingletonAdmin, self).changelist_view(*args, **kwargs)
-        except self.model.DoesNotExist:
-            return redirect(admin_url(self.model, "add"))
-        return redirect(admin_url(self.model, "change", singleton.id))
-
-    def change_view(self, *args, **kwargs):
-        """
-        If only the singleton instance exists, pass ``True`` for
-        ``singleton`` into the template which will use CSS to hide
-        the "save and add another" button.
-        """
-        kwargs.setdefault("extra_context", {})
-        kwargs["extra_context"]["singleton"] = self.model.objects.count() == 1
-        response = super(SingletonAdmin, self).change_view(*args, **kwargs)
-        return self.handle_save(args[0], response)
 
 
 ###########################################

--- a/mezzanine/core/templates/admin/base_site.html
+++ b/mezzanine/core/templates/admin/base_site.html
@@ -6,7 +6,7 @@
 {% block extrahead %}
 <link rel="stylesheet" href="{% static "mezzanine/css/admin/global.css" %}">
 <style>
-    /* These are set in PageAdmin's view methods, and mezzanine.core.admin.SingletonAdmin */
+    /* These are set in PageAdmin's view methods, and mezzanine.utils.admin.SingletonAdmin */
     {% if hide_delete_link or singleton %}.submit-row .deletelink {display:none !important;}{% endif %}
     {% if hide_slug_field %}.slug {display:none !important;}{% endif %}
     {% if singleton %}.change-view-save-another {display:none !important;}{% endif %}

--- a/mezzanine/utils/admin.py
+++ b/mezzanine/utils/admin.py
@@ -1,0 +1,63 @@
+from __future__ import unicode_literals
+
+from django.contrib import admin
+from django.shortcuts import redirect
+from django.http import HttpResponseRedirect
+
+from mezzanine.utils.urls import admin_url
+
+
+class SingletonAdmin(admin.ModelAdmin):
+    """
+    Admin class for models that should only contain a single instance
+    in the database. Redirect all views to the change view when the
+    instance exists, and to the add view when it doesn't.
+    """
+
+    def handle_save(self, request, response):
+        """
+        Handles redirect back to the dashboard when save is clicked
+        (eg not save and continue editing), by checking for a redirect
+        response, which only occurs if the form is valid.
+        """
+        form_valid = isinstance(response, HttpResponseRedirect)
+        if request.POST.get("_save") and form_valid:
+            return redirect("admin:index")
+        return response
+
+    def add_view(self, *args, **kwargs):
+        """
+        Redirect to the change view if the singleton instance exists.
+        """
+        try:
+            singleton = self.model.objects.get()
+        except (self.model.DoesNotExist, self.model.MultipleObjectsReturned):
+            kwargs.setdefault("extra_context", {})
+            kwargs["extra_context"]["singleton"] = True
+            response = super(SingletonAdmin, self).add_view(*args, **kwargs)
+            return self.handle_save(args[0], response)
+        return redirect(admin_url(self.model, "change", singleton.id))
+
+    def changelist_view(self, *args, **kwargs):
+        """
+        Redirect to the add view if no records exist or the change
+        view if the singleton instance exists.
+        """
+        try:
+            singleton = self.model.objects.get()
+        except self.model.MultipleObjectsReturned:
+            return super(SingletonAdmin, self).changelist_view(*args, **kwargs)
+        except self.model.DoesNotExist:
+            return redirect(admin_url(self.model, "add"))
+        return redirect(admin_url(self.model, "change", singleton.id))
+
+    def change_view(self, *args, **kwargs):
+        """
+        If only the singleton instance exists, pass ``True`` for
+        ``singleton`` into the template which will use CSS to hide
+        the "save and add another" button.
+        """
+        kwargs.setdefault("extra_context", {})
+        kwargs["extra_context"]["singleton"] = self.model.objects.count() == 1
+        response = super(SingletonAdmin, self).change_view(*args, **kwargs)
+        return self.handle_save(args[0], response)

--- a/mezzanine/utils/tests.py
+++ b/mezzanine/utils/tests.py
@@ -52,6 +52,8 @@ IGNORE_ERRORS = (
     # lambdas are OK.
     "do not assign a lambda",
 
+    # Imported during deprecation grace period after moving to utils.admin.
+    "'SingletonAdmin' imported but unused",
 )
 
 


### PR DESCRIPTION
Unfortunately I'm not aware of any reasonable way to raise a `DeprecationWarning` on import, but I would suppose importing `SingletonAdmin` in `core.admin` will suffice until it we can remove it in a major version.