### PR TITLE
radio field support for dynamic_inline.js

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -279,3 +279,4 @@
 * Geoffrey Royer
 * Chris Hawes
 * Andrii Soldatenko
+* Christian Kuper

--- a/mezzanine/core/static/mezzanine/js/admin/dynamic_inline.js
+++ b/mezzanine/core/static/mezzanine/js/admin/dynamic_inline.js
@@ -26,6 +26,8 @@ jQuery(function($) {
                     return field.value && field.value != field.defaultValue;
                 case 'checkbox':
                     return field.checked != field.defaultChecked;
+                case 'radio':
+                    return field.checked != field.defaultChecked;
                 case 'hidden':
                     return false;
                 default:


### PR DESCRIPTION
When using radio buttons in dynamic inlines this raised an 'Unhandled
field in dynamic_inline.js:' alert. This was fixed by dublicating the
'checkbox' case in the function 'anyFieldDirty' in 'dynamic_inline.js'