### PR TITLE
Improve efficiency of ORM call

### DIFF
--- a/mezzanine/core/admin.py
+++ b/mezzanine/core/admin.py
@@ -425,7 +425,7 @@ class SitePermissionUserAdmin(UserAdmin):
         super(SitePermissionUserAdmin, self).save_model(request, obj, form, change)
         user = self.model.objects.get(id=obj.id)
         has_perms = len(user.get_all_permissions()) > 0
-        has_sites = SitePermission.objects.filter(user=user).count() > 0
+        has_sites = SitePermission.objects.filter(user=user).exists()
         if (
             user.is_active
             and user.is_staff


### PR DESCRIPTION
using `if queryset.exists()` is more efficient than checking `if queryset.count() > 0` [read more](https://django.doctor/advice/C9002)

I found this problem during auditing your codebase. [Read the full report](https://django.doctor/stephenmcd/mezzanine)