### PR TITLE
Removed nesting of Context objects

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -101,7 +101,7 @@ def fields_for(context, form, template="includes/form_fields.html"):
     Renders fields for a form with an optional template choice.
     """
     context["form_for_fields"] = form
-    return get_template(template).render(Context(context))
+    return get_template(template).render(context)
 
 
 @register.inclusion_tag("includes/form_errors.html", takes_context=True)
@@ -109,8 +109,7 @@ def errors_for(context, form):
     """
     Renders an alert if the form has any errors.
     """
-    context["form"] = form
-    return context
+    return {"form": form}
 
 
 @register.filter
@@ -244,6 +243,9 @@ def search_form(context, search_model_names=None):
     string ``all`` can also be used, in which case the models defined
     by the ``SEARCH_MODEL_CHOICES`` setting will be used.
     """
+    c = {
+        "request": context["request"],
+    }
     if not search_model_names or not settings.SEARCH_MODEL_CHOICES:
         search_model_names = []
     elif search_model_names == "all":
@@ -259,8 +261,8 @@ def search_form(context, search_model_names=None):
         else:
             verbose_name = model._meta.verbose_name_plural.capitalize()
             search_model_choices.append((verbose_name, model_name))
-    context["search_model_choices"] = sorted(search_model_choices)
-    return context
+    c["search_model_choices"] = sorted(search_model_choices)
+    return c
 
 
 @register.simple_tag
@@ -414,17 +416,19 @@ def editable_loader(context):
     Set up the required JS/CSS for the in-line editing toolbar and controls.
     """
     user = context["request"].user
-    context["has_site_permission"] = has_site_permission(user)
-    if settings.INLINE_EDITING_ENABLED and context["has_site_permission"]:
+    c = {
+        "has_site_permission": has_site_permission(user),
+        "request": context["request"],
+    }
+    if settings.INLINE_EDITING_ENABLED and c["has_site_permission"]:
         t = get_template("includes/editable_toolbar.html")
-        context["REDIRECT_FIELD_NAME"] = REDIRECT_FIELD_NAME
-        try:
-            context["editable_obj"]
-        except KeyError:
-            context["editable_obj"] = context.get("page", None)
-        context["toolbar"] = t.render(Context(context))
-        context["richtext_media"] = RichTextField().formfield().widget.media
-    return context
+        c["REDIRECT_FIELD_NAME"] = REDIRECT_FIELD_NAME
+        c["editable_obj"] = context.get("editable_obj",
+                                        context.get("page", None))
+        c["accounts_logout_url"] = context.get("accounts_logout_url", None)
+        c["toolbar"] = t.render(Context(c))
+        c["richtext_media"] = RichTextField().formfield().widget.media
+    return c
 
 
 @register.filter
@@ -496,7 +500,7 @@ def editable(parsed, context, token):
             context["editable_form"] = get_edit_form(obj, field_names)
             context["original"] = parsed
             t = get_template("includes/editable_form.html")
-            return t.render(Context(context))
+            return t.render(context)
     return parsed
 
 
@@ -621,8 +625,9 @@ def admin_dropdown_menu(context):
     Renders the app list for the admin dropdown menu navigation.
     """
     user = context["request"].user
+    c = {}
     if user.is_staff:
-        context["dropdown_menu_app_list"] = admin_app_list(context["request"])
+        c["dropdown_menu_app_list"] = admin_app_list(context["request"])
         if user.is_superuser:
             sites = Site.objects.all()
         else:
@@ -630,9 +635,11 @@ def admin_dropdown_menu(context):
                 sites = user.sitepermissions.sites.all()
             except ObjectDoesNotExist:
                 sites = Site.objects.none()
-        context["dropdown_menu_sites"] = list(sites)
-        context["dropdown_menu_selected_site_id"] = current_site_id()
-        return context
+        c["dropdown_menu_sites"] = list(sites)
+        c["dropdown_menu_selected_site_id"] = current_site_id()
+        c["settings"] = context["settings"]
+        c["request"] = context["request"]
+        return c
 
 
 @register.inclusion_tag("admin/includes/app_list.html", takes_context=True)
@@ -664,7 +671,7 @@ def dashboard_column(context, token):
     output = []
     for tag in settings.DASHBOARD_TAGS[column_index]:
         t = Template("{%% load %s %%}{%% %s %%}" % tuple(tag.split(".")))
-        output.append(t.render(Context(context)))
+        output.append(t.render(context))
     return "".join(output)
 
 


### PR DESCRIPTION
This supersedes https://github.com/stephenmcd/mezzanine/pull/1519 

Inclusion tags should:

* Return dictionaries, not Context objects
* Explicitly pass all needed data to their templates
* Not modify passed in Context object ideally

No code should wrap Context objects in further Context objects, as this
causes errors in some contexts.

----

Details

The additional wrapping of the input Context object inside another Context object is unnecessary, and causes problems.

For example, flatten no longer works:

    >>> from django.template.context import Context
    >>> Context(Context()).flatten()
    ValueError: dictionary update sequence element #0 has length 3; 2 is required

In particular, this causes an incompatibility with django-compressor 1.6+, and possibly various other projects, especially if you need to override the templates Mezzanine provides for these inclusion tags.

In this PR, I have tried to make sure context dictionaries with everything necessary for the templates are created, and have then manually checked that things like the editable loader etc. are not broken. However, the lack of automated test coverage for this code means that more manual testing might be needed.