### PR TITLE
Removed nesting of Context object in editable_loader

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -422,7 +422,7 @@ def editable_loader(context):
             context["editable_obj"]
         except KeyError:
             context["editable_obj"] = context.get("page", None)
-        context["toolbar"] = t.render(Context(context))
+        context["toolbar"] = t.render(context)
         context["richtext_media"] = RichTextField().formfield().widget.media
     return context
 


### PR DESCRIPTION
The additional wrapping of the input `Context` object inside another `Context` object is unnecessary, and causes problems.

For example, `flatten` no longer works:

    >>> from django.template.context import Context
    >>> Context(Context()).flatten()
    ValueError: dictionary update sequence element #0 has length 3; 2 is required

In particular, this causes an incompatibility with django-compressor 1.6+

Producing a full test case of how it causes problems would be a lot of work - any chance this could be accepted without that? There aren't many existing tests for this bit of code - or any, AFAICS.