### PR TITLE
Thumbnail tag in Google Appengine

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -279,3 +279,4 @@
 * Geoffrey Royer
 * Chris Hawes
 * Andrii Soldatenko
+* Jesse London


### PR DESCRIPTION
## Improve compatibility of ``thumbnail`` tag with remote storage backends (Google Cloud Storage) and filesystem-less deployments (Appengine)

The ``thumbnail`` tag doesn't work on Google Appengine (GAE) without
these changes -- in that environment, the file system is mounted
read-only, and as such generated thumbnail images cannot be written to
it, (even temporarily).

Moreover, the pre-existing check for already-generated thumbnails
assumed a FileSystemStorage backend, (and indeed went around it); as
such, thumbnails were regenerated upon every request. These changes
leverage the file storage backend for this check, for more generalized
and optimized compatibility.

---

To note, the thumbnail function is also made to rely more completely on
the default storage backend when *saving* -- refactoring this block
slightly -- to simply use ``default_storage.open()``. This features
compatibility with both remote and local storage backends, without
additional work.

---

Finally, this change set updates the AUTHORS file, (in line with
contribution guidelines).