### PR TITLE
Fix formatting of “invalid choice” error message

### DIFF
--- a/mezzanine/core/fields.py
+++ b/mezzanine/core/fields.py
@@ -88,7 +88,7 @@ class MultiChoiceField(models.CharField):
     def validate(self, value, instance):
         choices = [str(choice[0]) for choice in self.choices]
         if set(value) - set(choices):
-            error = self.error_messages["invalid_choice"] % value
+            error = self.error_messages["invalid_choice"] % {'value': value}
             raise ValidationError(error)
 
     def value_to_string(self, obj):


### PR DESCRIPTION
The `invalid_choice` error message was changed in Django by commit [ee77d4b25360a9fc050c32769a334fd69a011a63](https://github.com/django/django/commit/ee77d4b25360a9fc050c32769a334fd69a011a63#diff-bf776a3b8e5dbfac2432015825ef8afeR80) to use a mapping key. Passing a dictionary to the `invalid_choice` format string is now required.

This change was made between Django 1.5 and 1.6, so it should be safe for Mezzanine.