### PR TITLE
Handle local paths with spaces in rsync_upload

### DIFF
--- a/mezzanine/project_template/fabfile.py
+++ b/mezzanine/project_template/fabfile.py
@@ -273,7 +273,7 @@ def rsync_upload():
     """
     excludes = ["*.pyc", "*.pyo", "*.db", ".DS_Store", ".coverage",
                 "local_settings.py", "/static", "/.git", "/.hg"]
-    local_dir = os.getcwd() + os.sep
+    local_dir = "'%s%s'" % (os.getcwd(), os.sep)
     return rsync_project(remote_dir=env.proj_path, local_dir=local_dir,
                          exclude=excludes)
 


### PR DESCRIPTION
By wrapping in single quotes.