### PR TITLE
Bump the required Django version range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 env:
-  - DJANGO="Django>=1.8,<1.9"
-  - DJANGO="Django>=1.9,<1.10"
-  - DJANGO="Django>=1.10,<1.11"
-  - DJANGO="Django>=1.11,<1.12"
+  - DJANGO="Django>=1.11,<2.0"
+  - DJANGO="Django>=2.0,<2.1"
 python:
   - "2.7"
   - "3.4"

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ try:
         packages=find_packages(),
         install_requires=[
             "django-contrib-comments",
-            "django >= 1.8, < 1.12",
+            "django >= 1.11, < 2.1",
             "filebrowser_safe >= 0.5.0",
             "grappelli_safe >= 0.5.0",
             "tzlocal >= 1.0",


### PR DESCRIPTION
The oldest still-supported Django release is currently 1.11, which will stay supported until early 2020. Drop Mezzanine's support for Django versions older than that.

Also include the Django 2.0 release series in the travis tests, since support for Django 2.0 is targeted for the next Mezzanine release.