### PR TITLE
Fix ModelTranslation support

### DIFF
--- a/mezzanine/core/managers.py
+++ b/mezzanine/core/managers.py
@@ -198,11 +198,11 @@ class SearchableQuerySet(QuerySet):
             queryset = queryset.filter(reduce(ior, optional))
         return queryset.distinct()
 
-    def _clone(self):
+    def _clone(self, *args, **kwargs):
         """
         Ensure attributes are copied to subsequent queries.
         """
-        clone = super(SearchableQuerySet, self)._clone()
+        clone = super(SearchableQuerySet, self)._clone(*args, **kwargs)
         clone._search_terms = self._search_terms
         clone._search_fields = self._search_fields
         clone._search_ordered = self._search_ordered


### PR DESCRIPTION
ModelTransalation' queryset class `TransalationQuerySet` defines a [`_clone()`](https://github.com/deschler/django-modeltranslation/blob/445ee84821cc8127deee83656a8d3c7ca6f72b54/modeltranslation/manager.py#L188) function that supports passing some kwargs, and some functions already depends on this behaviour (e.g: [`rewrite()`](https://github.com/deschler/django-modeltranslation/blob/445ee84821cc8127deee83656a8d3c7ca6f72b54/modeltranslation/manager.py#L202), [`populate()`](https://github.com/deschler/django-modeltranslation/blob/445ee84821cc8127deee83656a8d3c7ca6f72b54/modeltranslation/manager.py#L206)).
This commit restore the support of passing kwargs.