### PR TITLE
Changed dropdown-menu to admin-sidebar for admin panel

### DIFF
--- a/mezzanine/core/locale/ar/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/ar/LC_MESSAGES/django.po
@@ -562,7 +562,7 @@ msgstr "اقرأ المزيد"
 msgid "View site"
 msgstr "عرض الموقع"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "لوحة المعلومات"
 

--- a/mezzanine/core/locale/bg/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/bg/LC_MESSAGES/django.po
@@ -557,7 +557,7 @@ msgstr ""
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr ""
 

--- a/mezzanine/core/locale/ca/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/ca/LC_MESSAGES/django.po
@@ -582,7 +582,7 @@ msgstr "Llegir més"
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Taulell"
 

--- a/mezzanine/core/locale/cs/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/cs/LC_MESSAGES/django.po
@@ -634,7 +634,7 @@ msgstr "více"
 msgid "View site"
 msgstr "Zobrazit náhled"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Nástěnka"
 

--- a/mezzanine/core/locale/de/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/de/LC_MESSAGES/django.po
@@ -650,7 +650,7 @@ msgstr "Weiterlesen"
 msgid "View site"
 msgstr "Seite ansehen"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Dashboard"
 

--- a/mezzanine/core/locale/en/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/en/LC_MESSAGES/django.po
@@ -555,7 +555,7 @@ msgstr ""
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr ""
 

--- a/mezzanine/core/locale/eo/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/eo/LC_MESSAGES/django.po
@@ -544,7 +544,7 @@ msgstr "legu pli"
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Panelo"
 

--- a/mezzanine/core/locale/et/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/et/LC_MESSAGES/django.po
@@ -559,7 +559,7 @@ msgstr "loe lisa"
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Töölaud"
 

--- a/mezzanine/core/locale/fa/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/fa/LC_MESSAGES/django.po
@@ -644,7 +644,7 @@ msgstr "خواندن بیشتر"
 msgid "View site"
 msgstr "مشاهده سایت"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "داشبورد"
 

--- a/mezzanine/core/locale/fa_IR/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/fa_IR/LC_MESSAGES/django.po
@@ -684,7 +684,7 @@ msgstr "خواندن بیشتر"
 msgid "View site"
 msgstr "مشاهده سایت"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "داشبورد"
 

--- a/mezzanine/core/locale/fi/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/fi/LC_MESSAGES/django.po
@@ -677,7 +677,7 @@ msgstr "Jatka lukemista"
 msgid "View site"
 msgstr "Näytä sivusto"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Hallintapaneeli"
 

--- a/mezzanine/core/locale/fr/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/fr/LC_MESSAGES/django.po
@@ -716,7 +716,7 @@ msgstr "lire la suite"
 msgid "View site"
 msgstr "Voir le site"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Tableau de bord"
 

--- a/mezzanine/core/locale/hr_HR/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/hr_HR/LC_MESSAGES/django.po
@@ -542,7 +542,7 @@ msgstr "pročitaj više"
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Upravljačka ploča"
 

--- a/mezzanine/core/locale/hu/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/hu/LC_MESSAGES/django.po
@@ -581,7 +581,7 @@ msgstr "tovább"
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Műszerfal"
 

--- a/mezzanine/core/locale/id_ID/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/id_ID/LC_MESSAGES/django.po
@@ -556,7 +556,7 @@ msgstr ""
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr ""
 

--- a/mezzanine/core/locale/is_IS/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/is_IS/LC_MESSAGES/django.po
@@ -557,7 +557,7 @@ msgstr "lesa meira"
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr ""
 

--- a/mezzanine/core/locale/it/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/it/LC_MESSAGES/django.po
@@ -703,7 +703,7 @@ msgstr "leggi il resto"
 msgid "View site"
 msgstr "Vedi il sito"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Pannello di controllo"
 

--- a/mezzanine/core/locale/ja/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/ja/LC_MESSAGES/django.po
@@ -651,7 +651,7 @@ msgstr "もっと読む"
 msgid "View site"
 msgstr "サイトを見る"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "ダッシュボード"
 

--- a/mezzanine/core/locale/ko/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/ko/LC_MESSAGES/django.po
@@ -560,7 +560,7 @@ msgstr "더 읽기"
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "대시보드"
 

--- a/mezzanine/core/locale/lv/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/lv/LC_MESSAGES/django.po
@@ -558,7 +558,7 @@ msgstr "lasīt vairāk"
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Darbagalds"
 

--- a/mezzanine/core/locale/nb/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/nb/LC_MESSAGES/django.po
@@ -545,7 +545,7 @@ msgstr "les mer"
 msgid "View site"
 msgstr "Vis webside"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Dashbord"
 

--- a/mezzanine/core/locale/nl/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/nl/LC_MESSAGES/django.po
@@ -656,7 +656,7 @@ msgstr "lees meer"
 msgid "View site"
 msgstr "Toon site"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Dashboard"
 

--- a/mezzanine/core/locale/pap/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/pap/LC_MESSAGES/django.po
@@ -557,7 +557,7 @@ msgstr "lesa mas"
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Panel di kontrol"
 

--- a/mezzanine/core/locale/pl/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/pl/LC_MESSAGES/django.po
@@ -544,7 +544,7 @@ msgstr "czytaj więcej"
 msgid "View site"
 msgstr "Przejdź do strony"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Kokpit"
 

--- a/mezzanine/core/locale/pt_BR/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/pt_BR/LC_MESSAGES/django.po
@@ -541,7 +541,7 @@ msgstr "leia mais"
 msgid "View site"
 msgstr "Ver site"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Painel"
 

--- a/mezzanine/core/locale/pt_PT/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/pt_PT/LC_MESSAGES/django.po
@@ -586,7 +586,7 @@ msgstr "ler mais"
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Painel"
 

--- a/mezzanine/core/locale/ru/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/ru/LC_MESSAGES/django.po
@@ -549,7 +549,7 @@ msgstr "читать далее"
 msgid "View site"
 msgstr "Просмотр сайта"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Панель управления"
 

--- a/mezzanine/core/locale/sk/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/sk/LC_MESSAGES/django.po
@@ -562,7 +562,7 @@ msgstr "čítať viac"
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Nástenka"
 

--- a/mezzanine/core/locale/sr_Latn/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/sr_Latn/LC_MESSAGES/django.po
@@ -693,7 +693,7 @@ msgstr "pročitaj više"
 msgid "View site"
 msgstr "Prikaži sajt"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Kontrolna tabla"
 

--- a/mezzanine/core/locale/sv/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/sv/LC_MESSAGES/django.po
@@ -653,7 +653,7 @@ msgstr "läs mer"
 msgid "View site"
 msgstr "Se webbplatsen"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Panel"
 

--- a/mezzanine/core/locale/tr/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/tr/LC_MESSAGES/django.po
@@ -542,7 +542,7 @@ msgstr "daha fazlasını oku"
 msgid "View site"
 msgstr "Siteye dön"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Kontrol Paneli"
 

--- a/mezzanine/core/locale/uk_UA/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/uk_UA/LC_MESSAGES/django.po
@@ -647,7 +647,7 @@ msgstr "читати далі"
 msgid "View site"
 msgstr "Переглянути на сайті"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Панель управління"
 

--- a/mezzanine/core/locale/vi_VN/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/vi_VN/LC_MESSAGES/django.po
@@ -679,7 +679,7 @@ msgstr "đọc thêm"
 msgid "View site"
 msgstr "Xem site"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "Bảng điều khiển"
 

--- a/mezzanine/core/locale/zh/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/zh/LC_MESSAGES/django.po
@@ -556,7 +556,7 @@ msgstr ""
 msgid "View site"
 msgstr ""
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr ""
 

--- a/mezzanine/core/locale/zh_CN/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/zh_CN/LC_MESSAGES/django.po
@@ -621,7 +621,7 @@ msgstr "显示更多"
 msgid "View site"
 msgstr "PC版本"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "控制面板"
 

--- a/mezzanine/core/locale/zh_TW/LC_MESSAGES/django.po
+++ b/mezzanine/core/locale/zh_TW/LC_MESSAGES/django.po
@@ -543,7 +543,7 @@ msgstr "顯示更多"
 msgid "View site"
 msgstr "查看網站"
 
-#: templates/admin/index.html:17 templates/admin/includes/dropdown_menu.html:4
+#: templates/admin/index.html:17 templates/admin/includes/sidebar.html:4
 msgid "Dashboard"
 msgstr "儀表板"
 

--- a/mezzanine/core/static/mezzanine/css/admin/global.css
+++ b/mezzanine/core/static/mezzanine/css/admin/global.css
@@ -121,7 +121,7 @@ body.popup .breadcrumbs + ul.messagelist {
     top: 0;
     z-index: 2;
 }
-.dropdown-menu {
+.admin-sidebar {
     border-right: 1px solid #222;
     float: left;
     height: 95%; /* Fallback height */
@@ -132,41 +132,41 @@ body.popup .breadcrumbs + ul.messagelist {
     overflow-y: auto;
     width: 216px;
 }
-.dropdown-menu.hidden {
+.admin-sidebar.hidden {
     margin-left: -207px;
 }
-.dropdown-menu > ul {
+.admin-sidebar > ul {
     border-bottom: 1px solid #555;
 }
-.dropdown-menu > ul > li {
+.admin-sidebar > ul > li {
     padding: 20px 17px;
     list-style-type: none;
     border-bottom: 1px solid #222;
     border-top: 1px solid #555;
 }
-.dropdown-menu > ul > li:first-child {
+.admin-sidebar > ul > li:first-child {
     border-top: 0;
 }
-.dropdown-menu-menu > li {
+.admin-app-menu > li {
     padding: 15px 0 0 1px;
 }
-.dropdown-menu li a {
+.admin-sidebar li a {
     font-size: 20px;
 }
-.dropdown-menu li a:hover {
+.admin-sidebar li a:hover {
     color: #fff;
 }
-.dropdown-menu .selected,
-.dropdown-menu-menu > li > a:hover {
+.admin-sidebar .selected,
+.admin-app-menu > li > a:hover {
     border-left: 10px solid #666;
     margin-left: -20px;
     padding-left: 10px;
 }
-.dropdown-menu li li a {
+.admin-sidebar li li a {
     font-size: 15px;
     color: #ccc;
 }
-.dropdown-menu form {
+.admin-sidebar form {
     display: none;
 }
 #side-panel-toggle {

--- a/mezzanine/core/static/mezzanine/css/admin/rtl.css
+++ b/mezzanine/core/static/mezzanine/css/admin/rtl.css
@@ -15,7 +15,7 @@
     right: 0;
 }
 
-.dropdown-menu {
+.admin-sidebar {
     float: right;
 }
 
@@ -23,7 +23,7 @@
     float: left;
 }
 
-.dropdown-menu.hidden {
+.admin-sidebar.hidden {
     margin-left: auto;
     margin-right: -207px;
 }
@@ -47,7 +47,7 @@ ul.messagelist {
     margin-right: 17px;
 }
 
-.dropdown-menu .selected, .dropdown-menu-menu > li > a:hover {
+.admin-sidebar .selected, .admin-app-menu > li > a:hover {
     border-left: none;
     margin-left: 0;
     padding-left: 0;
@@ -56,7 +56,7 @@ ul.messagelist {
     padding-right: 10px;
 }
 
-.dropdown-menu form {
+.admin-sidebar form {
     float: left;
     margin: 3px 0 0 22px;
 }

--- a/mezzanine/core/static/mezzanine/js/admin/navigation.js
+++ b/mezzanine/core/static/mezzanine/js/admin/navigation.js
@@ -1,15 +1,15 @@
 
 jQuery(function($) {
 
-    $('#user-tools').after($('.dropdown-menu form'));
+    $('#user-tools').after($('.admin-sidebar form'));
     $('#header form').show().addClass('dark-select').find('select').chosen();
     $('.changelist-actions select').chosen();
 
     // Set the hrefs for the primary menu items to the href of their first
     // child (unless the primary menu item already has an href).
-    $('.dropdown-menu a').each(function() {
+    $('.admin-sidebar a').each(function() {
        if ( $(this).attr('href') == '#' ) {
-         $(this).attr('href', $(this).parent().find('.dropdown-menu-menu a:first').attr('href'));
+         $(this).attr('href', $(this).parent().find('.admin-app-menu a:first').attr('href'));
        }
     });
 
@@ -18,12 +18,12 @@ jQuery(function($) {
 
     // Hide all dropdown menus and apply click handlers.
     if (window.__admin_menu_collapsed) {
-        $('.dropdown-menu-menu').removeClass('open').hide();
-        $('.dropdown-menu > ul > li').click(function(){
-            var menu = $(this).children('.dropdown-menu-menu');
+        $('.admin-app-menu').removeClass('open').hide();
+        $('.admin-sidebar > ul > li').click(function(){
+            var menu = $(this).children('.admin-app-menu');
             if (menu.length > 0){
                 if (!menu.hasClass('open')) {
-                    $('.dropdown-menu-menu').removeClass('open').hide(400);
+                    $('.admin-app-menu').removeClass('open').hide(400);
                     menu.show(400).addClass('open');
                     return false;
                 }
@@ -35,14 +35,14 @@ jQuery(function($) {
     if (path == '/admin/password_change/') {
         path = '/admin/auth/user/';
     }
-    $('.dropdown-menu ul li li > a').each(function() {
+    $('.admin-sidebar ul li li > a').each(function() {
         // Open current section on load.
         var href = $(this).attr('href');
         if (href.substr(href.length - 12, href.length) == '/pages/page/') {
             pages = href;
         }
         $(this).click(function() {
-            $('.dropdown-menu .selected').removeClass('selected');
+            $('.admin-sidebar .selected').removeClass('selected');
             $(this).addClass('selected');
             return true;
         });
@@ -55,11 +55,11 @@ jQuery(function($) {
         }
     });
     if (!selected && path != window.__admin_url) {
-        $('.dropdown-menu li li a[href="' + pages + '"]').addClass('selected');
+        $('.admin-sidebar li li a[href="' + pages + '"]').addClass('selected');
     }
 
     // Get panel hidden/shown state from local storage.
-    var side_menu = $('.dropdown-menu');
+    var side_menu = $('.admin-sidebar');
     var messages = $('.messagelist');
     var content = $('#content');
     var bottom_controls = $('.change-form .submit-row');

--- a/mezzanine/core/templates/admin/base_site.html
+++ b/mezzanine/core/templates/admin/base_site.html
@@ -53,7 +53,7 @@ jQuery(function($) {
 
 {% block before_content %}
 {% if user.is_staff and not is_popup and not request.GET.pop %}
-{% admin_dropdown_menu %}
+{% admin_sidebar %}
 {% endif %}
 {% endblock %}
 

--- a/mezzanine/core/templates/admin/includes/sidebar.html
+++ b/mezzanine/core/templates/admin/includes/sidebar.html
@@ -1,11 +1,11 @@
 {% load i18n mezzanine_tags %}
 <div id="side-panel">
-<div class="dropdown-menu">
+<div class="admin-sidebar">
 <ul>
-    {% for app in dropdown_menu_app_list %}
+    {% for app in sidebar_app_list %}
     <li>
         <a href="#">{% trans app.name %}</a>
-        <ul class="dropdown-menu-menu">
+        <ul class="admin-app-menu">
         {% for model in app.models %}
             {% if model.perms.add or model.perms.change or model.perms.custom %}
             <li{% if forloop.first %} class="first"{% endif %}><a
@@ -28,13 +28,13 @@
 </form>
 {% endif %}
 
-{% if dropdown_menu_sites and dropdown_menu_sites|length > 1 %}
+{% if sidebar_sites and sidebar_sites|length > 1 %}
 <form action="{% url "set_site" %}">
 <input type="hidden" name="next" value="{{ request.path }}">
 <select name="site_id" onchange="this.form.submit();">
-{% for site in dropdown_menu_sites %}
+{% for site in sidebar_sites %}
 <option value="{{ site.id }}"
-    {% if site.id == dropdown_menu_selected_site_id %} selected{% endif %}
+    {% if site.id == sidebar_selected_site_id %} selected{% endif %}
     >{{ site }}</option>
 {% endfor %}
 </select>

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -528,7 +528,7 @@ def admin_app_list(request):
     Adopted from ``django.contrib.admin.sites.AdminSite.index``.
     Returns a list of lists of models grouped and ordered according to
     ``mezzanine.conf.ADMIN_MENU_ORDER``. Called from the
-    ``admin_dropdown_menu`` template tag as well as the ``app_list``
+    ``admin_sidebar`` template tag as well as the ``app_list``
     dashboard widget.
     """
     app_dict = {}
@@ -621,16 +621,16 @@ def admin_app_list(request):
     return app_list
 
 
-@register.inclusion_tag("admin/includes/dropdown_menu.html",
+@register.inclusion_tag("admin/includes/sidebar.html",
                         takes_context=True)
-def admin_dropdown_menu(context):
+def admin_sidebar(context):
     """
     Renders the app list for the admin dropdown menu navigation.
     """
     user = context["request"].user
     template_vars = {}
     if user.is_staff:
-        template_vars["dropdown_menu_app_list"] = admin_app_list(
+        template_vars["sidebar_app_list"] = admin_app_list(
             context["request"])
         if user.is_superuser:
             sites = Site.objects.all()
@@ -639,8 +639,8 @@ def admin_dropdown_menu(context):
                 sites = user.sitepermissions.sites.all()
             except ObjectDoesNotExist:
                 sites = Site.objects.none()
-        template_vars["dropdown_menu_sites"] = list(sites)
-        template_vars["dropdown_menu_selected_site_id"] = current_site_id()
+        template_vars["sidebar_sites"] = list(sites)
+        template_vars["sidebar_selected_site_id"] = current_site_id()
         template_vars["settings"] = context["settings"]
         template_vars["request"] = context["request"]
         return template_vars


### PR DESCRIPTION
For for issue #1554 : The admin sidebar breaks once an app redefines styles for `.dropdown-menu`.

* changed class names from `.dropdown-menu` to `.admin-sidebar` and `.dropdown-menu-menu` to `.admin-app-menu`
* changed template name to `sidebar.html`
* changed template tag name to `admin_sidebar`
* modified other files accordingly