### PR TITLE
Don't include any .pyc files in the release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include docs *
 recursive-exclude docs/build *
 recursive-include mezzanine *
 recursive-exclude */project_template/static *
+global-exclude *.pyc


### PR DESCRIPTION
The current release contains "mezzanine/__init__.pyc" this upsets some Python tools that don't like to see a .pyc file in pypi release.