### PR TITLE
Update blog share button links

### DIFF
--- a/mezzanine/blog/templates/blog/blog_post_detail.html
+++ b/mezzanine/blog/templates/blog/blog_post_detail.html
@@ -90,8 +90,8 @@
 
 {% block blog_post_detail_sharebuttons %}
 {% set_short_url_for blog_post %}
-<a class="btn btn-sm share-twitter" target="_blank" href="http://twitter.com/home?status={{ blog_post.short_url|urlencode }}%20{{ blog_post.title|urlencode }}">{% trans "Share on Twitter" %}</a>
-<a class="btn btn-sm share-facebook" target="_blank" href="http://facebook.com/sharer.php?u={{ request.build_absolute_uri }}&amp;t={{ blog_post.title|urlencode }}">{% trans "Share on Facebook" %}</a>
+<a class="btn btn-sm share-twitter" target="_blank" href="https://twitter.com/intent/tweet?url={{ blog_post.short_url|urlencode }}&amp;text={{ blog_post.title|urlencode }}">{% trans "Share on Twitter" %}</a>
+<a class="btn btn-sm share-facebook" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{ request.build_absolute_uri }}">{% trans "Share on Facebook" %}</a>
 {% endblock %}
 
 {% block blog_post_previous_next %}


### PR DESCRIPTION
Hi!

This small patch makes two changes to `blog_post_detail.html`:

For Twitter, use the new [web-intent API](https://dev.twitter.com/web/tweet-button/web-intent) which allows us to send the URL and text separately in structured format.

For Facebook, update the sharer URL and remove all parameters except the URL as [they are ignored](https://developers.facebook.com/x/bugs/357750474364812/) - it only let's you submit a URL which Facebook will crawl and fetch Open Graph content from.