### PR TITLE
Fix the old url parsing in import wordpress

### DIFF
--- a/mezzanine/blog/management/commands/import_wordpress.py
+++ b/mezzanine/blog/management/commands/import_wordpress.py
@@ -72,11 +72,14 @@ class Command(BaseImporterCommand):
             for item in getattr(entry, "tags", []):
                 terms[item.scheme].add(item.term)
 
+            # Is the URL of the site as determined by WordPress. Should be always present
+            # keep entry.id as old legacy link if entry['link'] is not present
+            old_url = entry.get('link', entry.id)
             if entry.wp_post_type == "post":
                 post = self.add_post(title=entry.title, content=content,
                                      pub_date=pub_date, tags=terms["tag"],
                                      categories=terms["category"],
-                                     old_url=entry.id)
+                                     old_url=old_url)
 
                 # Get the comments from the xml doc.
                 for c in xmlitem.getElementsByTagName("wp:comment"):


### PR DESCRIPTION
The old url is retrieved from the wordpress xml file in the wrong way. The correct key that contains the url is `entry['link']`. I managed to use the old `entry.id` as fallback in case the xml file is old or somehow is not present.
Using entry['link'] all the redirects are correctly created.

I tried to find some specs about the Wordpress xml file, but nothing is available: [see here on stackoverflow](https://stackoverflow.com/questions/9356099/wordpress-wxr-specification)

I found some specs reversing the xml file [here](https://devtidbits.com/2011/03/16/the-wordpress-extended-rss-wxr-exportimport-xml-document-format-decoded-and-explained/) and based on that article the definition of the `link` is: `the URL of the site as determined by WordPress.` or in other words the link compiled based on the permalink rules set in the wordpress installation.