### PR TITLE
Fix __admin_media_prefix__ pointing to nonexistent resource

### DIFF
--- a/mezzanine/core/templates/admin/base_site.html
+++ b/mezzanine/core/templates/admin/base_site.html
@@ -1,5 +1,5 @@
 {% extends "admin/base.html" %}
-{% load mezzanine_tags i18n staticfiles %}
+{% load mezzanine_tags i18n staticfiles static %}
 
 {% block title %}{{ title }} | Mezzanine{% endblock %}
 
@@ -18,7 +18,7 @@
     window.__tinymce_css = '{% static "mezzanine/css/tinymce.css" %}';
     window.__admin_url = '{{ admin_index_url }}';
     window.__static_proxy = '{{ static_proxy_url }}';
-    window.__admin_media_prefix__ = '{% static "admin" %}/';
+    window.__admin_media_prefix__ = '{% get_static_prefix %}/admin/';
     window.__grappelli_installed = {{ settings.GRAPPELLI_INSTALLED|lower }};
     window.__admin_menu_collapsed = {{ settings.ADMIN_MENU_COLLAPSED|lower }};
     window.__language_code = '{{ LANGUAGE_CODE }}';


### PR DESCRIPTION
Closes #1895

It breaks sites on production that use the ManifestStaticFilesStorage.

For such cases, Django provides the "get_static_prefix" template tag.

But it's an incitement to bypass the storage mechanism to produce the
URL to cache (by appending a hash in this case).

And I don't understand how it could work with more "exotic" yet valid
backends relying on cloud storage or CDNs, where the source file path
and the URL path won't match one to one.

I advise against this usage and call for its deprecation.