### PR TITLE
Change ALLOWED_PROTOCOLS list addtion to frozenset union

### DIFF
--- a/mezzanine/utils/html.py
+++ b/mezzanine/utils/html.py
@@ -110,7 +110,7 @@ def escape(html):
         strip=True,
         strip_comments=False,
         css_sanitizer=css_sanitizer,
-        protocols=ALLOWED_PROTOCOLS + ["tel"],
+        protocols=ALLOWED_PROTOCOLS.union(frozenset(["tel"])),
     )
 
 


### PR DESCRIPTION
In `utils/html.py` line 113 attempts to add `["tel"]` to `ALLOWED_PROTOCOLS` which results in `unsupported operand type(s) for +: 'frozenset' and 'list'` error whenever called. This fix converts the list to another frozenset and unions them.