### PR TITLE
Removed syncdb from deploy as it is no longer supported in Django1.9 

### DIFF
--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -635,7 +635,6 @@ def deploy():
             rsync_upload()
     with project():
         manage("collectstatic -v 0 --noinput")
-        manage("syncdb --noinput")
         manage("migrate --noinput")
     for name in get_templates():
         upload_template_and_reload(name)


### PR DESCRIPTION
It has been depricated since 1.7, migrate is used instead.

This is captured in bug #1523 