### PR TITLE
Don't enforce email uniqueness when blank, account for multiple existing dupes

### DIFF
--- a/mezzanine/core/admin.py
+++ b/mezzanine/core/admin.py
@@ -406,11 +406,12 @@ class SitePermissionInline(admin.TabularInline):
 class SitePermissionUserAdminForm(UserAdmin.form):
     def clean_email(form):
         email = form.cleaned_data.get("email")
-        try:
-            User.objects.exclude(id=form.instance.id).get(email=email)
-        except User.DoesNotExist:
-            return email
-        raise ValidationError(_("This email is already registered"))
+        if (
+            email 
+            and User.objects.filter(email=email).exclude(id=form.instance.id).count() > 0
+        ):
+            raise ValidationError(_("This email is already registered"))
+        return email
 
 
 class SitePermissionUserAdmin(UserAdmin):


### PR DESCRIPTION
Don't enforce email uniqueness when blank (emails can be optional), and account for possibility of multiple dupes (such as when migrating from prior to enforcement of uniqueness). Fix regression in stephenmcd/mezzanine#1868