### PR TITLE
Update override_current_site_id to handle exceptions 

### DIFF
--- a/mezzanine/utils/sites.py
+++ b/mezzanine/utils/sites.py
@@ -76,8 +76,14 @@ def override_current_site_id(site_id):
     within it. Used to access SiteRelated objects outside the current site.
     """
     override_current_site_id.thread_local.site_id = site_id
-    yield
-    del override_current_site_id.thread_local.site_id
+    try:
+        yield
+    except Exception:
+        raise
+    finally:
+        del override_current_site_id.thread_local.site_id
+
+
 override_current_site_id.thread_local = threading.local()
 
 


### PR DESCRIPTION
Currently, when `override_current_site_id` wraps a code block which raises an exception, it does not delete `override_current_site_id.thread_local.site_id`. 

Problem example: When working with celery, if the worker thread picks up a task which raises an exception, future tasks which call `current_site_id` will always return the first task's `site_id` since `override_current_site_id.thread_local.site_id` is still set.

Now context manager catches exception, cleans up after itself, and re-raises. 