### PR TITLE
Fix issue with PyPy2

### DIFF
--- a/mezzanine/utils/static.py
+++ b/mezzanine/utils/static.py
@@ -5,7 +5,8 @@ from __future__ import unicode_literals
 
 from django.contrib.admin.templatetags.admin_static import static
 from django.utils.functional import lazy
+from django.utils import six
 
 # The 'static' template tag returns cache-busting file names, which prevents
 # CDN's or browsers from serving old assets.
-static_lazy = lazy(static, str)
+static_lazy = lazy(static, six.text_type)


### PR DESCRIPTION
Under PyPy2 you can't do u"foo" == lazy(static, str)("bar") because the
code assumes dir(str) is a strict subset of dir(unicode), which isn't
true on PyPy2. The other way around is no problem however, and the
other strings in the static assets lists is unicode anyway.