### PR TITLE
Move contributing guidelines to CONTRIBUTING.rst.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,16 @@
+Please note the following guidelines for contributing:
+
+* If you're fairly confident you've identified a bug or have already written a
+  patch, feel free to open an issue or pull request. Otherwise, please discuss
+  on the `mezzanine-users`_ mailing list first.
+* Contributed code must be written in the existing style. For Python
+  (and to a decent extent, JavaScript as well), this is as simple as
+  following the `Django coding style`_ and (most importantly)
+  `PEP 8`_. Front-end CSS should adhere to the
+  `Bootstrap CSS guidelines`_.
+* Contributions must be available on a separately named branch
+  based on the latest version of the main branch.
+* Run the tests before committing your changes. If your changes
+  cause the tests to break, they won't be accepted.
+* If you are adding new functionality, you must include basic tests
+  and documentation.

--- a/README.rst
+++ b/README.rst
@@ -105,23 +105,6 @@ both `GitHub`_ and `Bitbucket`_ respectively, so contributing is as
 easy as forking the project on either of these sites and committing
 back your enhancements.
 
-Please note the following guidelines for contributing:
-
-* If you're fairly confident you've identified a bug or have already written a
-  patch, feel free to open an issue or pull request. Otherwise, please discuss
-  on the `mezzanine-users`_ mailing list first.
-* Contributed code must be written in the existing style. For Python
-  (and to a decent extent, JavaScript as well), this is as simple as
-  following the `Django coding style`_ and (most importantly)
-  `PEP 8`_. Front-end CSS should adhere to the
-  `Bootstrap CSS guidelines`_.
-* Contributions must be available on a separately named branch
-  based on the latest version of the main branch.
-* Run the tests before committing your changes. If your changes
-  cause the tests to break, they won't be accepted.
-* If you are adding new functionality, you must include basic tests
-  and documentation.
-
 
 Donating
 ========


### PR DESCRIPTION
This will present itself before people open issues which should cut down
on a lot of the erroneous ones.