### PR TITLE
Test Nginx config before restarting

### DIFF
--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -95,7 +95,7 @@ templates = {
     "nginx": {
         "local_path": "deploy/nginx.conf.template",
         "remote_path": "/etc/nginx/sites-enabled/%(proj_name)s.conf",
-        "reload_command": "service nginx restart",
+        "reload_command": "nginx -t && service nginx restart",
     },
     "supervisor": {
         "local_path": "deploy/supervisor.conf.template",


### PR DESCRIPTION
This way the configuration won't be updated if it's broken, and you also get an error message in the terminal explaining why it's broken (instead of just telling you to check service status/journal).