### PR TITLE
Ensure csrftoken cookie is set inside nevercache tag

### DIFF
--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -173,6 +173,15 @@ class UpdateCacheMiddleware(object):
         if hasattr(request, '_messages'):
             # Required to clear out user messages.
             request._messages.update(response)
+        if csrf_token:
+            # Response needs to be run-through the CSRF middleware again so
+            # that if there was a {% csrf_token %} inside of the nevercache
+            # the cookie will be correctly set for the the response
+            csrf_mw_name = "django.middleware.csrf.CsrfViewMiddleware"
+            if csrf_mw_name in settings.MIDDLEWARE_CLASSES:
+                request.csrf_processing_done = False
+                csrf_mw = CsrfViewMiddleware()
+                csrf_mw.process_response(request, response)
         return response
 
 

--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -173,15 +173,14 @@ class UpdateCacheMiddleware(object):
         if hasattr(request, '_messages'):
             # Required to clear out user messages.
             request._messages.update(response)
-        if csrf_token:
-            # Response needs to be run-through the CSRF middleware again so
-            # that if there was a {% csrf_token %} inside of the nevercache
-            # the cookie will be correctly set for the the response
-            csrf_mw_name = "django.middleware.csrf.CsrfViewMiddleware"
-            if csrf_mw_name in settings.MIDDLEWARE_CLASSES:
-                request.csrf_processing_done = False
-                csrf_mw = CsrfViewMiddleware()
-                csrf_mw.process_response(request, response)
+        # Response needs to be run-through the CSRF middleware again so
+        # that if there was a {% csrf_token %} inside of the nevercache
+        # the cookie will be correctly set for the the response
+        csrf_mw_name = "django.middleware.csrf.CsrfViewMiddleware"
+        if csrf_mw_name in settings.MIDDLEWARE_CLASSES:
+            request.csrf_processing_done = False
+            csrf_mw = CsrfViewMiddleware()
+            csrf_mw.process_response(request, response)
         return response
 
 

--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -178,7 +178,7 @@ class UpdateCacheMiddleware(object):
         # the cookie will be correctly set for the the response
         csrf_mw_name = "django.middleware.csrf.CsrfViewMiddleware"
         if csrf_mw_name in settings.MIDDLEWARE_CLASSES:
-            request.csrf_processing_done = False
+            response.csrf_processing_done = False
             csrf_mw = CsrfViewMiddleware()
             csrf_mw.process_response(request, response)
         return response

--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -4,6 +4,7 @@ import re
 from unittest import skipUnless
 
 from mezzanine.core.middleware import FetchFromCacheMiddleware
+from mezzanine.core.templatetags.mezzanine_tags import initialize_nevercache
 from mezzanine.utils.cache import cache_installed
 
 try:
@@ -13,6 +14,7 @@ except ImportError:
     # Python 2
     from urllib import urlencode
 
+from django.conf.urls import url
 from django.contrib.admin import AdminSite
 from django.contrib.admin.options import InlineModelAdmin
 from django.contrib.sites.models import Site
@@ -21,6 +23,8 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.forms import Textarea
 from django.forms.models import modelform_factory
+from django.http import HttpResponse
+from django.template import RequestContext, Template
 from django.templatetags.static import static
 from django.test.utils import override_settings
 from django.utils.html import strip_tags
@@ -534,3 +538,61 @@ class SiteRelatedTestCase(TestCase):
 
         site1.delete()
         site2.delete()
+
+
+class CSRFTestViews(object):
+    def nevercache_view(request):
+        template = "{% load mezzanine_tags %}"
+        template += "{% nevercache %}"
+        template += "{% csrf_token %}"
+        template += "{% endnevercache %}"
+
+        rendered = Template(template).render(RequestContext(request))
+
+        return HttpResponse(rendered)
+
+    urlpatterns = [
+        url("^nevercache_view/", nevercache_view),
+    ]
+
+
+class CSRFTestCase(TestCase):
+    @classmethod
+    def tearDownClass(cls):
+        # Initialize nevercache again now that @override_settings is finished
+        cache_installed.cache_clear()
+        initialize_nevercache()
+
+    @override_settings(
+        ROOT_URLCONF=CSRFTestViews,
+        CACHES={
+            'default': {
+                'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+             }
+        },
+        MIDDLEWARE_CLASSES=(
+            'mezzanine.core.middleware.UpdateCacheMiddleware',) +
+            settings.MIDDLEWARE_CLASSES +
+            ('mezzanine.core.middleware.FetchFromCacheMiddleware',
+        ),
+        TESTING=False)
+    def test_csrf_cookie_with_nevercache(self):
+        """
+        Test that the CSRF cookie is properly set when using nevercache.
+        """
+
+        # Clear the cached value for cache_installed and initialize nevercache
+        cache_installed.cache_clear()
+        initialize_nevercache()
+
+        # Test uses an authenticated user as the middleware behavior differs
+        self.client.login(username=self._username, password=self._password)
+        response = self.client.get("/nevercache_view/")
+
+        # CSRF token is expected to be rendered
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "csrfmiddlewaretoken")
+
+        # The CSRF cookie should be present
+        csrf_cookie = response.cookies.get(settings.CSRF_COOKIE_NAME, False)
+        self.assertNotEqual(csrf_cookie, False)


### PR DESCRIPTION
I'm currently hunting down occasional CSRF failures for users and noticed that Mezzanine isn't setting the CSRF cookie when it should for logged in users. It's not the cause for the issues I'm tracking, but it is a potential issue for other setups.

When the nevercache tag is used, any `{% csrf_token %}` inside the tag will not trigger a set cookie for the `csrftoken` cookie because the `CsrfViewMiddleware` has already run by the time `UpdateCacheMiddleware` renders the contents of the nevercache tag. Since the standard Mezzanine template include `core/templates/includes/form_fields.html` wraps the `{% csrf_token %}` with a nevercache tag this affects most forms being rendered by Mezzanine. It can be observed by logging into the demo site and going to 'Update Profile'. If you inspect the HTTP response there is no Set-Cookie for `csrftoken`.

Generally this isn't a problem because the cookie is set on login and has an expiration time of 1 year. Clearing cookies will also clear the session cookie and log the user out, so it's hard to end up in a situation where the session cookie is set (so the user is logged in) but not the CSRF cookie. In theory if the CSRF token is not refreshed within a year it will start failing, but it's unlikely for a user to be logged in for a year. This length is however [configurable](https://docs.djangoproject.com/en/1.9/ref/settings/#csrf-cookie-age) and there may be use cases (the docs mention IE problems) where setting it to `None` for a session-length cookie is needed, which could result in the situation where the user is logged in but the CSRF token cookie is not set after the the user closes their browser and reopens it.

Another possible case this would be problematic would be if a server is setup to use HTTP Basic Auth and Django is using a [Remote User Auth](https://docs.djangoproject.com/es/1.9/howto/auth-remote-user/). In that case there is no login form to cause the CSRF token to be set so the first time the user tries to use a form with this bug it would fail.

The pull request simply runs the `CsrfViewMiddleware` again for the response to set the cookie if `{% csrf_token %}` was used in a nevercache tag. There are no observable side effects from running it twice in the case that the cookie has already been set by a `{% csrf_token %}` not in a nevercache tag.