### PR TITLE
Add an option for turning off the runserver banner

### DIFF
--- a/mezzanine/core/management/commands/runserver.py
+++ b/mezzanine/core/management/commands/runserver.py
@@ -142,15 +142,24 @@ class Command(runserver.Command):
     under the project's ``STATIC_ROOT``.
     """
 
-    def inner_run(self, *args, **kwargs):
-        # Show Mezzanine's own cool banner in the terminal. There
-        # aren't really any exceptions to catch here, but we do
-        # so blanketly since such a trivial thing like the banner
-        # shouldn't be able to crash the development server.
-        try:
-            self.stdout.write(banner())
-        except:
-            pass
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--nobanner', action="store_false", dest='show_banner',
+            default=True,
+            help='Tells Mezzanine not to show a banner at startup.',
+        )
+
+    def inner_run(self, show_banner, *args, **kwargs):
+        if show_banner:
+            # Show Mezzanine's own cool banner in the terminal. There
+            # aren't really any exceptions to catch here, but we do
+            # so blanketly since such a trivial thing like the banner
+            # shouldn't be able to crash the development server.
+            try:
+                self.stdout.write(banner())
+            except:
+                pass
         super(Command, self).inner_run(*args, **kwargs)
 
     def get_handler(self, *args, **options):


### PR DESCRIPTION
This adds an option to Mezzanine’s runserver command for not showing the colored banner at startup.

The banner is typically printed many times when working on a Mezzanine app, because it’s reprinted every time the server restarts. I’ve noticed that this slows down my shell ([Eshell](https://www.gnu.org/software/emacs/manual/eshell.html)) considerably over time, so I’ve been using a modified version of Mezzanine locally where the banner isn’t printed at all. This patch makes it easier to turn off the banner without having to modify Mezzanine’s source code.