### PR TITLE
Fix TemplateSettings unicode/str

### DIFF
--- a/mezzanine/conf/context_processors.py
+++ b/mezzanine/conf/context_processors.py
@@ -2,11 +2,14 @@ from __future__ import unicode_literals
 
 from warnings import warn
 
+from django.utils.encoding import python_2_unicode_compatible
+
 
 # Deprecated settings and their defaults.
 DEPRECATED = {}
 
 
+@python_2_unicode_compatible
 class TemplateSettings(dict):
     """
     Dict wrapper for template settings. This exists to enforce
@@ -50,6 +53,9 @@ class TemplateSettings(dict):
     def __repr__(self):
         return repr(dict((k, self[k]) for k in self.allowed_settings
                          if hasattr(self.settings, k) or k in self))
+
+    def __str__(self):
+        return repr(self)
 
 
 def settings(request=None):

--- a/mezzanine/conf/context_processors.py
+++ b/mezzanine/conf/context_processors.py
@@ -47,6 +47,10 @@ class TemplateSettings(dict):
         self.allowed_settings.add(k)
         super(TemplateSettings, self).__setitem__(k, v)
 
+    def __repr__(self):
+        return repr(dict((k, self[k]) for k in self.allowed_settings
+                         if hasattr(self.settings, k) or k in self))
+
 
 def settings(request=None):
     """

--- a/mezzanine/conf/tests.py
+++ b/mezzanine/conf/tests.py
@@ -5,6 +5,7 @@ from unittest import skipUnless
 import warnings
 
 from django.conf import settings as django_settings
+from django.utils.encoding import force_text
 
 from mezzanine.conf import settings, registry, register_setting
 from mezzanine.conf.context_processors import TemplateSettings
@@ -259,3 +260,10 @@ class TemplateSettingsTests(TestCase):
         ts3['EXTRA_THING'] = 'foo'
         self.assertIn("'EXTRA_THING'", repr(ts3))
         self.assertIn("'foo'", repr(ts3))
+
+    def test_force_text(self):
+        ts = TemplateSettings(settings, [])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.assertEqual(force_text(ts), '{}')
+        self.assertEqual(len(w), 0)

--- a/mezzanine/conf/tests.py
+++ b/mezzanine/conf/tests.py
@@ -246,3 +246,16 @@ class TemplateSettingsTests(TestCase):
         ts['EXTRA_THING'] = 'foo'
         self.assertEqual(ts.EXTRA_THING, 'foo')
         self.assertEqual(ts['EXTRA_THING'], 'foo')
+
+    def test_repr(self):
+        ts = TemplateSettings(settings, [])
+        self.assertEqual(repr(ts), '{}')
+
+        ts2 = TemplateSettings(settings,
+                               ['DEBUG', 'SOME_NON_EXISTANT_SETTING'])
+        self.assertIn("'DEBUG': False", repr(ts2))
+
+        ts3 = TemplateSettings(settings, [])
+        ts3['EXTRA_THING'] = 'foo'
+        self.assertIn("'EXTRA_THING'", repr(ts3))
+        self.assertIn("'foo'", repr(ts3))

--- a/mezzanine/conf/tests.py
+++ b/mezzanine/conf/tests.py
@@ -7,6 +7,7 @@ import warnings
 from django.conf import settings as django_settings
 
 from mezzanine.conf import settings, registry, register_setting
+from mezzanine.conf.context_processors import TemplateSettings
 from mezzanine.conf.models import Setting
 from mezzanine.utils.tests import TestCase
 
@@ -224,3 +225,24 @@ class ConfTests(TestCase):
         new_site_title = settings.SITE_TITLE
         setting.delete()
         self.assertNotEqual(original_site_title, new_site_title)
+
+
+class TemplateSettingsTests(TestCase):
+    def test_allowed(self):
+        # We choose a setting that will definitely exist:
+        ts = TemplateSettings(settings, ['INSTALLED_APPS'])
+        self.assertEqual(ts.INSTALLED_APPS, settings.INSTALLED_APPS)
+        self.assertEqual(ts['INSTALLED_APPS'], settings.INSTALLED_APPS)
+
+    def test_not_allowed(self):
+        ts = TemplateSettings(settings, [])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertRaises(AttributeError, lambda: ts.INSTALLED_APPS)
+            self.assertRaises(KeyError, lambda: ts['INSTALLED_APPS'])
+
+    def test_add(self):
+        ts = TemplateSettings(settings, ['INSTALLED_APPS'])
+        ts['EXTRA_THING'] = 'foo'
+        self.assertEqual(ts.EXTRA_THING, 'foo')
+        self.assertEqual(ts['EXTRA_THING'], 'foo')


### PR DESCRIPTION
The main motivation behind this is to stop the warning:

    UserWarning: __unicode__ is not in TEMPLATE_ACCESSIBLE_SETTINGS

that appears if you are using django-debug-toolbar. This is caused ultimately by defining `__getattr__` which ends up being called via `hasattr(obj, "__unicode__")`.

In addition, this PR adds some basic tests for TemplateSettings, and makes the repr much more useful/accurate than before (which helps with debugging e.g. using django-debug-toolbar templates panel).