### PR TITLE
unicode method for form.fields

### DIFF
--- a/mezzanine/forms/models.py
+++ b/mezzanine/forms/models.py
@@ -77,7 +77,10 @@ class Field(Orderable):
 
     def __str__(self):
         return self.label
-
+    
+    def __unicode__(self):
+        return self.label
+    
     def get_choices(self):
         """
         Parse a comma separated choice string into a list of choices taking


### PR DESCRIPTION
As django templates and models primarily translate all strings to unicode.  This may be preferred and less confusing over the status quo u'field_01', u'field_02', etc.