### PR TITLE
Remove "Overriding vs. Extending" Docs.

### DIFF
--- a/docs/content-architecture.rst
+++ b/docs/content-architecture.rst
@@ -223,35 +223,6 @@ For example, if an additional author were added as a child page of
 the template ``pages/authors/dr-seuss/author.html`` would be among
 those checked.
 
-Overriding vs Extending Templates
-=================================
-
-A typical problem that reusable Django apps face, is being able to
-extend the app's templates rather than overriding them. The app will
-usually provide templates that the app will look for by name, which
-allows the developer to create their own versions of the templates in
-their project's templates directory. However if the template is
-sufficiently complex, with a good range of extendable template blocks,
-they need to duplicate all of the features of the template within
-their own version. This may cause the project's version of the
-templates to become incompatible as new versions of the upstream app
-become available.
-
-Ideally we would be able to use Django's ``extends`` tag to extend the
-app's template instead, and only override the template blocks we're
-interested in. The problem with this however, is that the app will
-attempt to load the template with a specific name, so we can't override
-*and* extend a template at the same time, as circular inheritance will
-occur, e.g. Django thinks the template is trying to extend itself, which
-is impossible.
-
-To solve this problem, Mezzanine provides the :func:`.overextends`
-template tag, which allows you to extend a template with the same name.
-The :func:`.overextends`  tag works the same way as Django's ``extends`` tag,
-(in fact it subclasses it), so it must be the first tag in the template.
-What it does differently is that the template using it will be excluded
-from loading when Django searches for the template to extend from.
-
 Page Processors
 ===============
 


### PR DESCRIPTION
I know we discussed this a little bit somewhere and rewriting this
section was suggested. However, I don't see any reason to keep it
around. This was always a django issue but we provided a
mezzanine-specific solution. Now that there's a django solution, why
clutter our docs with it?