### PR TITLE
fix: removed deprecated _get_val_from_obj

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -280,3 +280,4 @@
 * Chris Hawes
 * Andrii Soldatenko
 * Christian Kuper
+* Fepe Laser

--- a/mezzanine/core/fields.py
+++ b/mezzanine/core/fields.py
@@ -94,7 +94,7 @@ class MultiChoiceField(models.CharField):
             raise ValidationError(error)
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return ",".join(value)
 
 


### PR DESCRIPTION
In 2.0 Django deprecated `_get_val_from_obj`[1] and should be replaced with `value_from_object`

[1]: See https://code.djangoproject.com/ticket/24716