### PR TITLE
Fix invalid escape sequence in URL pattern

### DIFF
--- a/mezzanine/urls.py
+++ b/mezzanine/urls.py
@@ -38,7 +38,7 @@ if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:
 if "django.contrib.sitemaps" in settings.INSTALLED_APPS:
     sitemaps = {"sitemaps": {"all": DisplayableSitemap}}
     urlpatterns += [
-        url("^sitemap\.xml$", sitemap, sitemaps),
+        url(r"^sitemap\.xml$", sitemap, sitemaps),
     ]
 
 # Return a robots.txt that disallows all spiders when DEBUG is True.


### PR DESCRIPTION
Invalid escape sequences are deprecated in Python 3.6. One such instance was found in the sitemap URL pattern; use a raw string literal there instead.