### PR TITLE
Modified the blog homepage pattern to a working version. Added import it requires.

### DIFF
--- a/mezzanine/project_template/project_name/urls.py
+++ b/mezzanine/project_template/project_name/urls.py
@@ -8,6 +8,8 @@ from django.views.i18n import set_language
 from mezzanine.core.views import direct_to_template
 from mezzanine.conf import settings
 
+# Uncomment to use blog as home page. See also urlpatterns section below.
+# from mezzanine.blog import views as blog_views
 
 admin.autodiscover()
 
@@ -64,7 +66,7 @@ urlpatterns += [
     # page tree in the admin if it was installed.
     # NOTE: Don't forget to import the view function too!
 
-    # url("^$", mezzanine.blog.views.blog_post_list, name="home"),
+    # url("^$", blog_views.blog_post_list, name="home"),
 
     # MEZZANINE'S URLS
     # ----------------


### PR DESCRIPTION
Currently showing blog as front page requires knowledge of Mezzanine internals as a new import is required to the urls.py. This is way too difficult for a non-developer.

This commit adds the required import and modifies the related url pattern. Now user only needs to uncomment the url pattern line (and comment previous) and the import line to get the blog visible.

Not tested properly with git version and I'm not familiar with the codebase so please test before merging. Works on 4.2.3. ./setup.py test fails due to unrelated errors.