### PR TITLE
Remove leading slash from BLOG_SLUG url pattern

### DIFF
--- a/mezzanine/urls.py
+++ b/mezzanine/urls.py
@@ -67,7 +67,7 @@ if "mezzanine.accounts" in settings.INSTALLED_APPS:
 # Mezzanine's Blog app.
 blog_installed = "mezzanine.blog" in settings.INSTALLED_APPS
 if blog_installed:
-    BLOG_SLUG = settings.BLOG_SLUG.rstrip("/") + "/"
+    BLOG_SLUG = settings.BLOG_SLUG.rstrip("/")
     blog_patterns = [
         url("^%s" % BLOG_SLUG, include("mezzanine.blog.urls")),
     ]


### PR DESCRIPTION
Gives error "?: (urls.W002) Your URL pattern '^/' has a regex beginning with a '/'. Remove this slash as it is unnecessary."

Mezzanine 4.1.0
Django 1.9.6
Python 3.4.4
MySQL 5.7.10
Darwin 15.5.0