### PR TITLE
Fix file name decoding from zip files in python 3.

### DIFF
--- a/mezzanine/galleries/models.py
+++ b/mezzanine/galleries/models.py
@@ -69,13 +69,21 @@ class BaseGallery(models.Model):
                 except:
                     continue
                 name = os.path.split(name)[1]
-                # This is a way of getting around the broken nature of
-                # os.path.join on Python 2.x. See also the comment below.
+
+                # In python3, name is a string. Convert it to bytes.
+                if not isinstance(name, bytes):
+                    try:
+                        name = name.encode('cp437')
+                    except UnicodeEncodeError:
+                        # File name includes characters that aren't in cp437,
+                        # which isn't supported by most zip tooling. They will
+                        # not appear correctly.
+                        tempname = name
+
+                # Decode byte-name.
                 if isinstance(name, bytes):
                     encoding = charsetdetect(name)['encoding']
                     tempname = name.decode(encoding)
-                else:
-                    tempname = name
 
                 # A gallery with a slug of "/" tries to extract files
                 # to / on disk; see os.path.join docs.


### PR DESCRIPTION
In python3, non-ascii filenames in galleries are incorrectly decoded,
interpreting utf8 code points as box-drawing characters. For example, in
the demo project "Ávila Spain" is incorrectly parsed as "A╠üvila Spain".

CP437 is a superset of ascii and the de facto standard for file names.
Obviously not every valid utf-8 character is in this character set, but
a lot of tooling does not support file names with characters outside
this set anyway. If we were to encode them in a broader character set I
suspect we would get into OS-interoperability issues, so better to
forego encoding them and coerce them into valid file names.

Note that this changes the behavior such that in python3, file names are
now decoded with a chardet-detected encoding.

It's also notable that the latest release of chardet incorrectly
identifies the encoding, so in the demo galleries, "Ávila Spain" is
incorrectly parsed as "AĚvila Spain". This is fixed in chardet master.