### PR TITLE
Fix TypeError in escape function

### DIFF
--- a/mezzanine/utils/html.py
+++ b/mezzanine/utils/html.py
@@ -110,7 +110,7 @@ def escape(html):
         strip=True,
         strip_comments=False,
         css_sanitizer=css_sanitizer,
-        protocols=ALLOWED_PROTOCOLS + ["tel"],
+        protocols=ALLOWED_PROTOCOLS.union(["tel"]),
     )
 
 


### PR DESCRIPTION
#2054
Fix TypeError in escape function by using set union for protocols No test were added, because the function is already tested in :
    test_core.test_escape