### PR TITLE
raises error on nested override site

### DIFF
--- a/mezzanine/utils/sites.py
+++ b/mezzanine/utils/sites.py
@@ -72,6 +72,8 @@ def override_current_site_id(site_id):
     Context manager that overrides the current site id for code executed
     within it. Used to access SiteRelated objects outside the current site.
     """
+    if hasattr(override_current_site_id.thread_local,'site_id'):
+        raise RecursionError(f'''override_current_site_id can't be nested''')
     override_current_site_id.thread_local.site_id = site_id
     try:
         yield

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -598,6 +598,16 @@ class SiteRelatedTestCase(TestCase):
             self.assertEqual(current_site_id(), 2)
         self.assertEqual(current_site_id(), 1)
 
+    def test_nested_override_site_id(self):
+        self.assertEqual(current_site_id(), 1)
+        with override_current_site_id(2):
+            self.assertEqual(current_site_id(), 2)
+            with self.assertRaises(RecursionError):
+                with override_current_site_id(3):
+                    self.assertEqual(current_site_id(), 3)
+                self.assertEqual(current_site_id(), 2)
+        self.assertEqual(current_site_id(), 1)
+
 
 class CSRFTestViews:
     def nevercache_view(request):


### PR DESCRIPTION
When calls to override_current_site_id are nested, no errors are raised until the deepest context `__exit__`. This patch detects this use and raises an error.

Of course, we could _implement_ nested calls. The test is prepared for that time.