### PR TITLE
Replace usage of optparse with argparse

### DIFF
--- a/docs/blog-importing.rst
+++ b/docs/blog-importing.rst
@@ -168,10 +168,10 @@ management.base.BaseImporterCommand.add_comment` method. For example::
 
     class Command(BaseImporterCommand):
 
-        option_list = BaseImporterCommand.option_list + (
-            make_option("-s", "--some-arg-name", dest="some_arg_var",
-                help="Description of some-arg-name"),
-        )
+        def add_arguments(self, parser):
+            parser.add_argument(
+                "-s", "--some-arg-name", dest="some_arg_var",
+                help="Description of some-arg-name")
 
         def handle_import(self, options):
             # Perform the tasks that need to occur to retrieve blog posts.

--- a/mezzanine/bin/management/commands/mezzanine_project.py
+++ b/mezzanine/bin/management/commands/mezzanine_project.py
@@ -2,7 +2,6 @@
 from distutils.dir_util import copy_tree
 from importlib import import_module
 import os
-from optparse import make_option
 from shutil import move, rmtree
 from tempfile import mkdtemp
 
@@ -18,11 +17,6 @@ import mezzanine
 class Command(BaseCommand):
 
     help = BaseCommand.help.replace("Django", "Mezzanine")
-
-    if django.VERSION < (1, 8):
-        option_list = BaseCommand.option_list + (make_option(
-            "-a", "--alternate", dest="alt", metavar="PACKAGE",
-            help="Alternate package to use, containing a project_template"),)
 
     def add_arguments(self, parser):
         super(Command, self).add_arguments(parser)

--- a/mezzanine/blog/management/base.py
+++ b/mezzanine/blog/management/base.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, unicode_literals
 from future.builtins import input, int
-from optparse import make_option
 try:
     from urllib.parse import urlparse
 except:
@@ -32,17 +31,20 @@ class BaseImporterCommand(BaseCommand):
     import mechanism specific to the blogging platform being dealt with.
     """
 
-    option_list = BaseCommand.option_list + (
-        make_option("-m", "--mezzanine-user", dest="mezzanine_user",
-            help="Mezzanine username to assign the imported blog posts to."),
-        make_option("--noinput", action="store_false", dest="interactive",
-            default=True, help="Do NOT prompt for input of any kind. "
-                               "Fields will be truncated if too long."),
-        make_option("-n", "--navigation", action="store_true",
-            dest="in_navigation", help="Add any imported pages to navigation"),
-        make_option("-f", "--footer", action="store_true", dest="in_footer",
-            help="Add any imported pages to footer navigation"),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-m", "--mezzanine-user", dest="mezzanine_user",
+            help="Mezzanine username to assign the imported blog posts to.")
+        parser.add_argument(
+            "--noinput", action="store_false", dest="interactive",
+            help="Do NOT prompt for input of any kind. "
+                 "Fields will be truncated if too long.")
+        parser.add_argument(
+            "-n", "--navigation", action="store_true", dest="in_navigation",
+            help="Add any imported pages to navigation")
+        parser.add_argument(
+            "-f", "--footer", action="store_true", dest="in_footer",
+            help="Add any imported pages to footer navigation")
 
     def __init__(self, **kwargs):
         self.posts = []

--- a/mezzanine/blog/management/commands/import_blogger.py
+++ b/mezzanine/blog/management/commands/import_blogger.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from datetime import datetime, timedelta
-from optparse import make_option
 from time import timezone
 import re
 
@@ -17,10 +16,10 @@ class Command(BaseImporterCommand):
     determine which blog it should point to and harvest the XML from.
     """
 
-    option_list = BaseImporterCommand.option_list + (
-        make_option("-b", "--blogger-id", dest="blog_id",
-            help="Blogger Blog ID from blogger dashboard"),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-b", "--blogger-id", dest="blog_id",
+            help="Blogger Blog ID from blogger dashboard")
 
     def handle_import(self, options):
         """

--- a/mezzanine/blog/management/commands/import_posterous.py
+++ b/mezzanine/blog/management/commands/import_posterous.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 from datetime import datetime
 import json
 import time
-from optparse import make_option
 
 from django.core.management.base import CommandError
 
@@ -15,16 +14,20 @@ class Command(BaseImporterCommand):
     Import Tumblr blog posts into the blog app.
     """
 
-    option_list = BaseImporterCommand.option_list + (
-        make_option("-a", "--api-token", dest="api_token",
-            help="Posterous API Key"),
-        make_option("-u", "--posterous-user", dest="username",
-            help="Posterous Username"),
-        make_option("-p", "--posterous-pass", dest="password",
-            help="Posterous Password"),
-        make_option("-d", "--posterous-host", dest="hostname",
-            help="Posterous Blog Hostname (no http.. eg. 'foo.com')"),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-a", "--api-token", dest="api_token",
+            help="Posterous API Key")
+        parser.add_argument(
+            "-u", "--posterous-user", dest="username",
+            help="Posterous Username")
+        parser.add_argument(
+            "-p", "--posterous-pass", dest="password",
+            help="Posterous Password")
+        parser.add_argument(
+            "-d", "--posterous-host", dest="hostname",
+            help="Posterous Blog Hostname (no http.. eg. 'foo.com')")
+
     help = "Import Posterous blog posts into the blog app."
 
     def request(self, path, data=None):

--- a/mezzanine/blog/management/commands/import_rss.py
+++ b/mezzanine/blog/management/commands/import_rss.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from datetime import timedelta
-from optparse import make_option
 from time import timezone
 try:
     from urllib.request import urlopen
@@ -20,12 +19,14 @@ class Command(BaseImporterCommand):
     Import an RSS feed into the blog app.
     """
 
-    option_list = BaseImporterCommand.option_list + (
-        make_option("-r", "--rss-url", dest="rss_url",
-            help="RSS feed URL"),
-        make_option("-p", "--page-url", dest="page_url",
-            help="URL for a web page containing the RSS link"),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-r", "--rss-url", dest="rss_url",
+            help="RSS feed URL")
+        parser.add_argument(
+            "-p", "--page-url", dest="page_url",
+            help="URL for a web page containing the RSS link")
+
     help = ("Import an RSS feed into the blog app. Requires the "
             "dateutil and feedparser packages installed, and also "
             "BeautifulSoup if using the --page-url option.")

--- a/mezzanine/blog/management/commands/import_tumblr.py
+++ b/mezzanine/blog/management/commands/import_tumblr.py
@@ -4,7 +4,6 @@ from future.builtins import int
 
 from datetime import datetime
 from json import loads
-from optparse import make_option
 from time import sleep
 
 try:
@@ -39,10 +38,11 @@ class Command(BaseImporterCommand):
     Import Tumblr blog posts into the blog app.
     """
 
-    option_list = BaseImporterCommand.option_list + (
-        make_option("-t", "--tumblr-user", dest="tumblr_user",
-            help="Tumblr username"),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-t", "--tumblr-user", dest="tumblr_user",
+            help="Tumblr username")
+
     help = "Import Tumblr blog posts into the blog app."
 
     def handle_import(self, options):

--- a/mezzanine/blog/management/commands/import_wordpress.py
+++ b/mezzanine/blog/management/commands/import_wordpress.py
@@ -3,7 +3,6 @@ from future.builtins import int
 
 from collections import defaultdict
 from datetime import datetime, timedelta
-from optparse import make_option
 import re
 from time import mktime, timezone
 from xml.dom.minidom import parse
@@ -21,9 +20,9 @@ class Command(BaseImporterCommand):
     Wordpress Extended RSS file.
     """
 
-    option_list = BaseImporterCommand.option_list + (
-        make_option("-u", "--url", dest="url", help="URL to import file"),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-u", "--url", dest="url", help="URL to import file")
 
     def get_text(self, xml, name):
         """

--- a/mezzanine/core/management/commands/collecttemplates.py
+++ b/mezzanine/core/management/commands/collecttemplates.py
@@ -3,7 +3,6 @@ from future.builtins import int
 from future.builtins import input
 
 import os
-from optparse import make_option
 import shutil
 
 from django.conf import settings
@@ -21,16 +20,20 @@ class Command(BaseCommand):
     """
 
     can_import_settings = True
-    option_list = BaseCommand.option_list + (
-        make_option('--noinput', action='store_false', dest='interactive',
-            default=True, help="Do NOT prompt for input of any kind. "
-                               "Existing templates will be overwritten."),
-        make_option('-t', '--template', dest='template',
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--noinput', action='store_false', dest='interactive',
+            help="Do NOT prompt for input of any kind. "
+                 "Existing templates will be overwritten.")
+        parser.add_argument(
+            '-t', '--template', dest='template',
             help="The template name and relative path of a single template "
-                 "to copy, eg: blog/blog_post_list.html"),
-        make_option('-a', '--admin', action='store_true', dest='admin',
-            default=False, help="Include admin templates."),
-    )
+                 "to copy, eg: blog/blog_post_list.html")
+        parser.add_argument(
+            '-a', '--admin', action='store_true', dest='admin',
+            help="Include admin templates.")
+
     usage = lambda foo, bar: ("usage: %prog [appname1] [appname2] [options] "
                               "\n" + Command.__doc__.rstrip())
 

--- a/mezzanine/core/management/commands/createdb.py
+++ b/mezzanine/core/management/commands/createdb.py
@@ -1,15 +1,12 @@
 from __future__ import print_function, unicode_literals
 from future.builtins import int, input
 
-from optparse import make_option
 from socket import gethostname
 
-from django import VERSION
 from django.core.management.base import BaseCommand, CommandError
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.management import call_command
-from django.core.management.commands import migrate
 from django.db import connection
 
 from mezzanine.conf import settings
@@ -26,25 +23,16 @@ class Command(BaseCommand):
     help = "Performs initial Mezzanine database setup."
     can_import_settings = True
 
-    def __init__(self, *args, **kwargs):
-        """
-        Adds extra command options (executed only by Django <= 1.7).
-        """
-        super(Command, self).__init__(*args, **kwargs)
-        if VERSION[0] == 1 and VERSION[1] <= 7:
-            self.option_list = migrate.Command.option_list + (
-                make_option("--nodata", action="store_true", dest="nodata",
-                    default=False, help="Do not add demo data."),)
-
     def add_arguments(self, parser):
         """
         Adds extra command options (executed only by Django >= 1.8).
         """
-        parser.add_argument("--nodata", action="store_true", dest="nodata",
-            default=False, help="Do not add demo data.")
-        parser.add_argument("--noinput", action="store_false",
-            dest="interactive", default=True, help="Do not prompt the user "
-            "for input of any kind.")
+        parser.add_argument(
+            "--nodata", action="store_true", dest="nodata",
+            help="Do not add demo data.")
+        parser.add_argument(
+            "--noinput", action="store_false", dest="interactive",
+            help="Do not prompt the user for input of any kind.")
 
     def handle(self, **options):
 

--- a/mezzanine/generic/templatetags/comment_tags.py
+++ b/mezzanine/generic/templatetags/comment_tags.py
@@ -30,7 +30,6 @@ def comments_for(context, obj):
         'unposted_comment_form': form,
         'comment_url': reverse("comment"),
         'object_for_comments': obj,
-        'request': context.get('request'),
     }
 
 

--- a/mezzanine/twitter/management/commands/poll_twitter.py
+++ b/mezzanine/twitter/management/commands/poll_twitter.py
@@ -1,7 +1,5 @@
 from __future__ import print_function, unicode_literals
 
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 from django import db
 
@@ -13,9 +11,8 @@ class Command(BaseCommand):
     Polls the Twitter API for tweets associated to the queries in templates.
     """
 
-    option_list = BaseCommand.option_list + (
-        make_option("--force", default=False, action="store_true"),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument("--force", action="store_true")
 
     def handle(self, **options):
         queries = Query.objects.all()


### PR DESCRIPTION
Very straightforward replacement since our use of `optparse` wasn't complicated. I removed the `default` argument for options with `action="store_true"` or `action="store_false"`.