### PR TITLE
Add setting for default required field help text

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -396,6 +396,13 @@ Max length allowed for field labels in the forms app.
 
 Default: ``200``
 
+``FORMS_REQUIRED_DEFAULT_HELP_TEXT``
+------------------------------------
+
+Default help text to use for required fields in the forms app.
+
+Default: ``"required"``
+
 .. _FORMS_UPLOAD_ROOT:
 
 ``FORMS_UPLOAD_ROOT``

--- a/mezzanine/forms/defaults.py
+++ b/mezzanine/forms/defaults.py
@@ -31,6 +31,14 @@ register_setting(
 )
 
 register_setting(
+    name="FORMS_REQUIRED_DEFAULT_HELP_TEXT",
+    description=_("Default help text to use for required fields in the forms "
+        "app."),
+    editable=False,
+    default=_("required"),
+)
+
+register_setting(
     name="FORMS_CSV_DELIMITER",
     description=_("Char to use as a field delimiter when exporting form "
         "responses as CSV."),

--- a/mezzanine/forms/forms.py
+++ b/mezzanine/forms/forms.py
@@ -147,7 +147,8 @@ class FormForForm(forms.ModelForm):
             field_args = {"label": field.label, "required": field.required,
                           "help_text": field.help_text}
             if field.required and not field.help_text:
-                field_args["help_text"] = _("required")
+                field_args["help_text"] \
+                    = settings.FORMS_REQUIRED_DEFAULT_HELP_TEXT
             arg_names = field_class.__init__.__code__.co_varnames
             if "max_length" in arg_names:
                 field_args["max_length"] = settings.FORMS_FIELD_MAX_LENGTH


### PR DESCRIPTION
This commit adds a new setting for the default help text to use for required form fields in the forms app.