### PR TITLE
Use call_command() instead of execute() (#1691)

### DIFF
--- a/mezzanine/core/management/commands/createdb.py
+++ b/mezzanine/core/management/commands/createdb.py
@@ -153,5 +153,5 @@ class Command(BaseCommand):
                 "interactive": self.interactive,
                 "no_color": self.no_color,
             }
-            create_fields.Command().execute(**options)
-            update_fields.Command().execute(**options)
+            call_command(create_fields.Command(), **options)
+            call_command(update_fields.Command(), **options)

--- a/mezzanine/core/management/commands/createdb.py
+++ b/mezzanine/core/management/commands/createdb.py
@@ -43,7 +43,6 @@ class Command(BaseCommand):
         self.verbosity = int(options.get("verbosity", 0))
         self.interactive = int(options.get("interactive", 0))
         self.no_data = int(options.get("nodata", 0))
-        self.no_color = bool(options.get("no_color", False))
 
         call_command("migrate", verbosity=self.verbosity,
                      interactive=self.interactive)
@@ -151,7 +150,6 @@ class Command(BaseCommand):
             options = {
                 "verbosity": self.verbosity,
                 "interactive": self.interactive,
-                "no_color": self.no_color,
             }
             call_command(create_fields.Command(), **options)
             call_command(update_fields.Command(), **options)


### PR DESCRIPTION
Even though the bug seems to have been fixed on master, I have read that it is "better" to call call_command() instead of Command().execute:

> Note that in your problematic case, the code is directly calling graph_models.Command().execute(*apps, **options) instead of using call_command which takes care of populating all default arguments.

Source: https://code.djangoproject.com/ticket/26315#comment:7