### PR TITLE
Subclassable forms.EmailField.

### DIFF
--- a/mezzanine/forms/forms.py
+++ b/mezzanine/forms/forms.py
@@ -233,10 +233,10 @@ class FormForForm(forms.ModelForm):
     def email_to(self):
         """
         Return the value entered for the first field of type
-        ``forms.fields.EMAIL``.
+        ``forms.EmailField``.
         """
         for field in self.form_fields:
-            if field.is_a(fields.EMAIL):
+            if issubclass(fields.CLASSES[field.field_type], forms.EmailField):
                 return self.cleaned_data["field_%s" % field.id]
         return None
 


### PR DESCRIPTION
The `is_a` method checks whether a field is one of Mezzanine's built-in
form fields. As far as I can tell, every other usage is for the purpose
of initializing the built-in fields and widgets, so it makes sense to
exclude user-defined fields.

However in this instance, we only want to know whether the field is an
EmailField, not that it is *the* built-in Mezzanine email field.
Therefore, check the class rather than identity.

The effective change here is that user-defined fields (in
FORMS_EXTRA_FIELDS) which subclass django's EmailField will be able to
receive confirmation emails.