### PR TITLE
Fixes #1449 -- duplicate profile fields in admin

### DIFF
--- a/mezzanine/accounts/admin.py
+++ b/mezzanine/accounts/admin.py
@@ -51,6 +51,7 @@ try:
         can_delete = False
         template = "admin/profile_inline.html"
         extra = 0
+        min_num = 1
     UserProfileAdmin.inlines += (ProfileInline,)
 except ProfileNotConfigured:
     pass

--- a/mezzanine/accounts/admin.py
+++ b/mezzanine/accounts/admin.py
@@ -51,7 +51,13 @@ try:
         can_delete = False
         template = "admin/profile_inline.html"
         extra = 0
-        min_num = 1
+
+        def get_min_num(self, request, obj=None, **kwargs):
+            """This causes profile forms to be shown when editing but hidden
+            when creating. If min_num is fixed at 1, Django's initial user
+            creation form fails if the profile model has a required field."""
+            return 0 if obj is None else 1
+
     UserProfileAdmin.inlines += (ProfileInline,)
 except ProfileNotConfigured:
     pass

--- a/mezzanine/accounts/templates/admin/profile_inline.html
+++ b/mezzanine/accounts/templates/admin/profile_inline.html
@@ -12,7 +12,7 @@
     {{ inline_admin_formset.formset.non_form_errors }}
     <div class="items">
         {% for inline_admin_form in inline_admin_formset %}
-        <div class="{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}">
+        <div class="{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last %} empty-form{% endif %}">
             {% if inline_admin_form.form.non_field_errors %}{{ inline_admin_form.form.non_field_errors }}{% endif %}
             {% for fieldset in inline_admin_form %}
                 {% include "admin/includes/fieldset.html" %}

--- a/mezzanine/core/static/mezzanine/css/admin/global.css
+++ b/mezzanine/core/static/mezzanine/css/admin/global.css
@@ -313,8 +313,3 @@ td, th, th a, label, .help, p.help {
 .related-widget-wrapper .selector {
     margin-right: 10px;
 }
-
-/* Hide duplicate profile fields */
-fieldset.profile .items .empty-form {
-    display: none;
-}

--- a/mezzanine/core/static/mezzanine/css/admin/global.css
+++ b/mezzanine/core/static/mezzanine/css/admin/global.css
@@ -313,3 +313,8 @@ td, th, th a, label, .help, p.help {
 .related-widget-wrapper .selector {
     margin-right: 10px;
 }
+
+/* Hide duplicate profile fields */
+fieldset.profile .items .empty-form {
+    display: none;
+}


### PR DESCRIPTION
Same as the previous fix in #1450, but with ``min_num = 1`` added to ``ProfileInline``.