### PR TITLE
Don’t weigh search results in the future

### DIFF
--- a/mezzanine/core/managers.py
+++ b/mezzanine/core/managers.py
@@ -219,7 +219,8 @@ class SearchableQuerySet(QuerySet):
 
                 if result.publish_date:
                     age = (now() - result.publish_date).total_seconds()
-                    count = count / age**settings.SEARCH_AGE_SCALE_FACTOR
+                    if age > 0:
+                        count = count / age**settings.SEARCH_AGE_SCALE_FACTOR
 
                 results[i].result_count = count
             return iter(results)

--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -170,12 +170,23 @@ class CoreTests(TestCase):
             self.assertEqual(results[0].id, second)
 
         # Test ordering with age scaling.
-        settings.SEARCH_AGE_SCALE_FACTOR = 2
+        settings.SEARCH_AGE_SCALE_FACTOR = 1.5
         results = RichTextPage.objects.search("test")
         self.assertEqual(len(results), 2)
         if results:
             # `first` should now be ranked higher.
             self.assertEqual(results[0].id, first)
+
+        # Test results that have a publish date in the future
+        future = RichTextPage.objects.create(
+            title="test page to be published in the future",
+            publish_date=now() + timedelta(days=10),
+            **published
+        ).id
+        results = RichTextPage.objects.search("test", for_user=self._username)
+        self.assertEqual(len(results), 3)
+        if results:
+            self.assertEqual(results[0].id, future)
 
         # Test the actual search view.
         response = self.client.get(reverse("search") + "?q=test")


### PR DESCRIPTION
Fix a bug occurring when search results have publish dates in the future. Before this patch, an unlucky combination of a negative age and a fractional `SEARCH_AGE_SCALE_FACTOR` would result in a complex number search weight, giving problems with sorting since floats and complex numbers cannot be compared.

Simply ignore the age of future results during weighing instead.