### PR TITLE
Handle non integer values passed to `object_pk` and `replied_to`

### DIFF
--- a/mezzanine/generic/templatetags/comment_tags.py
+++ b/mezzanine/generic/templatetags/comment_tags.py
@@ -53,7 +53,7 @@ def comment_thread(context, parent):
     parent_id = parent.id if isinstance(parent, ThreadedComment) else None
     try:
         replied_to = int(context["request"].POST["replied_to"])
-    except KeyError:
+    except (KeyError, ValueError):
         replied_to = 0
     context.update(
         {

--- a/mezzanine/generic/views.py
+++ b/mezzanine/generic/views.py
@@ -84,7 +84,7 @@ def initial_validation(request, prefix):
         try:
             model = apps.get_model(*model_data)
             obj = model.objects.get(id=post_data.get("object_pk", None))
-        except (TypeError, ObjectDoesNotExist, LookupError):
+        except (TypeError, ObjectDoesNotExist, LookupError, ValueError):
             redirect_url = "/"
     if redirect_url:
         if request_is_ajax(request):


### PR DESCRIPTION
When pentesters look for vulnerabilities they attempt to stuff random values to every forms (including the ratings and comments). This change prevents returning a 500 error when a non integer value is passed to `object_pk` in a rating or comment form.