### PR TITLE
Fix blog RSS/Atom feed validation

### DIFF
--- a/mezzanine/blog/feeds.py
+++ b/mezzanine/blog/feeds.py
@@ -135,6 +135,10 @@ class PostsRSS(Feed):
         if item.featured_image:
             return item.featured_image.size
 
+    def item_enclosure_mime_type(self, item):
+        if item.featured_image:
+            return item.featured_image.mimetype[0]
+
 
 class PostsAtom(PostsRSS):
     """

--- a/mezzanine/blog/feeds.py
+++ b/mezzanine/blog/feeds.py
@@ -131,6 +131,10 @@ class PostsRSS(Feed):
         if item.featured_image:
             return self.add_domain(item.featured_image.url)
 
+    def item_enclosure_length(self, item):
+        if item.featured_image:
+            return item.featured_image.size
+
 
 class PostsAtom(PostsRSS):
     """

--- a/mezzanine/blog/feeds.py
+++ b/mezzanine/blog/feeds.py
@@ -149,3 +149,6 @@ class PostsAtom(PostsRSS):
 
     def subtitle(self):
         return self.description()
+
+    def item_updateddate(self, item):
+        return item.updated


### PR DESCRIPTION
Fix validation errors for the generated RSS and Atom feeds, according to https://validator.w3.org/feed/.

I'd add tests, but there are no specific tests for the feeds, or I couldn't find them...