### PR TITLE
Fix positional argument count on get_db_prep_value

### DIFF
--- a/mezzanine/core/fields.py
+++ b/mezzanine/core/fields.py
@@ -100,7 +100,7 @@ class MultiChoiceField(models.CharField):
         defaults.update(kwargs)
         return MultipleChoiceField(**defaults)
 
-    def get_db_prep_value(self, value, **kwargs):
+    def get_db_prep_value(self, value, connection, **kwargs):
         if isinstance(value, (tuple, list)):
             value = ",".join([str(i) for i in value])
         return value


### PR DESCRIPTION
When I try to run the Wordpress importer with the latest git head of Mezzanine (`ee24a48b5f33`) and Django 1.10.1, I get the error reproduced at the bottom of this comment when it tries to import WordPress pages. This occurs on both SQLite (which didn't experience this problem in February when I was last experimenting) and PostgreSQL (which I didn't test previously).

Despite spending a bit of time looking into it, I'm not totally sure why this started appearing now. The code at `core/fields.py:103` doesn't appear to have changed since 2012 and the Django API for this function hasn't changed since Django 1.2. Probably Django is passing the connection object now regardless of whether a multi-tenant DB configuration is used or not, and maybe it wasn't before?

In any case, I'm not sure what the hiccup is, but now that I got it working, I'm not super interested in spending more time hunting down the root cause. It's working again with the attached patch. Hope this helps. :smile: 


```
Imported comment by: Test
Traceback (most recent call last):
  File "manage.py", line 14, in <module>
    execute_from_command_line(sys.argv)
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/core/management/__init__.py", line 367, in execute_from_command_line
   utility.execute()
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/core/management/__init__.py", line 359, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/core/management/base.py", line 294, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/core/management/base.py", line 345, in execute
    output = self.handle(*args, **options)
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/Mezzanine-4.2.0-py3.5.egg/mezzanine/blog/management/base.py", line 232, in handle
    page, created = RichTextPage.objects.get_or_create(**page)
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/query.py", line 473, in get_or_create
    return self.get(**lookup), False
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/query.py", line 379, in get
    num = len(clone)
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/query.py", line 238, in __len__
    self._fetch_all()
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/query.py", line 1087, in _fetch_all
    self._result_cache = list(self.iterator())
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/query.py", line 54, in __iter__
    results = compiler.execute_sql()
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/sql/compiler.py", line 824, in execute_sql
    sql, params = self.as_sql()
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/sql/compiler.py", line 376, in as_sql
    where, w_params = self.compile(self.where) if self.where is not None else ("", [])
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/sql/compiler.py", line 353, in compile
    sql, params = node.as_sql(self, self.connection)
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/sql/where.py", line 79, in as_sql
    sql, params = compiler.compile(child)
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/sql/compiler.py", line 353, in compile
    sql, params = node.as_sql(self, self.connection)
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/lookups.py", line 156, in as_sql
    rhs_sql, rhs_params = self.process_rhs(compiler, connection)
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/lookups.py", line 92, in process_rhs
    return self.get_db_prep_lookup(value, connection)
  File "/home/jeff/mez_test/mez_venv/lib/python3.5/site-packages/django/db/models/lookups.py", line 184, in get_db_prep_lookup
    [get_db_prep_value(value, connection, prepared=True)]
TypeError: get_db_prep_value() takes 2 positional arguments but 3 were given
```