### PR TITLE
Follow image mode when padding

### DIFF
--- a/mezzanine/core/templatetags/mezzanine_tags.py
+++ b/mezzanine/core/templatetags/mezzanine_tags.py
@@ -437,7 +437,7 @@ def thumbnail(
             pad_top = 0
             pad_left = (pad_width - from_width) // 2
         if pad_size is not None:
-            pad_container = Image.new("RGBA", pad_size, padding_color)
+            pad_container = Image.new(image.mode, pad_size, padding_color)
             pad_container.paste(image, (pad_left, pad_top))
             image = pad_container
 


### PR DESCRIPTION
Forcing RBGA mode is not compatible with JPEG format. Instead follow the source image's mode. Fixes #1925