### PR TITLE
Add Coveralls coverage testing to CI, per #1012.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,12 @@ python:
 install:
   - pip install $DJANGO
   - pip install .
+  - pip install coveralls
+  - pip install coverage
 script:
-  - python setup.py test
+  - coverage run --source mezzanine setup.py test
 notifications:
   irc: "irc.freenode.org#mezzanine"
   on_success: change
   on_failure: change
+after_success: coveralls


### PR DESCRIPTION
A collaborator just needs to go to coveralls.io, login via github oauth, and flip the switch to "On".