### PR TITLE
class*="collapse" matches even collapse-closed, unwanted behavior

### DIFF
--- a/mezzanine/core/static/mezzanine/js/admin/collapse_backport.js
+++ b/mezzanine/core/static/mezzanine/js/admin/collapse_backport.js
@@ -2,10 +2,6 @@
 jQuery(function($) {
 
     /// FIELDSETS
-    $('fieldset[class*="collapse"]').each(function() {
-        $(this).addClass("collapse-open");
-        $(this).removeClass("collapse");
-    });
     $('fieldset[class*="collapse-closed"]').each(function() {
         $(this).addClass("collapsed");
         $(this).find('h2:first').addClass("collapse-toggle");


### PR DESCRIPTION
In:
```
$('fieldset[class*="collapse"]').each(function() {
    $(this).addClass("collapse-open");
    $(this).removeClass("collapse");
});
```

`$('fieldset[class*="collapse-closed"]')` matches `<fieldset class="module aligned collapse-closed"/>`, which leads it to add the `collapse-open` class. This in turn means `collapse-closed` and `collapse-open` always toggle in tandem rather than flopping between each other as intended.