### PR TITLE
Catch error if user sitepermissions don't exist.

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -12,6 +12,7 @@ from django.apps import apps
 from django.contrib import admin
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.sites.models import Site
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.files import File
 from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse, resolve, NoReverseMatch
@@ -625,7 +626,10 @@ def admin_dropdown_menu(context):
         if user.is_superuser:
             sites = Site.objects.all()
         else:
-            sites = user.sitepermissions.sites.all()
+            try:
+                sites = user.sitepermissions.sites.all()
+            except ObjectDoesNotExist:
+                sites = Site.objects.none()
         context["dropdown_menu_sites"] = list(sites)
         context["dropdown_menu_selected_site_id"] = current_site_id()
         return context


### PR DESCRIPTION
For the most part, if not using `SitePermissionMiddleware` Mezzanine
falls back on the `is_staff` attribute seamlessly. But since
d5d21ba527bd4 it's possible to have users without sitepermissions. This
breaks the admin dropdown, but not much else. This fix should allow
single site projects to continue to leave `SitePermissionMiddleware`
uninstalled.

I think this is a reasonable way to fix this issue (and is a reasonable issue to fix) but I'll admit I don't have the entirety of the `SitePermission` setup clear in my head, so I'm very open to suggestions for better approaches. If at all possible it would be really helpful to be able to preserve the `is_staff` behavior for single site projects.