### PR TITLE
Handle host-themes via a template loader

### DIFF
--- a/docs/multi-tenancy.rst
+++ b/docs/multi-tenancy.rst
@@ -133,3 +133,38 @@ an independent page hierarchy, etc.). Furthermore, the content types
 added to, say ``example_theme``, e.g. ``HomePage``, are shared and
 available in the different sites. Such nuances of sharing must be
 considered when employing this approach.
+
+Upgrading from ``TemplateForHostMiddleware``
+--------------------------------------------
+
+Mezzanine implements host-specific templates using a template loader since
+version 4.3. Prior to that, the ``TemplateForHostMiddleware`` was used. If you
+are upgrading from a version lower than 4.3 and getting warnings in the
+terminal about ``TemplateForHostMiddleware``, edit your ``settings.py`` to
+switch to the new loader-based approach:
+
+ * Remove ``TemplateForHostMiddleware`` from your ``MIDDLEWARE`` or
+   ``MIDDLEWARE_CLASSES`` setting.
+ * Remove ``"APP_DIRS": True`` from your ``TEMPLATES`` setting.
+ * Add ``mezzanine.template.loaders.host_themes.Loader`` to the list of
+   template loaders.
+
+Your ``TEMPLATES`` setting should look like this (notice the ``"loaders"`` key):
+
+.. code:: python
+
+    TEMPLATES = [
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "DIRS": [...],
+            "OPTIONS": {
+                "context_processors": [...],
+                "builtins": [...],
+                "loaders": [
+                    "mezzanine.template.loaders.host_themes.Loader",
+                    "django.template.loaders.filesystem.Loader",
+                    "django.template.loaders.app_directories.Loader",
+                ]
+            },
+        },
+    ]

--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -25,7 +25,7 @@ from mezzanine.utils.cache import (cache_key_prefix, nevercache_token,
 from mezzanine.utils.device import templates_for_device
 from mezzanine.utils.deprecation import (MiddlewareMixin, is_authenticated,
                                          get_middleware_setting)
-from mezzanine.utils.sites import current_site_id, templates_for_host
+from mezzanine.utils.sites import current_site_id
 from mezzanine.utils.urls import next_url
 
 
@@ -100,12 +100,15 @@ class TemplateForHostMiddleware(MiddlewareMixin):
     """
     Inserts host-specific templates to the template list.
     """
-    def process_template_response(self, request, response):
-        if hasattr(response, "template_name"):
-            if not isinstance(response.template_name, Template):
-                response.template_name = templates_for_host(
-                    response.template_name)
-        return response
+    def __init__(self, *args, **kwargs):
+        super(TemplateForHostMiddleware, self).__init__(*args, **kwargs)
+        warnings.warn(
+            "`TemplateForHostMiddleware` is deprecated. "
+            "Please remove it from your middleware settings and add "
+            "`mezzanine.template.loaders.host_themes.Loader` to your "
+            "template loader settings.",
+            FutureWarning, stacklevel=2
+        )
 
 
 class UpdateCacheMiddleware(MiddlewareMixin):

--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -104,9 +104,8 @@ class TemplateForHostMiddleware(MiddlewareMixin):
         super(TemplateForHostMiddleware, self).__init__(*args, **kwargs)
         warnings.warn(
             "`TemplateForHostMiddleware` is deprecated. "
-            "Please remove it from your middleware settings and add "
-            "`mezzanine.template.loaders.host_themes.Loader` to your "
-            "template loader settings.",
+            "Please upgrade to the template loader. See: "
+            "http://mezzanine.jupo.org/docs/multi-tenancy.html#upgrading-from-templateforhostmiddleware",
             FutureWarning, stacklevel=2
         )
 

--- a/mezzanine/project_template/project_name/settings.py
+++ b/mezzanine/project_template/project_name/settings.py
@@ -200,7 +200,6 @@ TEMPLATES = [
         "DIRS": [
             os.path.join(PROJECT_ROOT, "templates")
         ],
-        "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
                 "django.contrib.auth.context_processors.auth",
@@ -217,6 +216,11 @@ TEMPLATES = [
             "builtins": [
                 "mezzanine.template.loader_tags",
             ],
+            "loaders": [
+                "mezzanine.template.loaders.host_themes.Loader",
+                "django.template.loaders.filesystem.Loader",
+                "django.template.loaders.app_directories.Loader",
+            ]
         },
     },
 ]
@@ -270,7 +274,6 @@ MIDDLEWARE = (
     "mezzanine.core.request.CurrentRequestMiddleware",
     "mezzanine.core.middleware.RedirectFallbackMiddleware",
     "mezzanine.core.middleware.TemplateForDeviceMiddleware",
-    "mezzanine.core.middleware.TemplateForHostMiddleware",
     "mezzanine.core.middleware.AdminLoginInterfaceSelectorMiddleware",
     "mezzanine.core.middleware.SitePermissionMiddleware",
     "mezzanine.pages.middleware.PageMiddleware",

--- a/mezzanine/template/loaders/host_themes.py
+++ b/mezzanine/template/loaders/host_themes.py
@@ -1,0 +1,18 @@
+from __future__ import unicode_literals
+
+import os
+
+from django.template.loaders import filesystem
+
+from mezzanine.utils.sites import host_theme_path
+
+
+class Loader(filesystem.Loader):
+    """
+    Template loader that implements host detection.
+    """
+    def get_dirs(self):
+        theme_dir = host_theme_path()
+        if theme_dir:
+            return [os.path.join(theme_dir, "templates")]
+        return []

--- a/mezzanine/utils/sites.py
+++ b/mezzanine/utils/sites.py
@@ -118,21 +118,3 @@ def host_theme_path():
             else:
                 return os.path.dirname(os.path.abspath(module.__file__))
     return ""
-
-
-def templates_for_host(templates):
-    """
-    Given a template name (or list of them), returns the template names
-    as a list, with each name prefixed with the device directory
-    inserted into the front of the list.
-    """
-    if not isinstance(templates, (list, tuple)):
-        templates = [templates]
-    theme_dir = host_theme_path()
-    host_templates = []
-    if theme_dir:
-        for template in templates:
-            host_templates.append("%s/templates/%s" % (theme_dir, template))
-            host_templates.append(template)
-        return host_templates
-    return templates


### PR DESCRIPTION
This implements host-specific templates using a template loader instead of a middleware. Host-detection now works on all templates, like those included by templatetags or by `{% include %}` or `{% extend %}` calls. The middleware only worked on the final template rendered by a view.

I've also included a terminal warning with instructions for old projects to upgrade to the loader approach.
