### PR TITLE
Fixed crash in Page.get_ascendants with non-current site

### DIFF
--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -6,6 +6,7 @@ from unittest import skipUnless
 from mezzanine.core.middleware import FetchFromCacheMiddleware
 from mezzanine.core.templatetags.mezzanine_tags import initialize_nevercache
 from mezzanine.utils.cache import cache_installed
+from mezzanine.utils.sites import current_site_id, override_current_site_id
 
 try:
     # Python 3
@@ -558,6 +559,12 @@ class SiteRelatedTestCase(TestCase):
 
         site1.delete()
         site2.delete()
+
+    def test_override_site_id(self):
+        self.assertEqual(current_site_id(), 1)
+        with override_current_site_id(2):
+            self.assertEqual(current_site_id(), 2)
+        self.assertEqual(current_site_id(), 1)
 
 
 class CSRFTestViews(object):

--- a/mezzanine/pages/models.py
+++ b/mezzanine/pages/models.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 from future.builtins import str
+from mezzanine.utils.sites import override_current_site_id
+
 try:
     from urllib.parse import urljoin
 except ImportError:  # Python 2
@@ -115,8 +117,9 @@ class Page(BasePage, ContentTyped):
             # have not been customised.
             if self.slug:
                 kwargs = {"for_user": for_user}
-                pages = Page.objects.with_ascendants_for_slug(self.slug,
-                                                              **kwargs)
+                with override_current_site_id(self.site_id):
+                    pages = Page.objects.with_ascendants_for_slug(self.slug,
+                                                                  **kwargs)
                 self._ascendants = pages[0]._ascendants
             else:
                 self._ascendants = []

--- a/mezzanine/pages/tests.py
+++ b/mezzanine/pages/tests.py
@@ -31,6 +31,16 @@ User = get_user_model()
 
 class PagesTests(TestCase):
 
+    def setUp(self):
+        """
+        Make sure we have a thread-local request with a site_id attribute set.
+        """
+        super(PagesTests, self).setUp()
+        from mezzanine.core.request import _thread_local
+        request = self._request_factory.get('/')
+        request.site_id = settings.SITE_ID
+        _thread_local.request = request
+
     def test_page_ascendants(self):
         """
         Test the methods for looking up ascendants efficiently
@@ -40,8 +50,6 @@ class PagesTests(TestCase):
         primary, created = RichTextPage.objects.get_or_create(title="Primary")
         secondary, created = primary.children.get_or_create(title="Secondary")
         tertiary, created = secondary.children.get_or_create(title="Tertiary")
-        # Force a site ID to avoid the site query when measuring queries.
-        setattr(current_request(), "site_id", settings.SITE_ID)
 
         # Test that get_ascendants() returns the right thing.
         page = Page.objects.get(id=tertiary.id)
@@ -380,9 +388,6 @@ class PagesTests(TestCase):
 
     def test_ascendants_different_site(self):
         site2 = Site.objects.create(domain='site2.example.com', name='Site 2')
-
-        # Force a site ID to avoid the site query when measuring queries.
-        setattr(current_request(), "site_id", settings.SITE_ID)
 
         parent = Page.objects.create(title="Parent", site=site2)
         child = parent.children.create(title="Child", site=site2)

--- a/mezzanine/utils/sites.py
+++ b/mezzanine/utils/sites.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 import os
 import sys
+import threading
+from contextlib import contextmanager
 
 from django.contrib.sites.models import Site
 
@@ -12,21 +14,26 @@ from mezzanine.core.request import current_request
 def current_site_id():
     """
     Responsible for determining the current ``Site`` instance to use
-    when retrieving data for any ``SiteRelated`` models. If a request
-    is available, and the site can be determined from it, we store the
-    site against the request for subsequent retrievals. Otherwise the
-    order of checks is as follows:
+    when retrieving data for any ``SiteRelated`` models. If we're inside an
+    override_current_site_id context manager, return the overriding site ID.
+    Otherwise, try to determine the site using the following methods in order:
 
       - ``site_id`` in session. Used in the admin so that admin users
         can switch sites and stay on the same domain for the admin.
-      - host for the current request matched to the domain of the site
-        instance.
+      - The id of the Site object corresponding to the hostname in the current
+        request. This result is cached.
       - ``MEZZANINE_SITE_ID`` environment variable, so management
         commands or anything else outside of a request can specify a
         site.
       - ``SITE_ID`` setting.
 
+    If a current request exists and the current site is not overridden, the
+    site ID is stored on the request object to speed up subsequent calls.
     """
+
+    if hasattr(override_current_site_id.thread_local, "site_id"):
+        return override_current_site_id.thread_local.site_id
+
     from mezzanine.utils.cache import cache_installed, cache_get, cache_set
     request = current_request()
     site_id = getattr(request, "site_id", None)
@@ -57,6 +64,18 @@ def current_site_id():
     if request and site_id and not getattr(settings, "TESTING", False):
         request.site_id = site_id
     return site_id
+
+
+@contextmanager
+def override_current_site_id(site_id):
+    """
+    Context manager that overrides the current site id for code executed
+    within it. Used to access SiteRelated objects outside the current site.
+    """
+    override_current_site_id.thread_local.site_id = site_id
+    yield
+    del override_current_site_id.thread_local.site_id
+override_current_site_id.thread_local = threading.local()
 
 
 def has_site_permission(user):


### PR DESCRIPTION
This PR fixes #1637.

The problem is that `Page.get_ascendants()` assumes that `self` will be a `Page` assigned to the current site, and therefore that `PageManager.with_ascendants_for_slug(self.slug)` will return at least one `Page`.

This fixes the problem, but the correct result is obtained by doing recursive database queries up the page tree rather than the single query used by `with_ascendants_for_slug()`.

If we think that's acceptable (to fix something that wasn't working at all before) we can merge this as-is, otherwise some refactoring will likely be necessary.