### PR TITLE
Update editable.css

### DIFF
--- a/mezzanine/core/static/mezzanine/css/editable.css
+++ b/mezzanine/core/static/mezzanine/css/editable.css
@@ -36,6 +36,7 @@ a#editable-toolbar-toggle {border-left:0px !important; text-decoration:none;
     padding:20px; background:#fffcc3; border:1px solid #000;
     line-height:1em; border-radius:4px; min-width:350px;
     box-shadow: 0 0 80px #222;
+    color:#000;
 
     -ms-transform: translate(-50%, -50%);
     -webkit-transform: translate(-50%, -50%);


### PR DESCRIPTION
Updated to fix the color issue of the in-line editing form. If color of text being edited is white, text comes through the form white, making it appear empty.

Issue explained with images here: https://github.com/stephenmcd/mezzanine/issues/1814

You can also test this issue on the demo site using the chrome dev tools.

I simply added an explicit color (#000) to the form text, ensuring consistency no matter what color the text being edited is.