### PR TITLE
Make test pass after September 2018

### DIFF
--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -167,7 +167,7 @@ class CoreTests(TestCase):
         # Test ordering without age scaling.
         settings.SEARCH_AGE_SCALE_FACTOR = 0
         RichTextPage.objects.filter(id=first).update(
-            publish_date=datetime(2017, 1, 1, tzinfo=pytz.utc))
+            publish_date=now() - timedelta(days=3))
         RichTextPage.objects.filter(id=second).update(
             publish_date=datetime(2016, 1, 1, tzinfo=pytz.utc))
         results = RichTextPage.objects.search("test")


### PR DESCRIPTION
In September 2018, the search score of a page from 2016 with two matches surpassed that of a page from 2017 with one match, due to the non-linear age scale scoring, causing a test failure.

Update the test so that the page with one match is new enough to always score higher than the one from 2016.