### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/blog-importing.rst
+++ b/docs/blog-importing.rst
@@ -162,7 +162,7 @@ The first step is to define any custom arguments the command will
 require using Python's `argparse
 <http://docs.python.org/library/argparse.html>`_ handling.
 
-The main responsbility of the ``Command`` class is then to implement a
+The main responsibility of the ``Command`` class is then to implement a
 :meth:`~mezzanine.blog.management.base.BaseImporterCommand.handle_import`
 method which handles retrieving blog posts and comments from the
 particular blogging platform. The :meth:`~mezzanine.blog.management.\

--- a/mezzanine/blog/urls.py
+++ b/mezzanine/blog/urls.py
@@ -3,7 +3,7 @@ from django.urls import path, re_path
 from mezzanine.blog import views
 from mezzanine.conf import settings
 
-# Trailing slahes for urlpatterns based on setup.
+# Trailing slashes for urlpatterns based on setup.
 _slash = "/" if settings.APPEND_SLASH else ""
 
 # Blog patterns.

--- a/mezzanine/core/management/commands/runserver.py
+++ b/mezzanine/core/management/commands/runserver.py
@@ -38,7 +38,7 @@ class MezzStaticFilesHandler(StaticFilesHandler):
 
 def banner():
 
-    # Database name - this is just the ``vendor`` atrribute of
+    # Database name - this is just the ``vendor`` attribute of
     # the connection backend, with some exceptions where we
     # replace it with something else, such as microsoft -> sql server.
     conn = connection

--- a/mezzanine/core/middleware.py
+++ b/mezzanine/core/middleware.py
@@ -296,7 +296,7 @@ class SSLRedirectMiddleware(MiddlewareMixin):
                 # in this case we don't attempt a redirect - note that
                 # when /admin is restricted to SSL using Mezzanine's SSL
                 # setup, the flash uploader will post over SSL, so
-                # someone would need to explictly go out of their way to
+                # someone would need to explicitly go out of their way to
                 # trigger this.
                 return
             # Tell the client they need to re-POST.

--- a/mezzanine/core/static/mezzanine/js/jquery-ui-1.12.1.js
+++ b/mezzanine/core/static/mezzanine/js/jquery-ui-1.12.1.js
@@ -2647,7 +2647,7 @@ $.fn.extend( {
 				var el = $( this ),
 					normalizedMode = $.effects.mode( el, mode ) || defaultMode;
 
-				// Sentinel for duck-punching the :animated psuedo-selector
+				// Sentinel for duck-punching the :animated pseudo-selector
 				el.data( dataSpaceAnimated, true );
 
 				// Save effect mode for later use,
@@ -17887,7 +17887,7 @@ $.widget( "ui.tabs", {
 				// tab is already loading
 				tab.hasClass( "ui-tabs-loading" ) ||
 
-				// can't switch durning an animation
+				// can't switch during an animation
 				this.running ||
 
 				// click on active header, but not collapsible

--- a/mezzanine/core/static/mezzanine/js/jquery.form.js
+++ b/mezzanine/core/static/mezzanine/js/jquery.form.js
@@ -666,7 +666,7 @@ $.fn.ajaxSubmit = function(options) {
                         return;
                     }
                     // let this fall through because server response could be an empty document
-                    //log('Could not access iframe DOM after mutiple tries.');
+                    //log('Could not access iframe DOM after multiple tries.');
                     //throw 'DOMException: not available';
                 }
 

--- a/mezzanine/utils/urls.py
+++ b/mezzanine/utils/urls.py
@@ -117,7 +117,7 @@ def login_redirect(request):
     if next in ignorable_nexts:
         next = settings.LOGIN_REDIRECT_URL
         if next == "/accounts/profile/":
-            # Use the homepage if LOGIN_REDIRECT_URL is Django's defaut.
+            # Use the homepage if LOGIN_REDIRECT_URL is Django's default.
             next = get_script_prefix()
         else:
             try:


### PR DESCRIPTION
There are small typos in:
- docs/blog-importing.rst
- mezzanine/blog/urls.py
- mezzanine/core/management/commands/runserver.py
- mezzanine/core/middleware.py
- mezzanine/core/static/mezzanine/js/jquery-ui-1.12.1.js
- mezzanine/core/static/mezzanine/js/jquery.form.js
- mezzanine/utils/urls.py

Fixes:
- Should read `slashes` rather than `slahes`.
- Should read `responsibility` rather than `responsbility`.
- Should read `pseudo` rather than `psuedo`.
- Should read `multiple` rather than `mutiple`.
- Should read `explicitly` rather than `explictly`.
- Should read `during` rather than `durning`.
- Should read `default` rather than `defaut`.
- Should read `attribute` rather than `atrribute`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md