### PR TITLE
Weigh search results by age

### DIFF
--- a/docs/search-engine.rst
+++ b/docs/search-engine.rst
@@ -128,14 +128,15 @@ Ordering Results
 ================
 
 By default, results are ordered by the number of matches found within the
-fields searched. It is possible to control the relative weight of a match
-found within one field over a match found in another field. Given the
-first example of searching :class:`.Page` instances, you might decide that
-a match within the ``title`` field is worth 5 times as much as a match in
-the ``description`` field. These relative weights can be defined in the
-same fashion as outlined above for defining the fields to be used in a
-search by using a slightly different format for the ``search_fields``
-argument::
+fields searched and their age.
+
+It is possible to control the relative weight of a match found within one
+field over a match found in another field. Given the first example of
+searching :class:`.Page` instances, you might decide that a match within
+the ``title`` field is worth 5 times as much as a match in the
+``description`` field. These relative weights can be defined in the same
+fashion as outlined above for defining the fields to be used in a search
+by using a slightly different format for the ``search_fields`` argument::
 
     from mezzanine.pages.models import Page
 
@@ -146,6 +147,12 @@ argument::
 As shown, a dictionary or mapping sequence can be used to associate
 weights to fields in any of the cases described above where
 ``search_fields`` can be defined.
+
+It is also possible to control the weight given to a match by its age by
+customizing the :ref:`SEARCH_AGE_SCALE_FACTOR` setting. Setting this to a
+high number gives more weight to the age, ranking newer matches higher
+with less regard to their original weight. Setting it to zero disables
+weighing matches by their age entirely.
 
 Searching Heterogeneous Models
 ==============================

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -621,6 +621,15 @@ Number of results shown in the search results page.
 
 Default: ``10``
 
+.. _SEARCH_AGE_SCALE_FACTOR:
+
+``SEARCH_AGE_SCALE_FACTOR``
+---------------------------
+
+The amount of emphasis to put on age when ranking search results. A higher number gives more emphasis to age, ranking newer results higher with less regard to their ordinary score. Setting this to zero disables weighing search results by age.
+
+Default: ``1.5``
+
 .. _SITE_PREFIX:
 
 ``SITE_PREFIX``

--- a/mezzanine/core/defaults.py
+++ b/mezzanine/core/defaults.py
@@ -357,6 +357,18 @@ register_setting(
 )
 
 register_setting(
+    name="SEARCH_AGE_SCALE_FACTOR",
+    label=_("Emphasis to put on age when ranking search results"),
+    description=_("The amount of emphasis to put on age when ranking search "
+                  "results. A higher number gives more emphasis to age, "
+                  "ranking newer results higher with less regard to their "
+                  "ordinary score. Setting this to zero disables weighing "
+                  "search results by age."),
+    editable=False,
+    default=1.5,
+)
+
+register_setting(
     name="SITE_PREFIX",
     description=_("A URL prefix for mounting all of Mezzanine's urlpatterns "
         "under. When using this, you'll also need to manually apply it to "

--- a/mezzanine/core/managers.py
+++ b/mezzanine/core/managers.py
@@ -216,6 +216,11 @@ class SearchableQuerySet(QuerySet):
                             count += field_value.lower().count(term) * weight
                 if not count and related_weights:
                     count = int(sum(related_weights) / len(related_weights))
+
+                if result.publish_date:
+                    age = (now() - result.publish_date).total_seconds()
+                    count = count / age**settings.SEARCH_AGE_SCALE_FACTOR
+
                 results[i].result_count = count
             return iter(results)
         return results


### PR DESCRIPTION
Weigh search results by their age by default. Add a new setting, `SEARCH_AGE_SCALE_FACTOR`, controlling how much emphasis to put on the age when ranking results (set this to 0 to revert to the old behavior).