### PR TITLE
Richtext filters must return SafeString.

### DIFF
--- a/docs/admin-customization.rst
+++ b/docs/admin-customization.rst
@@ -163,13 +163,15 @@ need a way to convert that wiki syntax into HTML right before the
 content was rendered::
 
     # ... in myproj.filter
+    from django.utils.safestring import mark_safe
     from markdown import markdown
+
 
     def markdown_filter(content):
         """
         Converts markdown formatted content to html
         """
-        return markdown(content)
+        return mark_safe(markdown(content))
 
     # ... in myproj.settings
     RICHTEXT_FILTERS = (

--- a/mezzanine/blog/templates/blog/blog_post_detail.html
+++ b/mezzanine/blog/templates/blog/blog_post_detail.html
@@ -62,7 +62,7 @@
 
 {% block blog_post_detail_content %}
 {% editable blog_post.content %}
-{{ blog_post.content|richtext_filters|safe }}
+{{ blog_post.content|richtext_filters }}
 {% endeditable %}
 {% endblock %}
 

--- a/mezzanine/blog/templates/blog/blog_post_list.html
+++ b/mezzanine/blog/templates/blog/blog_post_list.html
@@ -64,7 +64,7 @@
     {% block blog_post_list_pagecontent %}
     {% if page.get_content_model.content %}
         {% editable page.get_content_model.content %}
-        {{ page.get_content_model.content|richtext_filters|safe }}
+        {{ page.get_content_model.content|richtext_filters }}
         {% endeditable %}
     {% endif %}
     {% endblock %}

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -25,6 +25,7 @@ from django.template.loader import get_template
 from django.utils import translation
 from django.utils.html import strip_tags
 from django.utils.text import capfirst
+from django.utils.safestring import SafeString, mark_safe
 
 from mezzanine.conf import settings
 from mezzanine.core.fields import RichTextField
@@ -471,6 +472,20 @@ def richtext_filters(content):
     for filter_name in settings.RICHTEXT_FILTERS:
         filter_func = import_dotted_path(filter_name)
         content = filter_func(content)
+        if not isinstance(content, SafeString):
+            # raise TypeError(
+                # filter_name + " must mark it's return value as safe. See "
+                # "https://docs.djangoproject.com/en/stable/topics/security/"
+                # "#cross-site-scripting-xss-protection")
+            import warnings
+            warnings.warn(
+                filter_name + " needs to insure that any untrusted inputs are "
+                "properly escaped and mark the html it returns as safe. In a "
+                "future release this will cause an exception. See "
+                "https://docs.djangoproject.com/en/stable/topics/security/"
+                "cross-site-scripting-xss-protection",
+                FutureWarning)
+            content = mark_safe(content)
     return content
 
 

--- a/mezzanine/forms/templates/pages/form.html
+++ b/mezzanine/forms/templates/pages/form.html
@@ -11,12 +11,12 @@
 {{ block.super }}
 {% if request.GET.sent %}
     {% editable page.form.response %}
-    {{ page.form.response|richtext_filters|safe }}
+    {{ page.form.response|richtext_filters }}
     {% endeditable %}
 {% else %}
     {% with page.form as page_form %}
     {% editable page_form.content %}
-    {{ page_form.content|richtext_filters|safe }}
+    {{ page_form.content|richtext_filters }}
     {% endeditable %}
     {% endwith %}
 

--- a/mezzanine/galleries/templates/pages/gallery.html
+++ b/mezzanine/galleries/templates/pages/gallery.html
@@ -10,7 +10,7 @@
 {{ block.super }}
 
 {% editable page.gallery.content %}
-{{ page.gallery.content|richtext_filters|safe }}
+{{ page.gallery.content|richtext_filters }}
 {% endeditable %}
 
 <div class="gallery row">

--- a/mezzanine/mobile/templates/mobile/blog/blog_post_detail.html
+++ b/mezzanine/mobile/templates/mobile/blog/blog_post_detail.html
@@ -32,7 +32,7 @@
 </p>
 
 {% editable blog_post.content %}
-{{ blog_post.content|richtext_filters|safe }}
+{{ blog_post.content|richtext_filters }}
 {% endeditable %}
 
 {% keywords_for blog_post as tags %}

--- a/mezzanine/mobile/templates/mobile/pages/form.html
+++ b/mezzanine/mobile/templates/mobile/pages/form.html
@@ -5,9 +5,9 @@
 {% block main %}{{ block.super }}
 
 {% if request.GET.sent %}
-    {{ page.form.response|richtext_filters|safe }}
+    {{ page.form.response|richtext_filters }}
 {% else %}
-    {{ page.form.content|richtext_filters|safe }}
+    {{ page.form.content|richtext_filters }}
     <form method="post" class="form"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% nevercache %}
         <input type="hidden" name="referrer" value="{{ request.META.HTTP_REFERER }}">

--- a/mezzanine/mobile/templates/mobile/pages/richtextpage.html
+++ b/mezzanine/mobile/templates/mobile/pages/richtextpage.html
@@ -5,7 +5,7 @@
 {% block main %}{{ block.super }}
 
 {% editable page.richtextpage.content %}
-{{ page.richtextpage.content|richtext_filters|safe }}
+{{ page.richtextpage.content|richtext_filters }}
 {% endeditable %}
 
 {% endblock %}

--- a/mezzanine/pages/templates/pages/richtextpage.html
+++ b/mezzanine/pages/templates/pages/richtextpage.html
@@ -5,7 +5,7 @@
 {% block main %}{{ block.super }}
 
 {% editable page.richtextpage.content %}
-{{ page.richtextpage.content|richtext_filters|safe }}
+{{ page.richtextpage.content|richtext_filters }}
 {% endeditable %}
 
 {% endblock %}

--- a/mezzanine/utils/html.py
+++ b/mezzanine/utils/html.py
@@ -15,6 +15,8 @@ except ImportError:  # Python 2
 
 import re
 
+from django.utils.safestring import mark_safe
+
 from bleach import clean, sanitizer
 
 
@@ -99,8 +101,8 @@ def escape(html):
     if settings.RICHTEXT_FILTER_LEVEL == defaults.RICHTEXT_FILTER_LEVEL_LOW:
         tags += LOW_FILTER_TAGS
         attrs += LOW_FILTER_ATTRS
-    return clean(html, tags=tags, attributes=attrs, strip=True,
-                 strip_comments=False, styles=styles)
+    return mark_safe(clean(html, tags=tags, attributes=attrs, strip=True,
+                           strip_comments=False, styles=styles))
 
 
 def thumbnails(html):
@@ -127,7 +129,7 @@ def thumbnails(html):
         if src_in_media and width and height:
             img["src"] = settings.MEDIA_URL + thumbnail(src, width, height)
     # BS adds closing br tags, which the browser interprets as br tags.
-    return str(dom).replace("</br>", "")
+    return mark_safe(str(dom).replace("</br>", ""))
 
 
 class TagCloser(HTMLParser):


### PR DESCRIPTION
For now, just raise a warning. In the way-off future I'd like to see
richtext_filters raise an exception when a SafeString is not received.

Django makes a contract with users: "Unless you explicitly mark
untrusted input as safe, we'll escape it and you don't need to worry
about XSS vulnerabilities." My position is that reusable apps should
proxy this contract to users.

In doing so, this also moves the SafeString conversion out of templates
and into the `escape` function in which bleach actually makes the html
safe.  The closer these two components are to each other the less likely
we are to make a mistake in between them.
