### PR TITLE
password reset: 'http' -> request.schema

### DIFF
--- a/mezzanine/accounts/templates/email/password_reset_verify.html
+++ b/mezzanine/accounts/templates/email/password_reset_verify.html
@@ -2,7 +2,7 @@
 {% block main %}
 <p>{% trans "Hey there, the password reset form was used for your account." %}</p>
 <p>{% trans "Please use the link below to log in and update your password." %}</p>
-<p><a href="http://{{ request.get_host }}{{ verify_url }}">http://{{ request.get_host }}{{ verify_url }}</a></p>
+<p><a href="{{ request.schema }}{{ request.get_host }}{{ verify_url }}">{{ request.schema }}{{ request.get_host }}{{ verify_url }}</a></p>
 <p>{% trans "If you didn't request for your password to be reset, please ignore this email." %}</p>
 {% endblock %}
 

--- a/mezzanine/accounts/templates/email/password_reset_verify.txt
+++ b/mezzanine/accounts/templates/email/password_reset_verify.txt
@@ -2,6 +2,6 @@
 {% block main %}
 {% trans "Hey there, the password reset form was used for your account." %}
 {% trans "Please use the link below to log in and update your password." %}
-http://{{ request.get_host }}{{ verify_url }}
+{{ request.schema }}{{ request.get_host }}{{ verify_url }}
 {% trans "If you didn't request for your password to be reset, please ignore this email." %}
 {% endblock %}


### PR DESCRIPTION
This fixes a potential security vulnerability in which the password
reset url is exposed to untrusted intermediary nodes in the network.
Thanks to John Barham for reporting. See
<https://groups.google.com/forum/?_escaped_fragment_=topic/mezzanine-users/KaDzCzCJDPM#!topic/mezzanine-users/KaDzCzCJDPM>.