### PR TITLE
Clear TEST_COLLATION deprecation warning

### DIFF
--- a/mezzanine/utils/conf.py
+++ b/mezzanine/utils/conf.py
@@ -214,7 +214,7 @@ def set_dynamic_settings(s):
                 s["DATABASES"][key]["NAME"] = db_path
         elif shortname == "mysql":
             # Required MySQL collation for tests.
-            s["DATABASES"][key]["TEST_COLLATION"] = "utf8_general_ci"
+            s["DATABASES"][key].setdefault("TEST", {})["COLLATION"] = "utf8_general_ci"
 
 
 def real_project_name(project_name):

--- a/mezzanine/utils/conf.py
+++ b/mezzanine/utils/conf.py
@@ -211,10 +211,10 @@ def set_dynamic_settings(s):
             # it's in the project directory and add the path to it.
             if "NAME" in db and os.sep not in db["NAME"]:
                 db_path = os.path.join(s.get("PROJECT_ROOT", ""), db["NAME"])
-                s["DATABASES"][key]["NAME"] = db_path
+                db["NAME"] = db_path
         elif shortname == "mysql":
             # Required MySQL collation for tests.
-            s["DATABASES"][key].setdefault("TEST", {})["COLLATION"] = "utf8_general_ci"
+            db.setdefault("TEST", {})["COLLATION"] = "utf8_general_ci"
 
 
 def real_project_name(project_name):


### PR DESCRIPTION
This patch gets rid of the deprecation warning when using MySQL:

`RemovedInDjango19Warning: In Django 1.9 the TEST_COLLATION connection setting will be moved to a COLLATION entry in the TEST setting`

The database test settings moved under a `TEST` parent setting with [Django 1.7](https://docs.djangoproject.com/en/1.7/ref/settings/#test) so it is supported by all versions of Django that Mezzanine supports. Should make the line of code compatible with 1.9.