### PR TITLE
Fix tests for pyflakes 1.2.x

### DIFF
--- a/mezzanine/utils/tests.py
+++ b/mezzanine/utils/tests.py
@@ -19,7 +19,7 @@ from mezzanine.utils.importing import path_for_import
 IGNORE_ERRORS = (
 
     # Used to version subpackages.
-    "'__version__' imported but unused",
+    "'mezzanine.__version__' imported but unused",
 
     # No caching fallback.
     "redefinition of function 'nevercache'",


### PR DESCRIPTION
The warning message now includes the module name.