### PR TITLE
Fix help text for Link page URL

### DIFF
--- a/mezzanine/pages/admin.py
+++ b/mezzanine/pages/admin.py
@@ -235,6 +235,7 @@ class LinkAdmin(PageAdmin):
         """
         if db_field.name == "slug":
             kwargs["required"] = True
+            kwargs["help_text"] = None
         return super(LinkAdmin, self).formfield_for_dbfield(db_field, **kwargs)
 
     def save_form(self, request, form, change):


### PR DESCRIPTION
The field is required, but the inherited help text says it's optional.