### PR TITLE
Bump django requirement 1.11 for Mezzanine 4.3.0

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -46,7 +46,7 @@ unless noted as optional, should be installed automatically following
 the above instructions:
 
 * `Python`_ 2.7 to 3.6
-* `Django`_ 1.8 to 1.10
+* `Django`_ 1.8 to 1.11
 * `django-contrib-comments`_ - for built-in threaded comments
 * `Pillow`_ - for image resizing (`Python Imaging Library`_ fork)
 * `grappelli-safe`_ - admin skin (`Grappelli`_ fork)


### PR DESCRIPTION
Documentation still mentioned 1.10