### PR TITLE
Fix app list in the Admin

### DIFF
--- a/mezzanine/core/templates/admin/app_index.html
+++ b/mezzanine/core/templates/admin/app_index.html
@@ -1,0 +1,22 @@
+{% extends "admin/index.html" %}
+{% load i18n %}
+
+{% block bodyclass %}{{ block.super }} app-{{ app_label }}{% endblock %}
+
+{% if not is_popup %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo;
+{% for app in app_list %}
+{{ app.name }}
+{% endfor %}
+</div>
+{% endblock %}
+{% endif %}
+
+{% block content %}
+  {% include "admin/includes/app_list.html" with dashboard_app_list=app_list %}
+{% endblock content %}
+
+{% block sidebar %}{% endblock %}

--- a/mezzanine/core/templates/admin/includes/app_list.html
+++ b/mezzanine/core/templates/admin/includes/app_list.html
@@ -5,7 +5,13 @@
    {% for app in dashboard_app_list %}
    <div class="module" id="app_{{ app.name|lower }}">
        <table>
-           <caption>{% trans app.name %}</caption>
+           <caption>
+                {% if app.app_url %}
+                    <a href="{{ app.app_url }}" class="section" title="{% blocktrans with name=app.name %}Models in the {{ name }} application{% endblocktrans %}">{{ app.name }}</a>
+                {% else %}
+                    {{ app.name }}
+                {% endif %}
+           </caption>
            {% for model in app.models %}
            <tr class="model-{{ model.object_name|lower }}">
            {% if model.perms.change or model.perms.custom %}

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -575,6 +575,10 @@ def admin_app_list(request):
                     app_dict[app_title] = {
                         "index": app_index,
                         "name": app_title,
+                        "app_url": reverse(
+                            'admin:app_list',
+                            kwargs={'app_label': opts.app_label}
+                        ),
                         "models": [],
                     }
                 app_dict[app_title]["models"].append({


### PR DESCRIPTION
Using mezzanine breaks the admin in multiple ways:

* On the admin dashboard, there's no link to the app specific listing. (The header of the section) But you can access the app specific listing by clicking on the breadcrumb.
* When listing an app, the full list is getting displayed. (Because the default `app_index.html` inherit from the default templates which displays the dashboard)

This pull request fixes these two bugs.

I also removed the `{%  trans %}` tag on the admin header because you can't really translate variables, and names are already translated.