### PR TITLE
Use `assertEqual` instead of `assertEquals`

### DIFF
--- a/mezzanine/generic/tests.py
+++ b/mezzanine/generic/tests.py
@@ -149,7 +149,7 @@ class GenericTests(TestCase):
             request.user = self._user
             request.session = {}
         response = comment(request)
-        self.assertEquals(response.status_code, 400)
+        self.assertEqual(response.status_code, 400)
 
     def test_multiple_comment_forms(self):
 


### PR DESCRIPTION
`assertEquals` is a deprecated alias for `assertEqual`, so use `assertEqual` instead.