### PR TITLE
Only autofocus visible fields with Html5Mixin

### DIFF
--- a/mezzanine/core/forms.py
+++ b/mezzanine/core/forms.py
@@ -21,11 +21,13 @@ class Html5Mixin(object):
     def __init__(self, *args, **kwargs):
         super(Html5Mixin, self).__init__(*args, **kwargs)
         if hasattr(self, "fields"):
-            # Autofocus first field
-            first_field = next(iter(self.fields.values()))
-            first_field.widget.attrs["autofocus"] = ""
+            first_field = None
 
             for name, field in self.fields.items():
+                # Autofocus first non-hidden field
+                if not first_field and not field.widget.is_hidden:
+                    first_field = field
+                    first_field.widget.attrs["autofocus"] = ""
                 if settings.FORMS_USE_HTML5:
                     if isinstance(field, forms.EmailField):
                         self.fields[name].widget.input_type = "email"


### PR DESCRIPTION
Check if a widget is visible before adding the `autofocus` attribute. In Cartridge where form fields are hidden between checkout steps the Html5Mixin was adding `autofocus` to hidden fields, which is both not very useful, and fails HTML validation.