### PR TITLE
Use Field.value_from_object() for Django 2.x

### DIFF
--- a/mezzanine/core/fields.py
+++ b/mezzanine/core/fields.py
@@ -92,7 +92,7 @@ class MultiChoiceField(models.CharField):
             raise ValidationError(error)
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return ",".join(value)
 
 


### PR DESCRIPTION
The previously used private method "Field._get_val_from_obj()" was
removed in Django 2.0 and so the "dumpdata" management command
was broken. Django already offers the replacement method for a long
time.