### PR TITLE
Deprecate SSLRedirectMiddleware. Resolve #1600.

### DIFF
--- a/mezzanine/core/defaults.py
+++ b/mezzanine/core/defaults.py
@@ -416,7 +416,7 @@ register_setting(
     description=_("If ``True``, users will be automatically redirected to "
         "HTTPS for the URLs specified by the ``SSL_FORCE_URL_PREFIXES`` "
         "setting."),
-    editable=True,
+    editable=False,
     default=False,
 )
 
@@ -425,7 +425,7 @@ register_setting(
     label=_("Force Host"),
     description=_("Host name that the site should always be accessed via that "
                 "matches the SSL certificate."),
-    editable=True,
+    editable=False,
     default="",
 )
 

--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import warnings
+
 from django.contrib import admin
 from django.contrib.auth import logout
 from django.contrib.messages import error
@@ -221,6 +223,13 @@ class SSLRedirectMiddleware(MiddlewareMixin):
     Also ensure URLs defined by ``SSL_FORCE_URL_PREFIXES`` are redirect
     to HTTPS, and redirect all other URLs to HTTP if on HTTPS.
     """
+    def __init__(self, get_response):
+        warnings.warn(
+            "SSLRedirectMiddleware is deprecated. See "
+            "https://docs.djangoproject.com/en/stable/ref/middleware/"
+            "#module-django.middleware.security for alternative solutions.",
+            DeprecationWarning)
+        super(SSLRedirectMiddleware, self).__init__(get_response)
 
     def languages(self):
         if not hasattr(self, "_languages"):

--- a/mezzanine/project_template/project_name/settings.py
+++ b/mezzanine/project_template/project_name/settings.py
@@ -273,8 +273,6 @@ MIDDLEWARE_CLASSES = (
     "mezzanine.core.middleware.TemplateForHostMiddleware",
     "mezzanine.core.middleware.AdminLoginInterfaceSelectorMiddleware",
     "mezzanine.core.middleware.SitePermissionMiddleware",
-    # Uncomment the following if using any of the SSL settings:
-    # "mezzanine.core.middleware.SSLRedirectMiddleware",
     "mezzanine.pages.middleware.PageMiddleware",
     "mezzanine.core.middleware.FetchFromCacheMiddleware",
 )


### PR DESCRIPTION
Also, set default SSL settings to `editable=False` so they do not
display in the settings by default.

I find that I can never actually see `DeprecationWarning`'s when using `runserver` but I do see regular `UserWarning`'s. Any ideas?