### PR TITLE
Enable browser-native spell checking in WYSIWYG tinymce editor, which…

### DIFF
--- a/mezzanine/core/static/mezzanine/js/tinymce_setup.js
+++ b/mezzanine/core/static/mezzanine/js/tinymce_setup.js
@@ -70,6 +70,7 @@
         ],
         link_list: window.__link_list_url,
         relative_urls: false,
+        browser_spellcheck: true,
         convert_urls: false,
         menubar: false,
         statusbar: false,


### PR DESCRIPTION
… got wiped in 82339b0 . Previously introduced in 86f6ef6 .

This seems to have been disabled when upgrading support for Tinymce 4. I used the more general `browser_spellcheck` rather than the `gecko_spellcheck` attribute used previously. Tested in Safari and Firefox.