### PR TITLE
Support access to related model on Django 2+

### DIFF
--- a/mezzanine/accounts/__init__.py
+++ b/mezzanine/accounts/__init__.py
@@ -83,8 +83,12 @@ def get_profile_user_fieldname(profile_model=None, user_model=None):
     Profile = profile_model or get_profile_model()
     User = user_model or get_user_model()
     for field in Profile._meta.get_fields():
-        if field.rel and field.rel.to == User:
-            return field.name
+        # Support for Django 2.
+        # Can be simplified when dropping support for Django 1.8
+        if hasattr(field, 'remote_field') or hasattr(field, 'rel'):
+            related_model = field.remote_field.model if hasattr(field, 'remote_field') else field.rel.to
+            if related_model == User:
+                return field.name
     raise ImproperlyConfigured("Value for ACCOUNTS_PROFILE_MODEL does not "
                                "contain a ForeignKey field for auth.User: %s"
                                % Profile.__name__)

--- a/mezzanine/generic/fields.py
+++ b/mezzanine/generic/fields.py
@@ -85,7 +85,7 @@ class BaseGenericRelation(GenericRelation):
             getter_name = "get_%s_name" % self.__class__.__name__.lower()
             cls.add_to_class(getter_name, lambda self: name)
 
-            sender = self.rel.to
+            sender = self.remote_field.model if hasattr(self, 'remote_field') else self.rel.to
             post_save.connect(self._related_items_changed, sender=sender)
             post_delete.connect(self._related_items_changed, sender=sender)
 


### PR DESCRIPTION
`field.rel` was removed in Django 2.  These changes maintain compatibility with Django<2