### PR TITLE
Use requirements.txt as default REQUIREMENTS_PATH

### DIFF
--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -63,7 +63,7 @@ env.domains_python = ", ".join(["'%s'" % s for s in env.domains])
 env.ssl_disabled = "#" if len(env.domains) > 1 else ""
 env.vcs_tools = ["git", "hg"]
 env.deploy_tool = conf.get("DEPLOY_TOOL", "rsync")
-env.reqs_path = conf.get("REQUIREMENTS_PATH", None)
+env.reqs_path = conf.get("REQUIREMENTS_PATH", "requirements.txt")
 env.locale = conf.get("LOCALE", "en_US.UTF-8")
 env.num_workers = conf.get("NUM_WORKERS",
                            "multiprocessing.cpu_count() * 2 + 1")


### PR DESCRIPTION
Since [local_settings.py says `requirements.txt` is the default value for `REQUIREMENTS_PATH`](https://github.com/stephenmcd/mezzanine/blob/master/mezzanine/project_template/project_name/local_settings.py.template#L42), shouldn't it be set here?

Sorry if I should not be pushing this to `master`, but there are too many branches, so I didn't know which one to push.