### PR TITLE
Fixed 'cache_installed' util to not crash if Django 1.10 style middlewares are present

### DIFF
--- a/mezzanine/conf/tests.py
+++ b/mezzanine/conf/tests.py
@@ -212,7 +212,10 @@ class ConfTests(TestCase):
 
         # Ensure usage with no current request does not break caching
         from mezzanine.core.request import _thread_local
-        del _thread_local.request
+        try:
+            del _thread_local.request
+        except AttributeError:
+            pass
 
         setting = Setting.objects.create(name='SITE_TITLE', value="Mezzanine")
         original_site_title = settings.SITE_TITLE

--- a/mezzanine/core/checks.py
+++ b/mezzanine/core/checks.py
@@ -7,7 +7,7 @@ from django.conf import global_settings
 from django.core.checks import Warning, register
 
 from mezzanine.conf import settings
-from mezzanine.utils.deprecation import get_middleware_setting
+from mezzanine.utils.conf import middlewares_or_subclasses_installed
 from mezzanine.utils.sites import SITE_PERMISSION_MIDDLEWARE
 
 
@@ -159,7 +159,8 @@ def _build_suggested_template_config(settings):
 
 @register()
 def check_sites_middleware(app_configs, **kwargs):
-    if SITE_PERMISSION_MIDDLEWARE not in get_middleware_setting():
+
+    if middlewares_or_subclasses_installed([SITE_PERMISSION_MIDDLEWARE]):
         return [Warning(SITE_PERMISSION_MIDDLEWARE +
                         " missing from settings.MIDDLEWARE - per site"
                         " permissions not applied",

--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -470,12 +470,16 @@ class CoreTests(TestCase):
               'mezzanine.core.tests.SubclassMiddleware']),
             (True,
              ['mezzanine.core.middleware.UpdateCacheMiddleware',
+              'mezzanine.core.tests.FetchFromCacheMiddleware',
+              'mezzanine.core.tests.function_middleware']),
+            (True,
+             ['mezzanine.core.middleware.UpdateCacheMiddleware',
               'mezzanine.core.middleware.FetchFromCacheMiddleware']),
         ]
 
         with self.settings(TESTING=False):  # Well, this is silly
-            for expected_result, middleware_classes in test_contexts:
-                kwargs = {get_middleware_setting_name(): middleware_classes}
+            for expected_result, middlewares in test_contexts:
+                kwargs = {get_middleware_setting_name(): middlewares}
                 with self.settings(**kwargs):
                     cache_installed.cache_clear()
                     self.assertEqual(cache_installed(), expected_result)
@@ -485,6 +489,12 @@ class CoreTests(TestCase):
 
 class SubclassMiddleware(FetchFromCacheMiddleware):
     pass
+
+
+def function_middleware(get_response):
+    def middleware(request):
+        return get_response(request)
+    return middleware
 
 
 @skipUnless("mezzanine.pages" in settings.INSTALLED_APPS,

--- a/mezzanine/pages/middleware.py
+++ b/mezzanine/pages/middleware.py
@@ -8,9 +8,8 @@ from mezzanine.conf import settings
 from mezzanine.pages import context_processors, page_processors
 from mezzanine.pages.models import Page
 from mezzanine.pages.views import page as page_view
-from mezzanine.utils.deprecation import (MiddlewareMixin, is_authenticated,
-                                         get_middleware_setting)
-from mezzanine.utils.importing import import_dotted_path
+from mezzanine.utils.conf import middlewares_or_subclasses_installed
+from mezzanine.utils.deprecation import (MiddlewareMixin, is_authenticated)
 from mezzanine.utils.urls import path_to_slug
 
 
@@ -46,21 +45,13 @@ class PageMiddleware(MiddlewareMixin):
         Used in ``mezzanine.pages.views.page`` to ensure
         ``PageMiddleware`` or a subclass has been installed. We cache
         the result on the ``PageMiddleware._installed`` to only run
-        this once. Short path is to just check for the dotted path to
-        ``PageMiddleware`` in ``MIDDLEWARE_CLASSES`` - if not found,
-        we need to load each middleware class to match a subclass.
+        this once.
         """
         try:
             return cls._installed
         except AttributeError:
             name = "mezzanine.pages.middleware.PageMiddleware"
-            mw_setting = get_middleware_setting()
-            installed = name in mw_setting
-            if not installed:
-                for name in mw_setting:
-                    if issubclass(import_dotted_path(name), cls):
-                        installed = True
-                        break
+            installed = middlewares_or_subclasses_installed([name])
             setattr(cls, "_installed", installed)
             return installed
 

--- a/mezzanine/pages/tests.py
+++ b/mezzanine/pages/tests.py
@@ -46,7 +46,10 @@ class PagesTests(TestCase):
 
     def tearDown(self):
         from mezzanine.core.request import _thread_local
-        del _thread_local.request
+        try:
+            del _thread_local.request
+        except AttributeError:
+            pass
 
     def test_page_ascendants(self):
         """

--- a/mezzanine/utils/cache.py
+++ b/mezzanine/utils/cache.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import types
 from hashlib import md5
 from inspect import getmro
 from time import time
@@ -70,7 +71,10 @@ def cache_installed():
     def flatten(seqs):
         return (item for seq in seqs for item in seq)
 
-    middleware_classes = map(import_string, get_middleware_setting())
+    middleware_items = map(import_string, get_middleware_setting())
+    middleware_classes = filter(
+        lambda m: isinstance(m, (types.ClassType, types.TypeType)),
+        middleware_items)
     middleware_ancestors = set(flatten(map(getmro, middleware_classes)))
 
     mezzanine_cache_middleware_classes = {

--- a/mezzanine/utils/cache.py
+++ b/mezzanine/utils/cache.py
@@ -1,18 +1,15 @@
 from __future__ import unicode_literals
 
-import types
 from hashlib import md5
-from inspect import getmro
 from time import time
 
 from django.core.cache import cache
 from django.utils.lru_cache import lru_cache
 from django.utils.cache import _i18n_cache_key_suffix
-from django.utils.module_loading import import_string
 
 from mezzanine.conf import settings
-from mezzanine.utils.deprecation import get_middleware_setting
 from mezzanine.utils.sites import current_site_id
+from mezzanine.utils.conf import middlewares_or_subclasses_installed
 
 
 def _hashed_key(key):
@@ -68,22 +65,11 @@ def cache_installed():
     """
     has_key = bool(getattr(settings, "NEVERCACHE_KEY", ""))
 
-    def flatten(seqs):
-        return (item for seq in seqs for item in seq)
-
-    middleware_items = map(import_string, get_middleware_setting())
-    middleware_classes = filter(
-        lambda m: isinstance(m, (types.ClassType, types.TypeType)),
-        middleware_items)
-    middleware_ancestors = set(flatten(map(getmro, middleware_classes)))
-
-    mezzanine_cache_middleware_classes = {
-        import_string("mezzanine.core.middleware.UpdateCacheMiddleware"),
-        import_string("mezzanine.core.middleware.FetchFromCacheMiddleware"),
-    }
-
     return (has_key and settings.CACHES and not settings.TESTING and
-            mezzanine_cache_middleware_classes.issubset(middleware_ancestors))
+            middlewares_or_subclasses_installed([
+                "mezzanine.core.middleware.UpdateCacheMiddleware",
+                "mezzanine.core.middleware.FetchFromCacheMiddleware",
+            ]))
 
 
 def cache_key_prefix(request):

--- a/mezzanine/utils/conf.py
+++ b/mezzanine/utils/conf.py
@@ -2,11 +2,15 @@ from __future__ import unicode_literals
 
 import os
 import sys
+from inspect import getmro
 from warnings import warn
 
+import six
 from django.db import OperationalError
 from django.conf import global_settings as defaults
+from django.utils.module_loading import import_string
 
+from mezzanine.utils.deprecation import get_middleware_setting
 from mezzanine.utils.timezone import get_best_local_timezone
 
 
@@ -241,3 +245,24 @@ def real_project_name(project_name):
     if project_name == "{{ project_name }}":
         return "project_name"
     return project_name
+
+
+def middlewares_or_subclasses_installed(needed_middlewares):
+
+    middleware_setting = set(get_middleware_setting())
+    # Shortcut case, check by string
+    if all(m in middleware_setting for m in needed_middlewares):
+        return True
+
+    def flatten(seqs):
+        return (item for seq in seqs for item in seq)
+
+    middleware_items = map(import_string, middleware_setting)
+    middleware_classes = filter(
+        lambda m: isinstance(m, six.class_types),
+        middleware_items)
+    middleware_ancestors = set(flatten(map(getmro, middleware_classes)))
+
+    needed_middlewares = set(map(import_string, needed_middlewares))
+
+    return needed_middlewares.issubset(middleware_ancestors)

--- a/mezzanine/utils/conf.py
+++ b/mezzanine/utils/conf.py
@@ -248,8 +248,12 @@ def real_project_name(project_name):
 
 
 def middlewares_or_subclasses_installed(needed_middlewares):
-
+    """
+    When passed an iterable of dotted strings, returns True if all
+    of the middlewares (or their subclasses) are installed.
+    """
     middleware_setting = set(get_middleware_setting())
+
     # Shortcut case, check by string
     if all(m in middleware_setting for m in needed_middlewares):
         return True

--- a/mezzanine/utils/sites.py
+++ b/mezzanine/utils/sites.py
@@ -9,7 +9,7 @@ from django.contrib.sites.models import Site
 
 from mezzanine.conf import settings
 from mezzanine.core.request import current_request
-from mezzanine.utils.deprecation import get_middleware_setting
+from mezzanine.utils.conf import middlewares_or_subclasses_installed
 
 
 SITE_PERMISSION_MIDDLEWARE = \
@@ -91,7 +91,7 @@ def has_site_permission(user):
     also fall back to an ``is_staff`` check if the middleware is not
     installed, to ease migration.
     """
-    if SITE_PERMISSION_MIDDLEWARE not in get_middleware_setting():
+    if middlewares_or_subclasses_installed([SITE_PERMISSION_MIDDLEWARE]):
         return user.is_staff and user.is_active
     return getattr(user, "has_site_permission", False)
 


### PR DESCRIPTION
Should be self explanatory. `inspect.getmro` crashes if you pass it a function, and new-style middleware items can be functions.
