### PR TITLE
Change documentation urls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -280,3 +280,4 @@
 * Chris Hawes
 * Andrii Soldatenko
 * Christian Kuper
+* Chris Curvey

--- a/mezzanine/core/templates/index.html
+++ b/mezzanine/core/templates/index.html
@@ -17,12 +17,12 @@
 </p>
 <ul>
     <li><a href="/admin/">Log in to the admin interface</a></li>
-    <li><a href="http://mezzanine.jupo.org/docs/content-architecture.html">Creating custom page types</a></li>
-    <li><a href="http://mezzanine.jupo.org/docs/frequently-asked-questions.html#templates">Modifying HTML templates</a></li>
-    <li><a href="http://mezzanine.jupo.org/docs/frequently-asked-questions.html#why-isn-t-the-homepage-a-page-object-i-can-edit-via-the-admin">Changing this homepage</a></li>
-    <li><a href="http://mezzanine.jupo.org/docs/frequently-asked-questions.html">Other frequently asked questions</a></li>
-    <li><a href="http://mezzanine.jupo.org/docs/configuration.html#default-settings">Full list of settings</a></li>
-    <li><a href="http://mezzanine.jupo.org/docs/deployment.html">Deploying to a production server</a></li>
+    <li><a href="https://mezzanine.readthedocs.io/en/latest/content-architecture.html">Creating custom page types</a></li>
+    <li><a href="http://mezzanine.readthedocs.io/en/latest/frequently-asked-questions.html#templates">Modifying HTML templates</a></li>
+    <li><a href="http://mezzanine.readthedocs.io/en/latest/frequently-asked-questions.html#why-isn-t-the-homepage-a-page-object-i-can-edit-via-the-admin">Changing this homepage</a></li>
+    <li><a href="http://mezzanine.readthedocs.io/en/latest/frequently-asked-questions.html">Other frequently asked questions</a></li>
+    <li><a href="http://mezzanine.readthedocs.io/en/latest/configuration.html#default-settings">Full list of settings</a></li>
+    <li><a href="http://mezzanine.readthedocs.io/en/latest/deployment.html">Deploying to a production server</a></li>
 </ul>
 {% endblocktrans %}
 {% endblock %}

--- a/mezzanine/core/templates/index.html
+++ b/mezzanine/core/templates/index.html
@@ -18,11 +18,11 @@
 <ul>
     <li><a href="/admin/">Log in to the admin interface</a></li>
     <li><a href="https://mezzanine.readthedocs.io/en/latest/content-architecture.html">Creating custom page types</a></li>
-    <li><a href="http://mezzanine.readthedocs.io/en/latest/frequently-asked-questions.html#templates">Modifying HTML templates</a></li>
-    <li><a href="http://mezzanine.readthedocs.io/en/latest/frequently-asked-questions.html#why-isn-t-the-homepage-a-page-object-i-can-edit-via-the-admin">Changing this homepage</a></li>
-    <li><a href="http://mezzanine.readthedocs.io/en/latest/frequently-asked-questions.html">Other frequently asked questions</a></li>
-    <li><a href="http://mezzanine.readthedocs.io/en/latest/configuration.html#default-settings">Full list of settings</a></li>
-    <li><a href="http://mezzanine.readthedocs.io/en/latest/deployment.html">Deploying to a production server</a></li>
+    <li><a href="https://mezzanine.readthedocs.io/en/latest/frequently-asked-questions.html#templates">Modifying HTML templates</a></li>
+    <li><a href="https://mezzanine.readthedocs.io/en/latest/frequently-asked-questions.html#why-isn-t-the-homepage-a-page-object-i-can-edit-via-the-admin">Changing this homepage</a></li>
+    <li><a href="https://mezzanine.readthedocs.io/en/latest/frequently-asked-questions.html">Other frequently asked questions</a></li>
+    <li><a href="https://mezzanine.readthedocs.io/en/latest/configuration.html#default-settings">Full list of settings</a></li>
+    <li><a href="https://mezzanine.readthedocs.io/en/latest/deployment.html">Deploying to a production server</a></li>
 </ul>
 {% endblocktrans %}
 {% endblock %}


### PR DESCRIPTION
I think I got this right.  This should fix the problems with the initial site homepage containing dead links.  I think this will fix both #2030 and #2034 (if I understand the issues correctly)

