### PR TITLE
Add check on default_storage for thumbnail

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -338,6 +338,8 @@ def thumbnail(image_url, width, height, upscale=True, quality=95, left=.5,
     if thumb_exists:
         # Thumbnail exists, don't generate it.
         return thumb_url
+    elif default_storage.exists(thumb_url):
+        return thumb_url
     elif not default_storage.exists(image_url):
         # Requested image does not exist, just return its URL.
         return image_url


### PR DESCRIPTION
This improve load times on the media library and on pages that use thumbnail often by up to 20x on storages like Amazon S3. The issue is that often the thumbnail has already been made but isn't on the local system because we are using ephemeral storage locally. Without this check we often end up recreating the thumbnail that already exists of the ephemeral storage has been wiped recently like on Heroku for when you push a new update, adding the check saves a ton of processing time.