### PR TITLE
Fix: Django 2 (Python 3) Tests

### DIFF
--- a/mezzanine/conf/tests.py
+++ b/mezzanine/conf/tests.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from future.builtins import bytes, str
 
+import sys
 from unittest import skipUnless
 import warnings
 
@@ -11,6 +12,8 @@ from mezzanine.conf import settings, registry, register_setting
 from mezzanine.conf.context_processors import TemplateSettings
 from mezzanine.conf.models import Setting
 from mezzanine.utils.tests import TestCase
+
+PY2 = sys.version_info[0] == 2
 
 
 class ConfTests(TestCase):
@@ -128,6 +131,7 @@ class ConfTests(TestCase):
         second_value = settings.FOO
         self.assertEqual(first_value, second_value)
 
+    @skipUnless(PY2, "Needed only in Python 2")
     def test_bytes_conversion(self):
 
         settings.clear_cache()

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-dj111
-    py34-dj{111,20)
+    py34-dj{111,20}
     py{35,36}-dj{111,20,21,master}
 
 [testenv]


### PR DESCRIPTION
In #1886 was shown that only two tests are failing for Django 2+. The first is fixed in #1887. This is fix for the second one.

Because Django 2 is Python 3 only some of the compatibility shims in Django for converting byte strings to unicode strings was removed and code which uses the old behaviour will no longer works. Generally In Python 3 always native (unicode) strings will be used or bytes will be converted to strings with appropriate encoding.

For that reason I'm disabling `test_bytes_conversion` test which uses old Django's automatic conversion from bytes to unicode. When this test is disabled under Python 3 then the failing test `test_settings` under Django 2+ now pass correctly.

This is needed for #1749