### PR TITLE
Move “required” from field help text to template

### DIFF
--- a/mezzanine/core/templates/includes/form_fields.html
+++ b/mezzanine/core/templates/includes/form_fields.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% load mezzanine_tags %}
 
 {% nevercache %}
@@ -21,6 +22,8 @@
     </p>
     {% elif field.help_text %}
     <p class="help-block">{{ field.help_text }}</p>
+    {% elif field.field.required %}
+    <p class="help-block">{% trans "required" %}</p>
     {% endif %}
 </div>
 {% endif %}

--- a/mezzanine/forms/forms.py
+++ b/mezzanine/forms/forms.py
@@ -146,8 +146,6 @@ class FormForForm(forms.ModelForm):
             field_widget = fields.WIDGETS.get(field.field_type)
             field_args = {"label": field.label, "required": field.required,
                           "help_text": field.help_text}
-            if field.required and not field.help_text:
-                field_args["help_text"] = _("required")
             arg_names = field_class.__init__.__code__.co_varnames
             if "max_length" in arg_names:
                 field_args["max_length"] = settings.FORMS_FIELD_MAX_LENGTH


### PR DESCRIPTION
The forms app used to set “required” as the help text for fields that are required and didn’t have a help text already. Move this text into the template instead, making it easier to override.

See https://github.com/stephenmcd/mezzanine/pull/1689 for a related discussion.