### PR TITLE
Remove `SessionAuthenticationMiddleware`

### DIFF
--- a/mezzanine/project_template/project_name/settings.py
+++ b/mezzanine/project_template/project_name/settings.py
@@ -266,7 +266,6 @@ MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 


### PR DESCRIPTION
Since Django 1.10, session verification is enabled regardless of whether or not `SessionAuthenticationMiddleware` is in `MIDDLEWARE`, and it was removed entirely in Django 2.0.

Remove `SessionAuthenticationMiddleware` from the project template to make it compatible with Django 2.0.