### PR TITLE
[Admin] : resolving keywords field with empty input

### DIFF
--- a/mezzanine/core/static/mezzanine/js/admin/keywords_field.js
+++ b/mezzanine/core/static/mezzanine/js/admin/keywords_field.js
@@ -9,7 +9,7 @@ jQuery(function($) {
     // the keyword's existance in the associated input box.
     $('.keywords-field a').click(function() {
         var field = $(this).parent().prev('input[type=text]');
-        var keywords = $.map(field.attr('value').split(','), function(keyword) {
+        var keywords = $.map(field.val().split(','), function(keyword) {
             return $.trim(keyword);
         });
         var keywords = $.grep(keywords, function(keyword) {


### PR DESCRIPTION
This error is shown in js console when I try to add a keyword (new or not) in the associated empty input :
```
keywords_field.js:13 Uncaught TypeError: Cannot read property 'split' of undefined
    at HTMLAnchorElement.<anonymous> (keywords_field.js:13)
    at HTMLAnchorElement.dispatch (jquery.js:4435)
    at HTMLAnchorElement.elemData.handle (jquery.js:4121)
```

Tested with :
Jquery UI version : jquery-ui-1.9.2.min.js
Jquery : jquery-1.8.3.min.js
Mezzanine : 4.2.3
Django : 1.9.11