### PR TITLE
Remove usage of deprecated `allow_tags` attribute

### DIFF
--- a/mezzanine/core/models.py
+++ b/mezzanine/core/models.py
@@ -15,7 +15,7 @@ from django.db import models
 from django.db.models.base import ModelBase
 from django.template.defaultfilters import truncatewords_html
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.html import strip_tags
+from django.utils.html import format_html, strip_tags
 from django.utils.timesince import timesince
 from django.utils.timezone import now
 from django.utils.translation import ugettext, ugettext_lazy as _
@@ -121,9 +121,8 @@ class Slugged(SiteRelated):
         return slugify(getattr(self, attr, None) or self.title)
 
     def admin_link(self):
-        return "<a href='%s'>%s</a>" % (self.get_absolute_url(),
-                                        ugettext("View on site"))
-    admin_link.allow_tags = True
+        return format_html("<a href='{}'>{}</a>", self.get_absolute_url(),
+                           ugettext("View on site"))
     admin_link.short_description = ""
 
 

--- a/mezzanine/generic/models.py
+++ b/mezzanine/generic/models.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.template.defaultfilters import truncatewords_html
 from django.utils.translation import ugettext, ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.html import escape
+from django.utils.html import format_html
 
 from django_comments.models import Comment
 
@@ -67,17 +67,16 @@ class ThreadedComment(Comment):
 
     def avatar_link(self):
         from mezzanine.core.templatetags.mezzanine_tags import gravatar_url
-        vars = (escape(self.user_email), gravatar_url(self.email),
-                escape(self.user_name))
-        return ("<a href='mailto:%s'><img style='vertical-align:middle; "
-                "margin-right:3px;' src='%s' />%s</a>" % vars)
-    avatar_link.allow_tags = True
+        return format_html(
+            "<a href='mailto:{}'><img style='vertical-align:middle; "
+            "margin-right:3px;' src='{}' />{}</a>",
+            self.user_email, gravatar_url(self.email), self.user_name
+        )
     avatar_link.short_description = _("User")
 
     def admin_link(self):
-        return "<a href='%s'>%s</a>" % (self.get_absolute_url(),
-                                        ugettext("View on site"))
-    admin_link.allow_tags = True
+        return format_html("<a href='{}'>{}</a>", self.get_absolute_url(),
+                           ugettext("View on site"))
     admin_link.short_description = ""
 
     # Exists for backward compatibility when the gravatar_url template

--- a/mezzanine/utils/models.py
+++ b/mezzanine/utils/models.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model as django_get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model, Field
+from django.utils.html import format_html
 
 from mezzanine.utils.importing import import_dotted_path
 
@@ -109,8 +110,7 @@ class AdminThumbMixin(object):
         from mezzanine.core.templatetags.mezzanine_tags import thumbnail
         x, y = settings.ADMIN_THUMB_SIZE.split('x')
         thumb_url = thumbnail(thumb, x, y)
-        return "<img src='%s%s'>" % (settings.MEDIA_URL, thumb_url)
-    admin_thumb.allow_tags = True
+        return format_html("<img src='{}{}'>", settings.MEDIA_URL, thumb_url)
     admin_thumb.short_description = ""
 
 


### PR DESCRIPTION
The `allow_tags` attribute on methods of `ModelAdmin` was deprecated in Django 1.9, and removed in Django 2.0. Use `django.utils.html.format_html` instead to achieve the same effect.