### PR TITLE
Fix translation tabs

### DIFF
--- a/mezzanine/core/admin.py
+++ b/mezzanine/core/admin.py
@@ -38,6 +38,7 @@ if settings.USE_MODELTRANSLATION:
 
         class Media:
             js = (
+                'admin/js/jquery.init.js',
                 static("mezzanine/js/%s" % settings.JQUERY_UI_FILENAME),
                 static("mezzanine/js/admin/tabbed_translation_fields.js"),
             )


### PR DESCRIPTION
When translation fields are present in admin, jquery.ui library is
loaded prior to django's jquery.init.js, which binds jQuery.ui to
django.jQuery rather than window.jQuery. That propagates down and
tabbing fails.