### PR TITLE
Feature: Testing through tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .idea/
 local_settings.py
 .eggs/
+.tox/
 Mezzanine.egg-info/
 build/
 docs/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,27 @@
 language: python
 env:
-  - DJANGO="Django>=1.11,<2.0"
-  - DJANGO="Django>=2.0,<2.1"
+  - DJANGO="111"
+  - DJANGO="20"
+  - DJANGO="21"
+  - DJANGO="master"
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 install:
-  - pip install --upgrade pip setuptools
-  - pip install $DJANGO
-  - pip install .
+  - pip install --upgrade pip setuptools tox
 script:
-  - python setup.py test
+  - tox -e py$(python -c 'import sys;print("".join(map(str, sys.version_info[:2])))')-dj${DJANGO}
+matrix:
+  fast_finish: true
+  include:
+    - python: "2.7"
+      env: DJANGO="111"
+    - python: "3.4"
+      env: DJANGO="111"
+    - python: "3.4"
+      env: DJANGO="20"
+  allow_failures:
+    - env: DJANGO="master"
 notifications:
   irc: "irc.freenode.org#mezzanine"
   on_success: change

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist =
+    py{27,34}-dj111
+    py{35,36}-dj{111,20,21,master}
+
+[testenv]
+commands = python setup.py test
+
+deps =
+    dj111: Django>=1.11,<1.12
+    dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
+    djmaster: git+https://github.com/django/django.git@master#egg=Django
+    dj{20,21,master}: git+https://github.com/stephenmcd/filebrowser-safe.git@master#egg=filebrowser_safe

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    py{27,34}-dj111
+    py27-dj111
+    py34-dj{111,20)
     py{35,36}-dj{111,20,21,master}
 
 [testenv]


### PR DESCRIPTION
-  Allow local testing trough tox
- Change travis configuration to use tox for running the tests

My reasoning for this Pull Request is to allow other contributors to easily run tests locally for all supported configurations. I changed travis to use tox in order not to duplicate configuration for setup the test environment.