### PR TITLE
Fix test_password_reset for Django 2+

### DIFF
--- a/mezzanine/core/tests.py
+++ b/mezzanine/core/tests.py
@@ -4,6 +4,8 @@ import re
 import pytz
 from unittest import skipUnless
 
+from django.utils.encoding import force_str
+
 from mezzanine.core.middleware import FetchFromCacheMiddleware
 from mezzanine.core.templatetags.mezzanine_tags import initialize_nevercache
 from mezzanine.utils.cache import cache_installed
@@ -335,7 +337,7 @@ class CoreTests(TestCase):
             response.content
         )
         self.assertEqual(len(url), 1)
-        url = url[0]
+        url = force_str(url[0])
 
         # Go to reset-page, submit form
         response = self.client.get(url)


### PR DESCRIPTION
In Django 2.0 bytes can't be passed as URL to test client.

This is one of the failing tests in #1886 and stephenmcd/filebrowser-safe#116