### PR TITLE
Fix for issue #1457

### DIFF
--- a/mezzanine/conf/forms.py
+++ b/mezzanine/conf/forms.py
@@ -47,17 +47,23 @@ class SettingsForm(forms.Form):
                             self._init_field(setting, field_class, name, code)
                 else:
                     self._init_field(setting, field_class, name)
-        activate(active_language)
+            activate(active_language)
 
     def _init_field(self, setting, field_class, name, code=None):
         """
         Initialize a field whether it is built with a custom name for a
         specific translation language or not.
         """
+
+        if settings.USE_MODELTRANSLATION and setting["translatable"]:
+            initial = Setting.objects.get(name=name).value
+        else:
+            initial = getattr(settings, name)
+
         kwargs = {
             "label": setting["label"] + ":",
             "required": setting["type"] in (int, float),
-            "initial": getattr(settings, name),
+            "initial": initial,
             "help_text": self.format_help(setting["description"]),
         }
         if setting["choices"]:


### PR DESCRIPTION
Fixed two problems (from issue #1457) with the editable settings admin when settings.USE_MODELTRANSLATION is True.

1) The settings for languages other than the user's current language used the wrong initial values
2) Non-translated settings appearing bellow a translated setting were displayed in the wrong language