### PR TITLE
Add public visibility status on Displayable model

### DIFF
--- a/mezzanine/core/models.py
+++ b/mezzanine/core/models.py
@@ -274,6 +274,15 @@ class Displayable(Slugged, MetaData, TimeStamped):
         return timesince(self.publish_date)
     publish_date_since.short_description = _("Published from")
 
+    def is_public(self):
+        """
+        Return ``True`` if this visible to the public, or ``False`` if it's
+        only shown for admin users.
+        """
+        return self.status == CONTENT_STATUS_PUBLISHED and \
+            (self.publish_date is None or self.publish_date <= now()) and \
+            (self.expiry_date is None or self.expiry_date >= now())
+
     def get_absolute_url(self):
         """
         Raise an error if called on a subclass without

--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -32,7 +32,7 @@ from django.template import RequestContext, Template
 from django.templatetags.static import static
 from django.test.utils import override_settings
 from django.utils.html import strip_tags
-from django.utils.timezone import datetime
+from django.utils.timezone import datetime, now, timedelta
 
 from mezzanine.conf import settings
 from mezzanine.core.admin import BaseDynamicInlineAdmin
@@ -605,6 +605,26 @@ class CSRFTestCase(TestCase):
         # The CSRF cookie should be present
         csrf_cookie = response.cookies.get(settings.CSRF_COOKIE_NAME, False)
         self.assertNotEqual(csrf_cookie, False)
+
+
+class DisplayableTestCase(TestCase):
+    def test_is_public(self):
+        page = Page.objects.create(publish_date=None, expiry_date=None,
+                                   status=CONTENT_STATUS_DRAFT)
+        self.assertFalse(page.is_public())
+
+        page.status = CONTENT_STATUS_PUBLISHED
+        self.assertTrue(page.is_public())
+
+        page.publish_date = now() + timedelta(days=10)
+        self.assertFalse(page.is_public())
+
+        page.publish_date = now() - timedelta(days=10)
+        page.expiry_date = now() + timedelta(days=10)
+        self.assertTrue(page.is_public())
+
+        page.expiry_date = now() - timedelta(days=10)
+        self.assertFalse(page.is_public())
 
 
 class ContentTypedTestCase(TestCase):


### PR DESCRIPTION
Add a method to the Displayable model for determining whether the instance is currently visible to the public. This can for instance be useful when wanting to style non-public pages or posts differently to make admin users able to tell them apart form public ones.