### PR TITLE
Add Mime Type determination to static_proxy

### DIFF
--- a/mezzanine/core/views.py
+++ b/mezzanine/core/views.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 from future.builtins import int, open, str
 
-import os, mimetypes
+import os
+import mimetypes
 
 from json import dumps
 
@@ -35,7 +36,9 @@ from mezzanine.utils.views import is_editable, paginate, set_cookie
 from mezzanine.utils.sites import has_site_permission
 from mezzanine.utils.urls import next_url
 
+
 mimetypes.init()
+
 
 def set_device(request, device=""):
     """
@@ -154,7 +157,7 @@ def static_proxy(request):
     response = ""
     (content_type, encoding) = mimetypes.guess_type(url)
     if content_type is None:
-      content_type = "application/octet-stream"
+        content_type = "application/octet-stream"
     path = finders.find(url)
     if path:
         if isinstance(path, (list, tuple)):

--- a/mezzanine/core/views.py
+++ b/mezzanine/core/views.py
@@ -35,6 +35,7 @@ from mezzanine.utils.views import is_editable, paginate, set_cookie
 from mezzanine.utils.sites import has_site_permission
 from mezzanine.utils.urls import next_url
 
+mimetypes.init()
 
 def set_device(request, device=""):
     """

--- a/mezzanine/core/views.py
+++ b/mezzanine/core/views.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 from future.builtins import int, open, str
 
-import os
+import os, mimetypes
 
 from json import dumps
 
@@ -151,7 +151,9 @@ def static_proxy(request):
         if url.startswith(prefix):
             url = url.replace(prefix, "", 1)
     response = ""
-    content_type = ""
+    (content_type, encoding) = mimetypes.guess_type(url)
+    if content_type is None:
+      content_type = "application/octet-stream"
     path = finders.find(url)
     if path:
         if isinstance(path, (list, tuple)):
@@ -164,11 +166,9 @@ def static_proxy(request):
             if not urlparse(static_url).scheme:
                 static_url = urljoin(host, static_url)
             base_tag = "<base href='%s'>" % static_url
-            content_type = "text/html"
             with open(path, "r") as f:
                 response = f.read().replace("<head>", "<head>" + base_tag)
         else:
-            content_type = "application/octet-stream"
             try:
                 with open(path, "rb") as f:
                     response = f.read()


### PR DESCRIPTION
I was having issues with uploadify because asset_proxy was setting Content-type to application/octet-stream, so I've added code to use the mimetypes library to detemine the correct Content-type header to send. I've tested and it resolves my particular problem.