### PR TITLE
Fixed the bug with the response header and non-ascii cache names

### DIFF
--- a/mezzanine/generic/views.py
+++ b/mezzanine/generic/views.py
@@ -110,7 +110,7 @@ def comment(request, template="generic/comments.html", extra_context=None):
         # Store commenter's details in a cookie for 90 days.
         for field in ThreadedCommentForm.cookie_fields:
             cookie_name = ThreadedCommentForm.cookie_prefix + field
-            cookie_value = post_data.get(field, "")
+            cookie_value = post_data.get(field, "").encode('ascii', errors='ignore')
             set_cookie(response, cookie_name, cookie_value)
         return response
     elif request.is_ajax() and form.errors:


### PR DESCRIPTION
Hi, I faced a weird problem when I tried to comment with a non-ascii name and made a solution for it with a simple trick.

The story is explained [here](https://stackoverflow.com/questions/46605315/django-mezzanine-comments-with-non-ascii-cache-names) in much more details. The solution comes from the first comment.
