### PR TITLE
Fix attribute error when calling clear_cache on settings.

### DIFF
--- a/mezzanine/conf/__init__.py
+++ b/mezzanine/conf/__init__.py
@@ -141,7 +141,8 @@ class Settings:
 
     def clear_cache(self):
         """Clear the settings cache for the current request."""
-        self._editable_caches.pop(self._current_request, None)
+        if hasattr(self, "_editable_caches"):
+            self._editable_caches.pop(self._current_request, None)
 
     def _get_editable(self, request):
         """


### PR DESCRIPTION
Small fix to compliment a recent bug fix related to commit: 99a0441 issue:  #1989 

An AttributeError is thrown upon initial instantiation in places where settings.clear_cache() is called, due the removal of the init method.

This is my first ever PR to an open source project so let me know if I need to add/change anything.