### PR TITLE
Replace all _meta.fields with _meta.get_fields.

### DIFF
--- a/mezzanine/accounts/__init__.py
+++ b/mezzanine/accounts/__init__.py
@@ -82,7 +82,7 @@ def get_profile_user_fieldname(profile_model=None, user_model=None):
     """
     Profile = profile_model or get_profile_model()
     User = user_model or get_user_model()
-    for field in Profile._meta.fields:
+    for field in Profile._meta.get_fields():
         if field.rel and field.rel.to == User:
             return field.name
     raise ImproperlyConfigured("Value for AUTH_PROFILE_MODULE does not "

--- a/mezzanine/accounts/templatetags/accounts_tags.py
+++ b/mezzanine/accounts/templatetags/accounts_tags.py
@@ -70,7 +70,7 @@ def profile_fields(user):
         profile = get_profile_for_user(user)
         user_fieldname = get_profile_user_fieldname()
         exclude = tuple(settings.ACCOUNTS_PROFILE_FORM_EXCLUDE_FIELDS)
-        for field in profile._meta.fields:
+        for field in profile._meta.get_fields():
             if field.name not in ("id", user_fieldname) + exclude:
                 value = getattr(profile, field.name)
                 fields[field.verbose_name.title()] = value

--- a/mezzanine/core/managers.py
+++ b/mezzanine/core/managers.py
@@ -232,7 +232,7 @@ class SearchableManager(Manager):
                 search_fields.update(search_fields_to_dict(super_fields))
         if not search_fields:
             search_fields = []
-            for f in self.model._meta.fields:
+            for f in self.model._meta.get_fields():
                 if isinstance(f, (CharField, TextField)):
                     search_fields.append(f.name)
             search_fields = search_fields_to_dict(search_fields)

--- a/mezzanine/core/models.py
+++ b/mezzanine/core/models.py
@@ -157,7 +157,7 @@ class MetaData(models.Model):
         # Use the first RichTextField, or TextField if none found.
         for field_type in (RichTextField, models.TextField):
             if not description:
-                for field in self._meta.fields:
+                for field in self._meta.get_fields():
                     if (isinstance(field, field_type) and
                             field.name != "description"):
                         description = getattr(self, field.name)

--- a/mezzanine/pages/admin.py
+++ b/mezzanine/pages/admin.py
@@ -75,7 +75,8 @@ class PageAdmin(DisplayableAdmin):
                 exclude_fields.extend(self.form.Meta.exclude)
             except (AttributeError, TypeError):
                 pass
-            fields = self.model._meta.fields + self.model._meta.many_to_many
+            fields = self.model._meta.get_fields() \
+                + self.model._meta.many_to_many
             for field in reversed(fields):
                 if field.name not in exclude_fields and field.editable:
                     if not hasattr(field, "translated_field"):


### PR DESCRIPTION
According to https://docs.djangoproject.com/en/1.8/ref/models/meta/ to
access all the fields of the _meta object you should call get_fields(). This
is new with Django 1.8. The _meta.fields is now a property with a docstring
saying it's Private API intended only to be used by Django itself.
