### PR TITLE
Replace _get_val_from_obj with value_from_object

### DIFF
--- a/mezzanine/core/fields.py
+++ b/mezzanine/core/fields.py
@@ -94,7 +94,7 @@ class MultiChoiceField(models.CharField):
             raise ValidationError(error)
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_to_string(obj)
         return ",".join(value)
 
 


### PR DESCRIPTION
Fix for #1977, I believe this functionality was just duplicated functionality and the method has been replaced.

See https://code.djangoproject.com/ticket/24716 for more info