### PR TITLE
Improvements to thumbnails code for using remote media storage

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -716,7 +716,7 @@ Default: ``('ACCOUNTS_APPROVAL_REQUIRED', 'ACCOUNTS_VERIFICATION_REQUIRED', 'ADM
 ``THUMBNAILS_DIR_NAME``
 -----------------------
 
-Directory name to store thumbnails in, that will be created relative to the original image's directory.
+Directory name to store thumbnails in, that will be created relative to the original image's directory, or to MEDIA_ROOT if an absolute path.
 
 Default: ``'.thumbnails'``
 

--- a/mezzanine/core/defaults.py
+++ b/mezzanine/core/defaults.py
@@ -518,7 +518,8 @@ register_setting(
 register_setting(
     name="THUMBNAILS_DIR_NAME",
     description=_("Directory name to store thumbnails in, that will be "
-        "created relative to the original image's directory."),
+        "created relative to the original image's directory, or to "
+        "MEDIA_ROOT if an absolute path."),
     editable=False,
     default=".thumbnails",
 )

--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -318,16 +318,26 @@ def thumbnail(image_url, width, height, upscale=True, quality=95, left=.5,
     # image, which is something we do in filebrowser when a new image
     # is written, allowing us to purge any previously generated
     # thumbnails that may match a new image name.
-    thumb_dir = os.path.join(settings.MEDIA_ROOT, image_dir,
-                             settings.THUMBNAILS_DIR_NAME, image_name)
+    if os.path.isabs(settings.THUMBNAILS_DIR_NAME):
+        thumb_dir = os.path.join(settings.MEDIA_ROOT,
+                                 settings.THUMBNAILS_DIR_NAME,
+                                 image_dir, image_name)
+        thumb_url = ("%s/%s/%s/%s" % (settings.THUMBNAILS_DIR_NAME,
+                                  os.path.dirname(image_url),
+                                  quote(image_name.encode("utf-8")),
+                                  quote(thumb_name.encode("utf-8")))
+                     ).lstrip('/')
+    else:
+        thumb_dir = os.path.join(settings.MEDIA_ROOT, image_dir,
+                                 settings.THUMBNAILS_DIR_NAME, image_name)
+        thumb_url = "%s/%s/%s" % (settings.THUMBNAILS_DIR_NAME,
+                                  quote(image_name.encode("utf-8")),
+                                  quote(thumb_name.encode("utf-8")))
+        image_url_path = os.path.dirname(image_url)
+        if image_url_path:
+            thumb_url = "%s/%s" % (image_url_path, thumb_url)
 
     thumb_path = os.path.join(thumb_dir, thumb_name)
-    thumb_url = "%s/%s/%s" % (settings.THUMBNAILS_DIR_NAME,
-                              quote(image_name.encode("utf-8")),
-                              quote(thumb_name.encode("utf-8")))
-    image_url_path = os.path.dirname(image_url)
-    if image_url_path:
-        thumb_url = "%s/%s" % (image_url_path, thumb_url)
 
     try:
         thumb_exists = default_storage.exists(thumb_url)


### PR DESCRIPTION
This PR includes two improvements to the thumbnails code when using remote media storage (eg. S3).

### 1. Allow absolute path for THUMBNAILS_DIR_NAME
Allow the `THUMBNAILS_DIR_NAME` setting to specify an absolute path. In this case, `THUMBNAILS_DIR_NAME` will be created relative to the `MEDIA_ROOT` directory, rather than relative to each image's directory. Each image's path is recreated below the root `THUMBNAILS_DIR_NAME` directory to avoid name collisions. Default behavior is not changed, so existing installations are not affected.

    THUMBNAILS_DIR_NAME = "/.thumbnails"

Using this feature offers improvements to `listdir()` on eg. a Boto3 storage backend, which is constrained to pulling all objects under a particular directory (ie. recursively) due to the nature S3-like object storage systems. With many thumbnail images, this can be a major performance hit, for example when browsing the Media Library in admin. By keeping this directory at the root level, outside of the location of media library files (`/uploads`), thumbnails do not show up in the Media Library at all, mitigating the problem.

### 2. Use default_storage for thumbnail creation rather than os
Implementation of the fix described here: https://groups.google.com/forum/#!msg/mezzanine-users/WGVaNhD5vRs/7Ktw7-UkosgJ. Thumbnails are now created solely with `default_storage` rather than `os` functions, which of course does not work when using S3 for media storage.

Note that this fix also appears to be implemented in a couple of other PRs: https://github.com/stephenmcd/mezzanine/pull/1951 and https://github.com/stephenmcd/mezzanine/pull/1922
