### PR TITLE
Add contrib_comments to INSTALLED_APPS in template

### DIFF
--- a/mezzanine/project_template/project_name/settings.py
+++ b/mezzanine/project_template/project_name/settings.py
@@ -238,6 +238,7 @@ INSTALLED_APPS = (
     "django.contrib.sites",
     "django.contrib.sitemaps",
     "django.contrib.staticfiles",
+    "django_comments",
     "mezzanine.boot",
     "mezzanine.conf",
     "mezzanine.core",


### PR DESCRIPTION
I'm not sure why this hasn't been a problem before, but now I'm seeing
the following traceback when contrib_comments isn't in INSTALLED_APPS:

```
  File ".../lib/python3.4/site-packages/Mezzanine-4.1.0-py3.4.egg/mezzanine/generic/models.py", line 10, in <module>
    from django_comments.models import Comment
  File ".../lib/python3.4/site-packages/django_comments/models.py", line 12, in <module>
    class Comment(CommentAbstractModel):
  File ".../lib/python3.4/site-packages/Django-1.9.6-py3.4.egg/django/db/models/base.py", line 102, in __new__
    "INSTALLED_APPS." % (module, name)
RuntimeError: Model class django_comments.models.Comment doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```