### PR TITLE
Google Chrome seems to interpret an empty response as <html><body></body></html>

### DIFF
--- a/mezzanine/generic/views.py
+++ b/mezzanine/generic/views.py
@@ -39,7 +39,7 @@ def admin_keywords_submit(request):
             if keyword_id not in keyword_ids:
                 keyword_ids.append(keyword_id)
                 titles.append(title)
-    return HttpResponse("%s|%s" % (",".join(keyword_ids), ", ".join(titles)))
+    return HttpResponse("%s|%s" % (",".join(keyword_ids), ", ".join(titles)), content_type='text/plain')
 
 
 def initial_validation(request, prefix):


### PR DESCRIPTION
Google Chrome seems to interpret an empty response as  <html><body></body></html> so forced content_type to text/plain to prevent Chrome handling it in this way.