### PR TITLE
Use django check for SitePermissionsMiddleware

### DIFF
--- a/mezzanine/core/apps.py
+++ b/mezzanine/core/apps.py
@@ -2,9 +2,6 @@ from __future__ import unicode_literals
 
 from django import VERSION as DJANGO_VERSION
 from django.apps import AppConfig
-from django.core.checks import register
-
-from .checks import check_template_settings
 
 
 class CoreConfig(AppConfig):
@@ -12,7 +9,7 @@ class CoreConfig(AppConfig):
     name = 'mezzanine.core'
 
     def ready(self):
-        register()(check_template_settings)
+        from . import checks  # noqa
 
         if DJANGO_VERSION < (1, 9):
             # add_to_builtins was removed in 1.9 and replaced with a

--- a/mezzanine/core/checks.py
+++ b/mezzanine/core/checks.py
@@ -7,6 +7,8 @@ from django.conf import global_settings
 from django.core.checks import Warning, register
 
 from mezzanine.conf import settings
+from mezzanine.utils.deprecation import get_middleware_setting
+from mezzanine.utils.sites import SITE_PERMISSION_MIDDLEWARE
 
 
 @register()
@@ -153,3 +155,12 @@ def _build_suggested_template_config(settings):
         setter(new_setting_name, value)
 
     return [suggested_templates_config]
+
+
+@register()
+def check_sites_middleware(app_configs, **kwargs):
+    if SITE_PERMISSION_MIDDLEWARE not in get_middleware_setting():
+        return [Warning(SITE_PERMISSION_MIDDLEWARE
+                        + " missing from settings.MIDDLEWARE - per site "
+                        "permissions not applied",
+                        id="mezzanine.core.W04")]

--- a/mezzanine/core/checks.py
+++ b/mezzanine/core/checks.py
@@ -4,11 +4,12 @@ import pprint
 
 from django import VERSION as DJANGO_VERSION
 from django.conf import global_settings
-from django.core.checks import Warning
+from django.core.checks import Warning, register
 
 from mezzanine.conf import settings
 
 
+@register()
 def check_template_settings(app_configs, **kwargs):
 
     issues = []

--- a/mezzanine/core/checks.py
+++ b/mezzanine/core/checks.py
@@ -160,7 +160,7 @@ def _build_suggested_template_config(settings):
 @register()
 def check_sites_middleware(app_configs, **kwargs):
     if SITE_PERMISSION_MIDDLEWARE not in get_middleware_setting():
-        return [Warning(SITE_PERMISSION_MIDDLEWARE
-                        + " missing from settings.MIDDLEWARE - per site "
-                        "permissions not applied",
+        return [Warning(SITE_PERMISSION_MIDDLEWARE +
+                        " missing from settings.MIDDLEWARE - per site"
+                        " permissions not applied",
                         id="mezzanine.core.W04")]

--- a/mezzanine/pages/apps.py
+++ b/mezzanine/pages/apps.py
@@ -1,7 +1,4 @@
 from django.apps import AppConfig
-from django.core.checks import register
-
-from .checks import check_context_processor
 
 
 class PagesConfig(AppConfig):
@@ -9,4 +6,4 @@ class PagesConfig(AppConfig):
     name = 'mezzanine.pages'
 
     def ready(self):
-        register()(check_context_processor)
+        from . import checks  # noqa

--- a/mezzanine/pages/checks.py
+++ b/mezzanine/pages/checks.py
@@ -1,10 +1,11 @@
 from __future__ import unicode_literals
 
-from django.core.checks import Warning
+from django.core.checks import Warning, register
 
 from mezzanine.conf import settings
 
 
+@register
 def check_context_processor(app_configs, **kwargs):
 
     issues = []

--- a/mezzanine/utils/sites.py
+++ b/mezzanine/utils/sites.py
@@ -11,6 +11,8 @@ from mezzanine.conf import settings
 from mezzanine.core.request import current_request
 from mezzanine.utils.deprecation import get_middleware_setting
 
+SITE_PERMISSION_MIDDLEWARE = "mezzanine.core.middleware.SitePermissionMiddleware"
+
 
 def current_site_id():
     """
@@ -87,11 +89,7 @@ def has_site_permission(user):
     also fall back to an ``is_staff`` check if the middleware is not
     installed, to ease migration.
     """
-    mw = "mezzanine.core.middleware.SitePermissionMiddleware"
-    if mw not in get_middleware_setting():
-        from warnings import warn
-        warn(mw + " missing from settings.MIDDLEWARE - per site"
-             "permissions not applied")
+    if SITE_PERMISSION_MIDDLEWARE not in get_middleware_setting():
         return user.is_staff and user.is_active
     return getattr(user, "has_site_permission", False)
 

--- a/mezzanine/utils/tests.py
+++ b/mezzanine/utils/tests.py
@@ -43,6 +43,9 @@ IGNORE_ERRORS = (
     # lambdas are OK.
     "do not assign a lambda",
 
+    # checks modules need to be imported to register check functions, they will
+    # be run by Django.
+    "'.checks' imported but unused"
 )
 
 

--- a/mezzanine/utils/tests.py
+++ b/mezzanine/utils/tests.py
@@ -197,8 +197,11 @@ def run_pep8_for_package(package_name, extra_ignore=None):
             super(Checker, self).check_all(*args, **kwargs)
             return self.errors
 
+    style_guide = pep8.StyleGuide(config_file="setup.cfg")
+
     def pep8_checker(path):
-        for line_number, text in Checker(path).check_all():
+        for line_number, text in Checker(path,
+                                         options=style_guide.options).check_all():
             yield "%s:%s: %s" % (path, line_number, text)
 
     args = (pep8_checker, package_name, extra_ignore)

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ universal = 1
 exclude = build,.git,migrations
 ignore = E123,E126,E127,E128,E402,W503,E731,W601
 max-line-length = 119
+
+[pep8]
+max-line-length = 119


### PR DESCRIPTION
See #1400 

I had a look, and I don't think that any of the other warnings that remain need this treatment — they are all things that need to be addressed in other ways, like deprecation warnings, rather than optional things that can be safely silenced.