### PR TITLE
Add Top Rated Blog Posts To Blog Tags

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -279,3 +279,4 @@
 * Geoffrey Royer
 * Chris Hawes
 * Andrii Soldatenko
+* Adam McQuistan

--- a/mezzanine/blog/templates/blog/includes/filter_panel.html
+++ b/mezzanine/blog/templates/blog/includes/filter_panel.html
@@ -21,6 +21,27 @@
 {% endif %}
 {% endblock %}
 
+{% block blog_top_rated_posts %}
+{% blog_top_rated_posts 5 as top_rated_posts %}
+{% if top_rated_posts %}
+<h3>{% trans "Top Rated Posts" %}</h3>
+<ul class="list-unstyled recent-posts">
+{% for top_rated_post in top_rated_posts %}
+<li>
+    {% spaceless %}
+    <a href="{{ top_rated_post.get_absolute_url }}">
+        {% if settings.BLOG_USE_FEATURED_IMAGE and top_rated_post.featured_image %}
+        <img src="{{ MEDIA_URL }}{% thumbnail top_rated_post.featured_image 24 24 %}">
+        {% endif %}
+    {{ top_rated_post.title }}
+    </a>
+    {% endspaceless %}
+</li>
+{% endfor %}
+</ul>
+{% endif %}
+{% endblock %}
+
 {% block blog_months %}
 {% blog_months as months %}
 {% if months %}

--- a/mezzanine/blog/templatetags/blog_tags.py
+++ b/mezzanine/blog/templatetags/blog_tags.py
@@ -92,7 +92,8 @@ def blog_recent_posts(limit=5, tag=None, username=None, category=None):
 
 
 @register.as_tag
-def blog_top_rated_posts(limit=5, tag=None, username=None, category=None, order_by="average"):
+def blog_top_rated_posts(
+    limit=5, tag=None, username=None, category=None, order_by="average"):
     """
     Put a list of top rated published blog posts into the template
     context. A tag title or slug, category title or slug or author's

--- a/mezzanine/blog/templatetags/blog_tags.py
+++ b/mezzanine/blog/templatetags/blog_tags.py
@@ -92,7 +92,7 @@ def blog_recent_posts(limit=5, tag=None, username=None, category=None):
 
 
 @register.as_tag
-def blog_top_rated_posts(limit=5, tag=None, username=None, category=None):
+def blog_top_rated_posts(limit=5, tag=None, username=None, category=None, order_by="average"):
     """
     Put a list of top rated published blog posts into the template
     context. A tag title or slug, category title or slug or author's
@@ -100,10 +100,10 @@ def blog_top_rated_posts(limit=5, tag=None, username=None, category=None):
 
     Usage::
 
-        {% blog_top_rated_posts 5 as recent_posts %}
-        {% blog_top_rated_posts limit=5 tag="django" as recent_posts %}
-        {% blog_top_rated_posts limit=5 category="python" as recent_posts %}
-        {% blog_top_rated_posts 5 username=admin as recent_posts %}
+        {% blog_top_rated_posts 5 as top_rated_posts %}
+        {% blog_top_rated_posts limit=5 tag="django" as top_rated_posts %}
+        {% blog_top_rated_posts limit=5 category="python" as top_rated_posts %}
+        {% blog_top_rated_posts 5 username=admin as top_rated_posts %}
 
     """
     blog_posts = BlogPost.objects.published().select_related("user")
@@ -126,7 +126,10 @@ def blog_top_rated_posts(limit=5, tag=None, username=None, category=None):
             blog_posts = blog_posts.filter(user=author)
         except User.DoesNotExist:
             return []
-    return list(blog_posts.order_by('-rating_average')[:limit])
+    if order_by in ['average', 'sum', 'count']:
+        blog_posts = blog_posts.order_by('-rating_%s' % order_by)
+
+    return list(blog_posts[:limit])
 
 
 @register.inclusion_tag("admin/includes/quick_blog.html", takes_context=True)

--- a/mezzanine/blog/templatetags/blog_tags.py
+++ b/mezzanine/blog/templatetags/blog_tags.py
@@ -96,7 +96,7 @@ def blog_top_rated_posts(limit=5, tag=None, username=None, category=None, order_
     """
     Put a list of top rated published blog posts into the template
     context. A tag title or slug, category title or slug or author's
-    username can also be specified to filter the recent posts returned.
+    username can also be specified to filter the top rated posts returned.
 
     Usage::
 


### PR DESCRIPTION
I would like to add the feature / ability to show top rated blog post to the blog/includes/filter_pannel.html 
as well as any others by using this new `blog_tags. blog_top_rated_posts` tag.