### PR TITLE
Fix imports from deprecated `urlresolvers` module

### DIFF
--- a/mezzanine/accounts/tests.py
+++ b/mezzanine/accounts/tests.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.forms.fields import DateField, DateTimeField
 from django.utils.http import int_to_base36
 

--- a/mezzanine/accounts/views.py
+++ b/mezzanine/accounts/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth import (login as auth_login, authenticate,
                                  logout as auth_logout, get_user_model)
 from django.contrib.auth.decorators import login_required
 from django.contrib.messages import info, error
-from django.core.urlresolvers import NoReverseMatch, get_script_prefix
+from django.urls import NoReverseMatch, get_script_prefix
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.utils.translation import ugettext_lazy as _

--- a/mezzanine/blog/feeds.py
+++ b/mezzanine/blog/feeds.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.contrib.syndication.views import Feed, add_domain
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import get_object_or_404
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.html import strip_tags

--- a/mezzanine/blog/models.py
+++ b/mezzanine/blog/models.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 from future.builtins import str
 
 from django.db import models
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from mezzanine.conf import settings

--- a/mezzanine/blog/tests.py
+++ b/mezzanine/blog/tests.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     from urlparse import urlparse
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template import Context, Template
 from django.test import override_settings
 

--- a/mezzanine/core/admin.py
+++ b/mezzanine/core/admin.py
@@ -8,7 +8,7 @@ from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User as AuthUser
 from django.contrib.redirects.admin import RedirectAdmin
 from django.contrib.messages import error
-from django.core.urlresolvers import NoReverseMatch
+from django.urls import NoReverseMatch
 from django.forms import ValidationError, ModelForm
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404

--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -7,7 +7,7 @@ from django.contrib.auth import logout
 from django.contrib.messages import error
 from django.contrib.redirects.models import Redirect
 from django.core.exceptions import MiddlewareNotUsed
-from django.core.urlresolvers import reverse, resolve
+from django.urls import reverse, resolve
 from django.http import (HttpResponse, HttpResponseRedirect,
                          HttpResponsePermanentRedirect, HttpResponseGone)
 from django.middleware.csrf import CsrfViewMiddleware, get_token

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -15,7 +15,7 @@ from django.contrib.sites.models import Site
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files import File
 from django.core.files.storage import default_storage
-from django.core.urlresolvers import reverse, resolve, NoReverseMatch
+from django.urls import reverse, resolve, NoReverseMatch
 from django.db.models import Model
 from django.template import Node, Template, TemplateSyntaxError
 from django.template.base import (TOKEN_BLOCK, TOKEN_COMMENT,

--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -24,7 +24,7 @@ from django.contrib.sites.models import Site
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.core.management import call_command, CommandError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.forms import Textarea
 from django.forms.models import modelform_factory

--- a/mezzanine/core/views.py
+++ b/mezzanine/core/views.py
@@ -19,7 +19,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.admin.options import ModelAdmin
 from django.contrib.staticfiles import finders
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import (HttpResponse, HttpResponseServerError,
                          HttpResponseNotFound)
 from django.shortcuts import redirect

--- a/mezzanine/forms/forms.py
+++ b/mezzanine/forms/forms.py
@@ -13,7 +13,7 @@ except ImportError:
     from django.forms.extras.widgets import SelectDateWidget
 
 from django.core.files.storage import FileSystemStorage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template import Template
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _

--- a/mezzanine/forms/tests.py
+++ b/mezzanine/forms/tests.py
@@ -40,7 +40,7 @@ class TestsForm(TestCase):
         being translated back to the default language.
         """
         from collections import OrderedDict
-        from django.core.urlresolvers import reverse
+        from django.urls import reverse
         from django.utils.translation import (get_language, activate,
                                               ugettext as _)
         from modeltranslation.utils import auto_populate

--- a/mezzanine/generic/templatetags/comment_tags.py
+++ b/mezzanine/generic/templatetags/comment_tags.py
@@ -3,7 +3,7 @@ from future.builtins import int
 
 from collections import defaultdict
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.defaultfilters import linebreaksbr, urlize
 
 from mezzanine import template

--- a/mezzanine/generic/tests.py
+++ b/mezzanine/generic/tests.py
@@ -7,7 +7,7 @@ from future.utils import native_str
 from unittest import skipUnless
 
 from django.contrib.contenttypes.models import ContentType
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from mezzanine.blog.models import BlogPost
 from mezzanine.conf import settings

--- a/mezzanine/generic/views.py
+++ b/mezzanine/generic/views.py
@@ -7,7 +7,7 @@ from string import punctuation
 from django.apps import apps
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.messages import error
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import ObjectDoesNotExist
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect

--- a/mezzanine/pages/models.py
+++ b/mezzanine/pages/models.py
@@ -7,7 +7,7 @@ try:
 except ImportError:  # Python 2
     from urlparse import urljoin
 
-from django.core.urlresolvers import resolve, reverse
+from django.urls import resolve, reverse
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _, ugettext

--- a/mezzanine/utils/email.py
+++ b/mezzanine/utils/email.py
@@ -3,7 +3,7 @@ from future.builtins import bytes, str
 
 from django.contrib.auth.tokens import default_token_generator
 from django.core.mail import EmailMultiAlternatives
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template import loader
 from django.utils.http import int_to_base36
 

--- a/mezzanine/utils/urls.py
+++ b/mezzanine/utils/urls.py
@@ -5,8 +5,7 @@ import re
 import unicodedata
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.urlresolvers import (resolve, reverse, NoReverseMatch,
-                                      get_script_prefix)
+from django.urls import resolve, reverse, NoReverseMatch, get_script_prefix
 from django.shortcuts import redirect
 from django.utils.encoding import smart_text
 


### PR DESCRIPTION
Importing from the `django.core.urlresolvers` module was deprecated in favor of `django.urls` in Django 1.10, and the former was removed entirely in Django 2.0. Import from `django.urls` instead.
