### PR TITLE
Make the search engine work in Django 2

### DIFF
--- a/mezzanine/core/managers.py
+++ b/mezzanine/core/managers.py
@@ -171,13 +171,15 @@ class SearchableQuerySet(QuerySet):
             queryset = queryset.filter(reduce(ior, optional))
         return queryset.distinct()
 
-    def _clone(self, *args, **kwargs):
+    def _clone(self):
         """
         Ensure attributes are copied to subsequent queries.
         """
-        for attr in ("_search_terms", "_search_fields", "_search_ordered"):
-            kwargs[attr] = getattr(self, attr)
-        return super(SearchableQuerySet, self)._clone(*args, **kwargs)
+        clone = super(SearchableQuerySet, self)._clone()
+        clone._search_terms = self._search_terms
+        clone._search_fields = self._search_fields
+        clone._search_ordered = self._search_ordered
+        return clone
 
     def order_by(self, *field_names):
         """


### PR DESCRIPTION
The `*args` and `**kwargs` arguments to `QuerySet._clone` are removed in Django 2. Preserve the queryset attributes by copying them directly instead.