### PR TITLE
Fix caching editable settings forever when no request

### DIFF
--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -149,7 +149,9 @@ class Settings(object):
         try:
             editable_settings = self._editable_caches[request]
         except KeyError:
-            editable_settings = self._editable_caches[request] = self._load()
+            editable_settings = self._load()
+            if request is not self.NULL_REQUEST:
+                self._editable_caches[request] = editable_settings
         return editable_settings
 
     @classmethod

--- a/mezzanine/conf/tests.py
+++ b/mezzanine/conf/tests.py
@@ -204,3 +204,20 @@ class ConfTests(TestCase):
         """
         if settings.USE_MODELTRANSLATION:
             self.assertTrue(settings.USE_I18N)
+
+    def test_editable_caching(self):
+        """
+        Test the editable setting caching behavior.
+        """
+
+        # Ensure usage with no current request does not break caching
+        from mezzanine.core.request import _thread_local
+        del _thread_local.request
+
+        setting = Setting.objects.create(name='SITE_TITLE', value="Mezzanine")
+        original_site_title = settings.SITE_TITLE
+        setting.value = "Foobar"
+        setting.save()
+        new_site_title = settings.SITE_TITLE
+        setting.delete()
+        self.assertNotEqual(original_site_title, new_site_title)

--- a/mezzanine/pages/tests.py
+++ b/mezzanine/pages/tests.py
@@ -41,6 +41,10 @@ class PagesTests(TestCase):
         request.site_id = settings.SITE_ID
         _thread_local.request = request
 
+    def tearDown(self):
+        from mezzanine.core.request import _thread_local
+        del _thread_local.request
+
     def test_page_ascendants(self):
         """
         Test the methods for looking up ascendants efficiently


### PR DESCRIPTION
There's a bug where if code is being executed in a setup that doesn't use requests (like in `shell` or a Celery worker) then editable settings will be cached once and never change.

The fix is pretty simple, but we might want to drop `NULL_REQUEST` entirely since I believe with the change it doesn't provide any value. It was originally meant to be a value which could be inserted into the `WeakKeyDictionary` but that behavior is actually the cause of the bug. If there's no request we don't want to cache anything, or we'll accidentally cache it forever. @AlexHill, what are your thoughts?