### PR TITLE
Add compatibility with the Django 1.10 MIDDLEWARE setting.

### DIFF
--- a/mezzanine/core/request.py
+++ b/mezzanine/core/request.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 import threading
 
+from mezzanine.utils.deprecation import MiddlewareMixin
+
 
 _thread_local = threading.local()
 
@@ -13,7 +15,7 @@ def current_request():
     return getattr(_thread_local, "request", None)
 
 
-class CurrentRequestMiddleware(object):
+class CurrentRequestMiddleware(MiddlewareMixin):
     """
     Stores the request in the current thread for global access.
     """

--- a/mezzanine/pages/middleware.py
+++ b/mezzanine/pages/middleware.py
@@ -8,11 +8,12 @@ from mezzanine.conf import settings
 from mezzanine.pages import context_processors, page_processors
 from mezzanine.pages.models import Page
 from mezzanine.pages.views import page as page_view
+from mezzanine.utils.deprecation import MiddlewareMixin, MIDDLEWARE_SETTING
 from mezzanine.utils.importing import import_dotted_path
 from mezzanine.utils.urls import path_to_slug
 
 
-class PageMiddleware(object):
+class PageMiddleware(MiddlewareMixin):
     """
     Adds a page to the template context for the current response.
 
@@ -33,7 +34,8 @@ class PageMiddleware(object):
     context, so that the current page is always available.
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super(PageMiddleware, self).__init__(*args, **kwargs)
         if "mezzanine.pages" not in settings.INSTALLED_APPS:
             raise MiddlewareNotUsed
 
@@ -51,9 +53,9 @@ class PageMiddleware(object):
             return cls._installed
         except AttributeError:
             name = "mezzanine.pages.middleware.PageMiddleware"
-            installed = name in settings.MIDDLEWARE_CLASSES
+            installed = name in MIDDLEWARE_SETTING
             if not installed:
-                for name in settings.MIDDLEWARE_CLASSES:
+                for name in MIDDLEWARE_SETTING:
                     if issubclass(import_dotted_path(name), cls):
                         installed = True
                         break

--- a/mezzanine/pages/views.py
+++ b/mezzanine/pages/views.py
@@ -70,7 +70,8 @@ def page(request, slug, template=u"pages/page.html", extra_context=None):
     if not PageMiddleware.installed():
         raise ImproperlyConfigured("mezzanine.pages.middleware.PageMiddleware "
                                    "(or a subclass of it) is missing from " +
-                                   "settings.MIDDLEWARE_CLASSES")
+                                   "settings.MIDDLEWARE_CLASSES or " +
+                                   "settings.MIDDLEWARE")
 
     if not hasattr(request, "page") or request.page.slug != slug:
         raise Http404

--- a/mezzanine/utils/deprecation.py
+++ b/mezzanine/utils/deprecation.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+
+
+# Middleware mixin for Django 1.10
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    class MiddlewareMixin(object):
+        pass
+
+
+MIDDLEWARE_SETTING = settings.MIDDLEWARE if hasattr(settings, 'MIDDLEWARE') \
+                                        and settings.MIDDLEWARE is not None \
+                                        else settings.MIDDLEWARE_CLASSES


### PR DESCRIPTION
This patch allows developers to use the new `MIDDLEWARE` setting in Django. Changes are as follows:

- Wrap all of Mezzanine's middleware in `django.utils.deprecation.MiddlewareMixin` when it is available. This allows it to work as new-style middleware in Django 1.10.

- Dynamically check which of `MIDDLEWARE` and `MIDDLEWARE_CLASSES` is defined before monkey-patching settings in `mezzanine.conf.set_dynamic_settings`.

Note that Mezzanine will still default to `MIDDLEWARE_CLASSES` when creating new projects etc. (I think we have to wait till Django 1.12 before changing that). The purpose of this patch is just to allow developers to switch to using the new setting (and new-style middleware) without it breaking. 